### PR TITLE
This change updates the core_init_atmosphere cmake file to add new files

### DIFF
--- a/src/core_init_atmosphere/CMakeLists.txt
+++ b/src/core_init_atmosphere/CMakeLists.txt
@@ -23,12 +23,15 @@ set(init_atm_core_srcs
         mpas_atmphys_initialize_real.F
         mpas_atmphys_utilities.F
         mpas_geotile_manager.F
+        mpas_gsl_oro_data_sm_scale.F
+        mpas_gsl_oro_data_lg_scale.F
         mpas_init_atm_bitarray.F
         mpas_init_atm_cases.F
         mpas_init_atm_core.F
         mpas_init_atm_core_interface.F
-	mpas_init_atm_thompson_aerosols.F
+        mpas_init_atm_thompson_aerosols.F
         mpas_init_atm_gwd.F
+        mpas_init_atm_gwd_gsl.F
         mpas_init_atm_hinterp.F
         mpas_init_atm_llxy.F
         mpas_init_atm_queue.F


### PR DESCRIPTION
This change updates the core_init_atmosphere cmake file to add new files added in commit d2c068015  (PR #1276).
That PR updated the makefiles, but not the cmake files. That resulted in compile errors when building with cmake:
src/core_init_atmosphere/mpas_init_atm_cases.F:48:11:

   48 |       use mpas_init_atm_gwd_gsl, only : calc_gsl_oro_data
      |           1
Fatal Error: Cannot open module file 'mpas_init_atm_gwd_gsl.mod' for reading at
(1): No such file or directory

Tested by building mpas_bundle.
