### PR TITLE
Remote redundant part for noahmp soil init

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_lsm_noahmpinit.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_lsm_noahmpinit.F
@@ -395,42 +395,6 @@
  call mpas_pool_get_array(output_noahmp,'t2mvxy',t2mvxy  )
  call mpas_pool_get_array(output_noahmp,'qtdrain',qtdrain)
 
-!--- initialization of the soil liquid water content:
- do i = its,ite
-    if(ivgtyp(i) == mpas_noahmp%isice_table .and. xice(i) .le. 0._RKIND) then
-       !initialization over landice grid cells (frozen at init time):
-       do ns = 1,nsoil
-          smois(ns,i) = 1._RKIND
-          sh2o(ns,i)  = 0._RKIND
-          tslb(ns,i)  = min(tslb(ns,i),263.15) ! set landice temperature at -10C.
-       enddo
-    else
-       !initialization over all non-landice grid cells:
-       bexp   = mpas_noahmp%bexp_table(isltyp(i))
-       smcmax = mpas_noahmp%smcmax_table(isltyp(i))
-       psisat = mpas_noahmp%psisat_table(isltyp(i))
-
-       do ns = 1,nsoil
-          if(smois(ns,i) > smcmax) smois(ns,i) = smcmax
-       enddo
-       if(bexp.gt.0. .and. smcmax.gt.0. .and. psisat.gt.0.) then
-          do ns = 1,nsoil
-             if(tslb(ns,i) .lt. 273.149) then ! initial soil ice.
-                fk = ( ((hlice/(grav*(-psisat)))*((tslb(ns,i)-t0)/tslb(ns,i)))**(-1/bexp) )*smcmax
-                fk = max(fk,0.02)
-                sh2o(ns,i) = min(fk,smois(ns,i))
-             else
-                sh2o(ns,i) = smois(ns,i)
-             endif
-          enddo
-       else
-          do ns = 1,nsoil
-             sh2o(ns,i) = smois(ns,i)
-          enddo
-       endif
-    endif
- enddo
-
 
  do i = its,ite
     mpas_noahmp%tmn(i)   = tmn(i)


### PR DESCRIPTION
Remove redundant soil liquid water init from NoahMP, based on this previous PR:
https://github.com/MPAS-Dev/MPAS-Model/pull/1244

With this previous PR: https://github.com/MPAS-Dev/MPAS-Model/pull/1244,
the mpas_noahmp%sh2o field is correctly initialized in calling NoahmpInitMain and correctly assigned to sh2o. 

This PR will remove the redundant part (L398-433).

@cenlinhe @barlage