### PR TITLE
Eliminate host-device copying of LBC driving data from mpas_atm_get_bdy_state

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_boundaries.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_boundaries.F
@@ -359,11 +359,11 @@ module mpas_atm_boundaries
     !
     !  routine mpas_atm_get_bdy_state_2d
     !
-    !> \brief   Returns LBC state at a specified delta-t in the future
+    !> \brief   Provides LBC state at a specified delta-t in the future
     !> \author  Michael Duda
     !> \date    28 September 2016
     !> \details 
-    !>  This function returns an array providing the state for the requested
+    !>  This subroutine returns an array providing the state for the requested
     !>  progostic variable delta_t in the future from the current time known
     !>  by the simulation clock (which is typically the time at the start of
     !>  the current timestep).
@@ -371,24 +371,24 @@ module mpas_atm_boundaries
     !>  The vertDim and horizDim should match the nominal block dimensions of
     !>  the field to be returned by the call; for example, a call to retrieve
     !>  the state of the 'u' field would set vertDim=nVertLevels and 
-    !>  horizDim=nEdges. This function internally adds 1 to the horizontal
+    !>  horizDim=nEdges. This routine internally adds 1 to the horizontal
     !>  dimension to account for the "garbage" element.
     !>
     !>  The field is identified by the 'field' argument, and this argument is
     !>  prefixed with 'lbc_' before attempting to retrieve the field from
-    !>  the 'lbc' pool. For scalars, the field argument should give the name 
+    !>  the 'lbc' pool. For scalars, the field argument should give the name
     !>  of the constituent, e.g., 'qv'.
     !>
-    !>  Example calls to this function:
-    !>  
-    !>   u(:,:) = mpas_atm_get_bdy_state(clock, domain % blocklist, nVertLevels, nEdges, 'u', 0.0_RKIND)
-    !>   w(:,:) = mpas_atm_get_bdy_state(clock, domain % blocklist, nVertLevels+1, nCells, 'w', 0.0_RKIND)
-    !>   rho_zz(:,:) = mpas_atm_get_bdy_state(clock, domain % blocklist, nVertLevels, nCells, 'rho_zz', 0.0_RKIND)
-    !>   theta(:,:) = mpas_atm_get_bdy_state(clock, domain % blocklist, nVertLevels, nCells, 'theta', 0.0_RKIND)
-    !>   scalars(1,:,:) = mpas_atm_get_bdy_state(clock, domain % blocklist, nVertLevels, nCells, 'qv', 0.0_RKIND)
+    !>  Example calls to this subroutine:
+    !> 
+    !>   call mpas_atm_get_bdy_state(clock, domain % blocklist, nVertLevels, nEdges, 'u', 0.0_RKIND, u)
+    !>   call mpas_atm_get_bdy_state(clock, domain % blocklist, nVertLevels+1, nCells, 'w', 0.0_RKIND, w)
+    !>   call mpas_atm_get_bdy_state(clock, domain % blocklist, nVertLevels, nCells, 'rho_zz', 0.0_RKIND, rho_zz)
+    !>   call mpas_atm_get_bdy_state(clock, domain % blocklist, nVertLevels, nCells, 'theta', 0.0_RKIND, theta)
+    !>   call mpas_atm_get_bdy_state(clock, domain % blocklist, nVertLevels, nCells, 'qv', 0.0_RKIND, scalars(1,:,:))
     !
     !-----------------------------------------------------------------------
-    function mpas_atm_get_bdy_state_2d(clock, block, vertDim, horizDim, field, delta_t) result(return_state)
+    subroutine mpas_atm_get_bdy_state_2d(clock, block, vertDim, horizDim, field, delta_t, return_state)
 
         use mpas_pool_routines, only : mpas_pool_get_error_level, mpas_pool_set_error_level
         use mpas_derived_types, only : MPAS_POOL_SILENT
@@ -400,8 +400,7 @@ module mpas_atm_boundaries
         integer, intent(in) :: vertDim, horizDim
         character(len=*), intent(in) :: field
         real (kind=RKIND), intent(in) :: delta_t
-
-        real (kind=RKIND), dimension(vertDim,horizDim+1) :: return_state
+        real (kind=RKIND), dimension(vertDim,horizDim+1), intent(out) :: return_state
 
         type (mpas_pool_type), pointer :: lbc
         integer, pointer :: idx_ptr
@@ -497,18 +496,18 @@ module mpas_atm_boundaries
             MPAS_ACC_TIMER_STOP('mpas_atm_get_bdy_state_2d [ACC_data_xfer]')
         end if
 
-    end function mpas_atm_get_bdy_state_2d
+    end subroutine mpas_atm_get_bdy_state_2d
 
 
     !***********************************************************************
     !
     !  routine mpas_atm_get_bdy_state_3d
     !
-    !> \brief   Returns LBC state at a specified delta-t in the future
+    !> \brief   Provides LBC state at a specified delta-t in the future
     !> \author  Michael Duda
     !> \date    4 September 2024
     !> \details
-    !>  This function returns an array providing the state for the requested
+    !>  This subroutine returns an array providing the state for the requested
     !>  progostic variable delta_t in the future from the current time known
     !>  by the simulation clock (which is typically the time at the start of
     !>  the current timestep).
@@ -517,20 +516,21 @@ module mpas_atm_boundaries
     !>  dimensions of the field to be returned by the call; for example, a
     !>  call to retrieve the state of the 'scalars' field would set
     !>  innerDim=num_scalars, vertDim=nVertLevels, and horizDim=nCells. This
-    !>  function internally adds 1 to the horizontal dimension to account for
+    !>  routine internally adds 1 to the horizontal dimension to account for
     !>  the "garbage" element.
     !>
     !>  The field is identified by the 'field' argument, and this argument is
     !>  prefixed with 'lbc_' before attempting to retrieve the field from
     !>  the 'lbc' pool.
     !>
-    !>  Example calls to this function:
+    !>  Example call to this subroutine:
     !>
-    !>   scalar(:,:,:) = mpas_atm_get_bdy_state(clock, domain % blocklist, &
-    !>                       num_scalars, nVertLevels, nCells, 'scalars', 0.0_RKIND)
+    !>   call mpas_atm_get_bdy_state(clock, domain % blocklist, &
+    !>                               num_scalars, nVertLevels, nCells, 'scalars', &
+    !>                               0.0_RKIND, scalars)
     !
     !-----------------------------------------------------------------------
-    function mpas_atm_get_bdy_state_3d(clock, block, innerDim, vertDim, horizDim, field, delta_t) result(return_state)
+    subroutine mpas_atm_get_bdy_state_3d(clock, block, innerDim, vertDim, horizDim, field, delta_t, return_state)
 
         use mpas_pool_routines, only : mpas_pool_get_error_level, mpas_pool_set_error_level
         use mpas_derived_types, only : MPAS_POOL_SILENT
@@ -542,8 +542,7 @@ module mpas_atm_boundaries
         integer, intent(in) :: innerDim, vertDim, horizDim
         character(len=*), intent(in) :: field
         real (kind=RKIND), intent(in) :: delta_t
-
-        real (kind=RKIND), dimension(innerDim,vertDim,horizDim+1) :: return_state
+        real (kind=RKIND), dimension(innerDim,vertDim,horizDim+1), intent(out) :: return_state
 
         type (mpas_pool_type), pointer :: lbc
         real (kind=RKIND), dimension(:,:,:), pointer :: tend
@@ -596,7 +595,7 @@ module mpas_atm_boundaries
         !$acc           delete(tend, state)
         MPAS_ACC_TIMER_STOP('mpas_atm_get_bdy_state_3d [ACC_data_xfer]')
 
-    end function mpas_atm_get_bdy_state_3d
+    end subroutine mpas_atm_get_bdy_state_3d
 
 
     !***********************************************************************

--- a/src/core_atmosphere/dynamics/mpas_atm_boundaries.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_boundaries.F
@@ -452,8 +452,7 @@ module mpas_atm_boundaries
         !
         if (associated(tend) .and. associated(state)) then
             MPAS_ACC_TIMER_START('mpas_atm_get_bdy_state_2d [ACC_data_xfer]')
-            !$acc enter data create(return_state) &
-            !$acc            copyin(tend, state)
+            !$acc enter data copyin(tend, state)
             MPAS_ACC_TIMER_STOP('mpas_atm_get_bdy_state_2d [ACC_data_xfer]')
 
             !$acc parallel default(present)
@@ -466,8 +465,7 @@ module mpas_atm_boundaries
             !$acc end parallel
 
             MPAS_ACC_TIMER_START('mpas_atm_get_bdy_state_2d [ACC_data_xfer]')
-            !$acc exit data copyout(return_state) &
-            !$acc           delete(tend, state)
+            !$acc exit data delete(tend, state)
             MPAS_ACC_TIMER_STOP('mpas_atm_get_bdy_state_2d [ACC_data_xfer]')
         else
             call mpas_pool_get_array(lbc, 'lbc_scalars', tend_scalars, 1)
@@ -477,8 +475,7 @@ module mpas_atm_boundaries
             idx=idx_ptr ! Avoid non-array pointer for OpenACC
 
             MPAS_ACC_TIMER_START('mpas_atm_get_bdy_state_2d [ACC_data_xfer]')
-            !$acc enter data create(return_state) &
-            !$acc            copyin(tend_scalars, state_scalars)
+            !$acc enter data copyin(tend_scalars, state_scalars)
             MPAS_ACC_TIMER_STOP('mpas_atm_get_bdy_state_2d [ACC_data_xfer]')
 
             !$acc parallel default(present)
@@ -491,8 +488,7 @@ module mpas_atm_boundaries
             !$acc end parallel
 
             MPAS_ACC_TIMER_START('mpas_atm_get_bdy_state_2d [ACC_data_xfer]')
-            !$acc exit data copyout(return_state) &
-            !$acc           delete(tend_scalars, state_scalars)
+            !$acc exit data delete(tend_scalars, state_scalars)
             MPAS_ACC_TIMER_STOP('mpas_atm_get_bdy_state_2d [ACC_data_xfer]')
         end if
 
@@ -575,8 +571,7 @@ module mpas_atm_boundaries
         call mpas_pool_get_array(lbc, 'lbc_'//trim(field), state, 2)
 
         MPAS_ACC_TIMER_START('mpas_atm_get_bdy_state_3d [ACC_data_xfer]')
-        !$acc enter data create(return_state) &
-        !$acc            copyin(tend, state)
+        !$acc enter data copyin(tend, state)
         MPAS_ACC_TIMER_STOP('mpas_atm_get_bdy_state_3d [ACC_data_xfer]')
 
         !$acc parallel default(present)
@@ -591,8 +586,7 @@ module mpas_atm_boundaries
         !$acc end parallel
 
         MPAS_ACC_TIMER_START('mpas_atm_get_bdy_state_3d [ACC_data_xfer]')
-        !$acc exit data copyout(return_state) &
-        !$acc           delete(tend, state)
+        !$acc exit data delete(tend, state)
         MPAS_ACC_TIMER_STOP('mpas_atm_get_bdy_state_3d [ACC_data_xfer]')
 
     end subroutine mpas_atm_get_bdy_state_3d

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -786,7 +786,9 @@ module atm_time_integration
       character (len=StrKIND), pointer :: config_microp_scheme
       character (len=StrKIND), pointer :: config_convection_scheme
 
-      integer, pointer :: num_scalars, index_qv, nCells, nCellsSolve, nEdges, nEdgesSolve, nVertices, nVerticesSolve, nVertLevels
+      integer, pointer :: num_scalars, index_qv, nCells, nCellsSolve, nVertices, nVerticesSolve
+      integer, pointer :: nEdges_ptr, nEdgesSolve_ptr, nVertLevels_ptr
+      integer :: nEdges, nEdgesSolve, nVertLevels
 
       character(len=StrKIND), pointer :: config_IAU_option
 
@@ -851,13 +853,20 @@ module atm_time_integration
       !
       call mpas_pool_get_dimension(mesh, 'nCells', nCells)
       call mpas_pool_get_dimension(mesh, 'nCellsSolve', nCellsSolve)
-      call mpas_pool_get_dimension(mesh, 'nEdges', nEdges)
+      call mpas_pool_get_dimension(mesh, 'nEdges', nEdges_ptr)
       call mpas_pool_get_dimension(mesh, 'nVertices', nVertices)
-      call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
+      call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels_ptr)
 
       !call mpas_pool_get_dimension(mesh, 'nCellsSolve', nCellsSolve)
-      call mpas_pool_get_dimension(mesh, 'nEdgesSolve', nEdgesSolve)
+      call mpas_pool_get_dimension(mesh, 'nEdgesSolve', nEdgesSolve_ptr)
       !call mpas_pool_get_dimension(mesh, 'nVerticesSolve', nVerticesSolve)
+
+      ! For OpenACC parallel regions, use regular scalar integers for loop
+      ! bounds rather than pointers to integers, as the former are implicitly
+      ! copied to the device
+      nEdges = nEdges_ptr
+      nEdgesSolve = nEdgesSolve_ptr
+      nVertLevels = nVertLevels_ptr
 
       call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
 

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -1271,25 +1271,40 @@ module atm_time_integration
                time_dyn_step = dt_dynamics*real(dynamics_substep-1) + rk_timestep(rk_step)
 
                call mpas_atm_get_bdy_state(clock, block, nVertLevels, nEdges, 'u', time_dyn_step, ru_driving_values)
+
                ! do this inline at present - it is simple enough
+               !$acc enter data copyin(u, ru_driving_values)
+               !$acc parallel default(present)
+               !$acc loop gang worker
                do iEdge = 1, nEdgesSolve
                   if(bdyMaskEdge(iEdge) > nRelaxZone) then
+                     !$acc loop vector
                      do k = 1, nVertLevels
                         u(k,iEdge) = ru_driving_values(k,iEdge)
                      end do
                   end if
                end do
+               !$acc end parallel
+               !$acc exit data copyout(u)
+               !$acc exit data delete(ru_driving_values)
 
                call mpas_atm_get_bdy_state(clock, block, nVertLevels, nEdges, 'ru', time_dyn_step, ru_driving_values)
                call mpas_pool_get_array(diag, 'ru', u)
                ! do this inline at present - it is simple enough
+               !$acc enter data copyin(u, ru_driving_values)
+               !$acc parallel default(present)
+               !$acc loop gang worker
                do iEdge = 1, nEdges
                   if(bdyMaskEdge(iEdge) > nRelaxZone) then
+                     !$acc loop vector
                      do k = 1, nVertLevels
                         u(k,iEdge) = ru_driving_values(k,iEdge)
                      end do
                   end if
                end do
+               !$acc end parallel
+               !$acc exit data copyout(u)
+               !$acc exit data delete(ru_driving_values)
                
                deallocate(ru_driving_values)
 

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -78,13 +78,19 @@ module atm_time_integration
    real (kind=RKIND), dimension(:,:), allocatable :: wdtn_arr
    real (kind=RKIND), dimension(:,:), allocatable :: rho_zz_int
 
-   real (kind=RKIND), dimension(:,:,:), allocatable :: scalars_driving ! regional_MPAS addition 
    real (kind=RKIND), dimension(:,:), allocatable :: ru_driving_tend ! regional_MPAS addition 
    real (kind=RKIND), dimension(:,:), allocatable :: rt_driving_tend ! regional_MPAS addition 
    real (kind=RKIND), dimension(:,:), allocatable :: rho_driving_tend ! regional_MPAS addition 
+
+   real (kind=RKIND), dimension(:,:,:), allocatable :: scalars_driving ! regional_MPAS addition
    real (kind=RKIND), dimension(:,:), allocatable :: ru_driving_values ! regional_MPAS addition 
    real (kind=RKIND), dimension(:,:), allocatable :: rt_driving_values ! regional_MPAS addition 
    real (kind=RKIND), dimension(:,:), allocatable :: rho_driving_values ! regional_MPAS addition 
+   !$acc declare create(scalars_driving)
+   !$acc declare create(ru_driving_values)
+   !$acc declare create(rt_driving_values)
+   !$acc declare create(rho_driving_values)
+
    integer, dimension(:), pointer :: bdyMaskEdge ! regional_MPAS addition
    logical, pointer :: config_apply_lbcs
    
@@ -1273,7 +1279,7 @@ module atm_time_integration
                call mpas_atm_get_bdy_state(clock, block, nVertLevels, nEdges, 'u', time_dyn_step, ru_driving_values)
 
                ! do this inline at present - it is simple enough
-               !$acc enter data copyin(u, ru_driving_values)
+               !$acc enter data copyin(u)
                !$acc parallel default(present)
                !$acc loop gang worker
                do iEdge = 1, nEdgesSolve
@@ -1286,12 +1292,11 @@ module atm_time_integration
                end do
                !$acc end parallel
                !$acc exit data copyout(u)
-               !$acc exit data delete(ru_driving_values)
 
                call mpas_atm_get_bdy_state(clock, block, nVertLevels, nEdges, 'ru', time_dyn_step, ru_driving_values)
                call mpas_pool_get_array(diag, 'ru', u)
                ! do this inline at present - it is simple enough
-               !$acc enter data copyin(u, ru_driving_values)
+               !$acc enter data copyin(u)
                !$acc parallel default(present)
                !$acc loop gang worker
                do iEdge = 1, nEdges
@@ -1304,8 +1309,7 @@ module atm_time_integration
                end do
                !$acc end parallel
                !$acc exit data copyout(u)
-               !$acc exit data delete(ru_driving_values)
-               
+
                deallocate(ru_driving_values)
 
             end if  ! regional_MPAS addition
@@ -6997,8 +7001,7 @@ module atm_time_integration
       vertexDegree = vertexDegree_ptr
 
       MPAS_ACC_TIMER_START('atm_bdy_adjust_dynamics_relaxzone_tend [ACC_data_xfer]')
-      !$acc enter data copyin(tend_rho, tend_rt, rho_zz, theta_m, rho_driving_values, &
-      !$acc                   rt_driving_values, tend_ru, ru, ru_driving_values)
+      !$acc enter data copyin(tend_rho, tend_rt, rho_zz, theta_m, tend_ru, ru)
       !$acc enter data create(divergence1, divergence2, vorticity1, vorticity2)
       MPAS_ACC_TIMER_STOP('atm_bdy_adjust_dynamics_relaxzone_tend [ACC_data_xfer]')
       
@@ -7147,8 +7150,8 @@ module atm_time_integration
 
        MPAS_ACC_TIMER_START('atm_bdy_adjust_dynamics_relaxzone_tend [ACC_data_xfer]')
       !$acc exit data copyout(tend_rho, tend_rt, tend_ru)
-      !$acc exit data delete(rho_zz, theta_m, ru, rho_driving_values, rt_driving_values, &
-      !$acc            ru_driving_values, divergence1, divergence2, vorticity1, vorticity2)
+      !$acc exit data delete(rho_zz, theta_m, ru, &
+      !$acc            divergence1, divergence2, vorticity1, vorticity2)
       MPAS_ACC_TIMER_STOP('atm_bdy_adjust_dynamics_relaxzone_tend [ACC_data_xfer]')
        
    end subroutine atm_bdy_adjust_dynamics_relaxzone_tend
@@ -7185,8 +7188,7 @@ module atm_time_integration
       call mpas_pool_get_array(diag, 'rtheta_base', rtheta_base)
 
       MPAS_ACC_TIMER_START('atm_bdy_reset_speczone_values [ACC_data_xfer]')
-      !$acc enter data copyin(rt_driving_values, rho_driving_values, rtheta_base, &
-      !$acc                   theta_m, rtheta_p)
+      !$acc enter data copyin(rtheta_base, theta_m, rtheta_p)
       MPAS_ACC_TIMER_STOP('atm_bdy_reset_speczone_values [ACC_data_xfer]')
       
       !$acc parallel default(present)
@@ -7204,7 +7206,7 @@ module atm_time_integration
 
       MPAS_ACC_TIMER_START('atm_bdy_reset_speczone_values [ACC_data_xfer]')
       !$acc exit data copyout(theta_m, rtheta_p) &
-      !$acc            delete(rt_driving_values, rho_driving_values, rtheta_base)
+      !$acc            delete(rtheta_base)
       MPAS_ACC_TIMER_STOP('atm_bdy_reset_speczone_values [ACC_data_xfer]')
 
    end subroutine atm_bdy_reset_speczone_values
@@ -7297,7 +7299,7 @@ module atm_time_integration
       !---
       MPAS_ACC_TIMER_START('atm_bdy_adjust_scalars [ACC_data_xfer]')
       !$acc enter data create(scalars_tmp) &
-      !$acc            copyin(scalars_driving, scalars_new)
+      !$acc            copyin(scalars_new)
       MPAS_ACC_TIMER_STOP('atm_bdy_adjust_scalars [ACC_data_xfer]')
 
       !$acc parallel default(present)
@@ -7381,7 +7383,7 @@ module atm_time_integration
       !$acc end parallel
 
       MPAS_ACC_TIMER_START('atm_bdy_adjust_scalars [ACC_data_xfer]')
-      !$acc exit data delete(scalars_tmp, scalars_driving) &
+      !$acc exit data delete(scalars_tmp) &
       !$acc           copyout(scalars_new)
       MPAS_ACC_TIMER_STOP('atm_bdy_adjust_scalars [ACC_data_xfer]')
 
@@ -7454,7 +7456,7 @@ module atm_time_integration
       !---
 
       MPAS_ACC_TIMER_START('atm_bdy_set_scalars_work [ACC_data_xfer]')
-      !$acc enter data copyin(scalars_new, scalars_driving)
+      !$acc enter data copyin(scalars_new)
       MPAS_ACC_TIMER_STOP('atm_bdy_set_scalars_work [ACC_data_xfer]')
 
       !$acc parallel default(present)
@@ -7480,7 +7482,6 @@ module atm_time_integration
 
       MPAS_ACC_TIMER_START('atm_bdy_set_scalars_work [ACC_data_xfer]')
       !$acc exit data copyout(scalars_new)
-      !$acc exit data delete(scalars_driving)
       MPAS_ACC_TIMER_STOP('atm_bdy_set_scalars_work [ACC_data_xfer]')
             
    end subroutine atm_bdy_set_scalars_work

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -1155,9 +1155,9 @@ module atm_time_integration
                allocate(rho_driving_values(nVertLevels,nCells+1))
 
                time_dyn_step = dt_dynamics*real(dynamics_substep-1) + rk_timestep(rk_step)
-               ru_driving_values(1:nVertLevels,1:nEdges+1) =  mpas_atm_get_bdy_state( clock, block, nVertLevels, nEdges, 'ru', time_dyn_step )
-               rt_driving_values(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'rtheta_m', time_dyn_step )
-               rho_driving_values(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'rho_zz', time_dyn_step )
+               call mpas_atm_get_bdy_state(clock, block, nVertLevels, nEdges, 'ru', time_dyn_step, ru_driving_values)
+               call mpas_atm_get_bdy_state(clock, block, nVertLevels, nCells, 'rtheta_m', time_dyn_step, rt_driving_values)
+               call mpas_atm_get_bdy_state(clock, block, nVertLevels, nCells, 'rho_zz', time_dyn_step, rho_driving_values)
 
                call mpas_timer_start('atm_bdy_adjust_dynamics_relaxzone_tend')
 !$OMP PARALLEL DO
@@ -1261,7 +1261,7 @@ module atm_time_integration
 
                time_dyn_step = dt_dynamics*real(dynamics_substep-1) + rk_timestep(rk_step)
 
-               ru_driving_values(1:nVertLevels,1:nEdges+1) =  mpas_atm_get_bdy_state( clock, block, nVertLevels, nEdges, 'u', time_dyn_step )
+               call mpas_atm_get_bdy_state(clock, block, nVertLevels, nEdges, 'u', time_dyn_step, ru_driving_values)
                ! do this inline at present - it is simple enough
                do iEdge = 1, nEdgesSolve
                   if(bdyMaskEdge(iEdge) > nRelaxZone) then
@@ -1271,7 +1271,7 @@ module atm_time_integration
                   end if
                end do
 
-               ru_driving_values(1:nVertLevels,1:nEdges+1) =  mpas_atm_get_bdy_state( clock, block, nVertLevels, nEdges, 'ru', time_dyn_step )
+               call mpas_atm_get_bdy_state(clock, block, nVertLevels, nEdges, 'ru', time_dyn_step, ru_driving_values)
                call mpas_pool_get_array(diag, 'ru', u)
                ! do this inline at present - it is simple enough
                do iEdge = 1, nEdges
@@ -1312,8 +1312,8 @@ module atm_time_integration
                   !
                   ! get the scalar values driving the regional boundary conditions
                   !
-                  scalars_driving(:,:,:) = mpas_atm_get_bdy_state(clock, block, num_scalars, nVertLevels, nCells, &
-                                                                  'scalars', rk_timestep(rk_step))
+                  call mpas_atm_get_bdy_state(clock, block, num_scalars, nVertLevels, nCells, &
+                                              'scalars', rk_timestep(rk_step), scalars_driving)
 
                   !$OMP PARALLEL DO
                   do thread=1,nThreads
@@ -1458,8 +1458,8 @@ module atm_time_integration
                !
                ! get the scalar values driving the regional boundary conditions
                !
-               scalars_driving(:,:,:) = mpas_atm_get_bdy_state(clock, block, num_scalars, nVertLevels, nCells, &
-                                                               'scalars', rk_timestep(rk_step))
+               call mpas_atm_get_bdy_state(clock, block, num_scalars, nVertLevels, nCells, &
+                                           'scalars', rk_timestep(rk_step), scalars_driving)
 
 !$OMP PARALLEL DO
                do thread=1,nThreads
@@ -1570,8 +1570,8 @@ module atm_time_integration
         allocate(rho_driving_values(nVertLevels,nCells+1))
         time_dyn_step = dt  ! end of full timestep values
 
-        rt_driving_values(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'rtheta_m', time_dyn_step )
-        rho_driving_values(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'rho_zz', time_dyn_step )
+        call mpas_atm_get_bdy_state(clock, block, nVertLevels, nCells, 'rtheta_m', time_dyn_step, rt_driving_values)
+        call mpas_atm_get_bdy_state(clock, block, nVertLevels, nCells, 'rho_zz', time_dyn_step, rho_driving_values)
 
 !$OMP PARALLEL DO
         do thread=1,nThreads
@@ -1597,7 +1597,7 @@ module atm_time_integration
          !
          ! get the scalar values driving the regional boundary conditions
          !
-         scalars_driving(:,:,:) = mpas_atm_get_bdy_state(clock, block, num_scalars, nVertLevels, nCells, 'scalars', dt)
+         call mpas_atm_get_bdy_state(clock, block, num_scalars, nVertLevels, nCells, 'scalars', dt, scalars_driving)
 
 !$OMP PARALLEL DO
          do thread=1,nThreads


### PR DESCRIPTION
This PR eliminates the host-device copying of LBC driving data provided by the `mpas_atm_get_bdy_state_{2d,3d}` routines.

In order to eliminate host-device copying of the LBC driving data provided by the `mpas_atm_get_bdy_state_{2d,3d}` routines, the allocatable arrays `scalars_driving`, `ru_driving_values`, `rt_driving_values`, and `rho_driving_values` in the `atm_time_integration` module are now automatically allocated on the device through `!$acc declare create` directives.
    
Accordingly, the `mpas_atm_get_bdy_state_{2d,3d}` routines no longer need `create` / `copyout` data directives for the `return_state` array produced by those routines, since the actual arguments to the `return_state` dummy argument are always one of the four arrays (`scalars_driving`, `ru_driving_values`, `rt_driving_values`, and `rho_driving_values`) that are allocated on the device before calls to these routines.
    
Also, all other code in the `atm_time_integration` module that employs the LBC driving data arrays no longer needs to use `copyin` / `delete` data directives for those arrays.

As part of the work to eliminate all host-device copying of the LBC driving data arrays, two loop in the `atm_srk3` routine for setting `u` and `ru` in the specified zone have been ported to GPUs with OpenACC, and those ported loops use the on-device copies of `ru_driving_values`.