### PR TITLE
Enable package logic code to be automatically generated through new XML attribute, active_when

### DIFF
--- a/src/core_atmosphere/mpas_atm_core_interface.F
+++ b/src/core_atmosphere/mpas_atm_core_interface.F
@@ -127,7 +127,11 @@ module atm_core_interface
       character(len=StrKIND) :: attvalue
       integer :: local_ierr
 
-      ierr = 0
+
+      ierr = atm_setup_packages_when(configs, packages)
+      if (ierr /= 0) then
+         return
+      end if
 
       !
       ! Incremental analysis update
@@ -585,6 +589,8 @@ module atm_core_interface
 #include "block_dimension_routines.inc"
 
 #include "define_packages.inc"
+
+#include "setup_packages.inc"
 
 #include "structs_and_variables.inc"
 

--- a/src/core_init_atmosphere/mpas_init_atm_core_interface.F
+++ b/src/core_init_atmosphere/mpas_init_atm_core_interface.F
@@ -123,7 +123,10 @@ module init_atm_core_interface
       logical, pointer :: noahmp, config_noahmp_static
 
 
-      ierr = 0
+      ierr = init_atm_setup_packages_when(configs, packages)
+      if (ierr /= 0) then
+         return
+      end if
 
       call mpas_pool_get_config(configs, 'config_init_case', config_init_case)
       call mpas_pool_get_config(configs, 'config_static_interp', config_static_interp)
@@ -512,6 +515,8 @@ module init_atm_core_interface
 #include "block_dimension_routines.inc"
 
 #include "define_packages.inc"
+
+#include "setup_packages.inc"
 
 #include "structs_and_variables.inc"
 

--- a/src/tools/registry/gen_inc.c
+++ b/src/tools/registry/gen_inc.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include <regex.h>
 #include "ezxml.h"
 #include "registry_types.h"
 #include "gen_inc.h"
@@ -21,6 +22,11 @@
 
 void process_core_macro(const char *macro, const char *val, va_list ap);
 void process_domain_macro(const char *macro, const char *val, va_list ap);
+char * nmlopt_from_str(regex_t *preg, const char *str, regoff_t *next);
+const char * nmlopt_type(ezxml_t registry, const char *nmlopt);
+int package_logic_routine(FILE *fd, regex_t *preg, const char *corename,
+                          const char *packagename, const char *packagewhen,
+                          ezxml_t registry);
 
 #define NUM_MODIFIED_ATTRS 2
 #define NUM_IGNORED_ATTRS 9
@@ -2603,3 +2609,284 @@ void mangle_name(char *new_name, const size_t new_name_size, const char *old_nam
     snprintf(new_name, new_name_size, "%s", old_name);
 #endif
 }
+
+
+/******************************************************************************
+ *
+ * generate_package_logic
+ *
+ * Generates code for the Fortran routine 'CORE_setup_packages_when' in the file
+ * 'setup_packages.inc', where CORE is the core abbreviation from the registry
+ * core_abbrev attribute.
+ *
+ * Inputs:
+ *   registry - an XML tree containing the complete Registry file
+ *
+ * Return value: An integer status code. A value of 0 indicates success, and a
+ *   non-zero value indicates that an error was encountered when generating
+ *   logic for the package.
+ *
+ ******************************************************************************/
+int generate_package_logic(ezxml_t registry)/*{{{*/
+{
+	ezxml_t packages_xml, package_xml;
+	FILE *fd;
+	regex_t preg;
+	char *match = NULL;
+	regoff_t next = 0;
+        const char *corename;
+
+        corename = ezxml_attr(registry, "core_abbrev");
+
+        printf("---- GENERATING PACKAGE LOGIC ----\n");
+
+	if (regcomp(&preg, "config[0-9a-zA-Z_]*", REG_EXTENDED)) {
+		printf("Error compiling regex.\n");
+		return 1;
+	}
+
+	fd = fopen("setup_packages.inc", "w+");
+
+	fortprintf(fd, "   !\n");
+	fortprintf(fd, "   ! WARNING: This function is automatically generated at compile time.\n");
+        fortprintf(fd, "   !          Any modifications to this code will be lost when MPAS is recompiled.\n");
+	fortprintf(fd, "   !\n");
+	fortprintf(fd, "   function %s_setup_packages_when(configPool, packagePool) result(ierr)\n", corename);
+	fortprintf(fd, "\n");
+	fortprintf(fd, "      use mpas_derived_types, only : mpas_pool_type\n");
+	fortprintf(fd, "\n");
+	fortprintf(fd, "      implicit none\n");
+	fortprintf(fd, "\n");
+	fortprintf(fd, "      integer :: ierr\n");
+	fortprintf(fd, "\n");
+	fortprintf(fd, "      type (mpas_pool_type), intent(in) :: configPool\n");
+	fortprintf(fd, "      type (mpas_pool_type), intent(inout) :: packagePool\n");
+	fortprintf(fd, "\n");
+	fortprintf(fd, "\n");
+	fortprintf(fd, "      ierr = 0\n");
+	fortprintf(fd, "\n");
+
+	for (packages_xml = ezxml_child(registry, "packages"); packages_xml; packages_xml = packages_xml->next) {
+		for (package_xml = ezxml_child(packages_xml, "package"); package_xml; package_xml = package_xml->next) {
+			const char *packagename, *packagewhen;
+
+			packagename = ezxml_attr(package_xml, "name");
+			packagewhen = ezxml_attr(package_xml, "active_when");
+
+			if (packagewhen != NULL) {
+				fortprintf(fd, "      call %s_setup_%s_package(configPool, packagePool)\n", corename, packagename);
+			}
+		}
+	}
+
+	fortprintf(fd, "\n");
+	fortprintf(fd, "   end function %s_setup_packages_when\n", corename);
+	fortprintf(fd, "\n");
+
+	for (packages_xml = ezxml_child(registry, "packages"); packages_xml; packages_xml = packages_xml->next) {
+		for (package_xml = ezxml_child(packages_xml, "package"); package_xml; package_xml = package_xml->next) {
+			const char *packagename, *packagewhen;
+
+			packagename = ezxml_attr(package_xml, "name");
+			packagewhen = ezxml_attr(package_xml, "active_when");
+
+			if (packagewhen != NULL) {
+				if (package_logic_routine(fd, &preg, corename, packagename, packagewhen, registry) != 0) {
+					fprintf(stderr, "Error: Problem generating logic routine for package %s, active when (%s)\n", packagename, packagewhen);
+					regfree(&preg);
+					fclose(fd);
+					return 1;
+				}
+			}
+		}
+	}
+
+	regfree(&preg);
+
+	fclose(fd);
+
+	return 0;
+}/*}}}*/
+
+
+/******************************************************************************
+ *
+ * package_logic_routine
+ *
+ * Generates code for the Fortran routine 'setup_X_package' that defines the active
+ * status of the package X, whose name is given by packagename, based on the logic
+ * described in the packagewhen string.
+ *
+ * Inputs:
+ *   fd - an open file descriptor, to which the generated code will be written
+ *   preg - a compiled regular-expression that matches namelist options
+ *   corename - a string with the name of the core for which package logic is
+ *              being generated. The corename is used in the name of the routine
+ *              being generated.
+ *   packagename - the name of the package for which code is being generated
+ *   packagewhen - the string containing the logical condition under which the
+ *                 package is active
+ *   registry - an XML tree containing the complete Registry file
+ *
+ * Return value: An integer status code. A value of 0 indicates success, and a
+ *   non-zero value indicates that an error was encountered when generating
+ *   logic for the package.
+ *
+ ******************************************************************************/
+int package_logic_routine(FILE *fd, regex_t *preg, const char *corename,
+                          const char *packagename, const char *packagewhen,
+                          ezxml_t registry)/*{{{*/
+{
+	ezxml_t packages_xml, package_xml;
+	char *match;
+	regoff_t next;
+
+
+	fortprintf(fd, "\n");
+	fortprintf(fd, "   !\n");
+	fortprintf(fd, "   ! WARNING: This subroutine is automatically generated at compile time.\n");
+        fortprintf(fd, "   !          Any modifications to this code will be lost when MPAS is recompiled.\n");
+	fortprintf(fd, "   !\n");
+	fortprintf(fd, "   subroutine %s_setup_%s_package(configPool, packagePool)\n", corename, packagename);
+	fortprintf(fd, "\n");
+	fortprintf(fd, "      use mpas_kind_types, only : RKIND, StrKIND\n");
+	fortprintf(fd, "      use mpas_derived_types, only : mpas_pool_type\n");
+	fortprintf(fd, "\n");
+	fortprintf(fd, "      implicit none\n");
+	fortprintf(fd, "\n");
+	fortprintf(fd, "      type (mpas_pool_type), intent(in) :: configPool\n");
+	fortprintf(fd, "      type (mpas_pool_type), intent(inout) :: packagePool\n");
+	fortprintf(fd, "\n");
+	fortprintf(fd, "      logical, pointer :: %sActive\n", packagename);
+	fortprintf(fd, "\n");
+
+	next = 0;
+	while ((match = nmlopt_from_str(preg, packagewhen, &next)) != NULL) {
+		const char *nmltype;
+
+		nmltype =  nmlopt_type(registry, match);
+
+		if (nmltype != NULL) {
+			if (strcmp(nmltype, "integer") == 0) {
+				fortprintf(fd, "      integer, pointer :: %s\n", match);
+			} else if (strcmp(nmltype, "real") == 0) {
+				fortprintf(fd, "      real(kind=RKIND), pointer :: %s\n", match);
+			} else if (strcmp(nmltype, "logical") == 0) {
+				fortprintf(fd, "      logical, pointer :: %s\n", match);
+			} else if (strcmp(nmltype, "character") == 0) {
+				fortprintf(fd, "      character(len=StrKIND), pointer :: %s\n", match);
+			} else {
+				fortprintf(fd, "      INTENTIONAL COMPILE ERROR - UNKNOWN TYPE %s FOR %s\n", nmltype, match);
+				fprintf(stderr, "Error: Unknown type %s for %s\n", nmltype, match);
+				free(match);
+	                        return 1;
+			}
+		} else {
+			fortprintf(fd, "      INTENTIONAL COMPILE ERROR - %s NOT FOUND IN REGISTRY\n", match);
+			fprintf(stderr, "Error: %s not found in registry\n", match);
+			free(match);
+                        return 1;
+		}
+
+		free(match);
+	}
+	fortprintf(fd, "\n");
+
+	next = 0;
+	while ((match = nmlopt_from_str(preg, packagewhen, &next)) != NULL) {
+
+		fortprintf(fd, "      nullify(%s)\n", match, match);
+		fortprintf(fd, "      call mpas_pool_get_config(configPool, '%s', %s)\n", match, match);
+
+		free(match);
+	}
+	fortprintf(fd, "\n");
+	fortprintf(fd, "      nullify(%sActive)\n", packagename);
+	fortprintf(fd, "      call mpas_pool_get_package(packagePool, '%sActive', %sActive)\n", packagename, packagename);
+	fortprintf(fd, "\n");
+	fortprintf(fd, "      %sActive = ( %s )\n", packagename, packagewhen);
+	fortprintf(fd, "\n");
+	fortprintf(fd, "   end subroutine %s_setup_%s_package\n", corename, packagename);
+	fortprintf(fd, "\n");
+
+	return 0;
+}/*}}}*/
+
+
+/******************************************************************************
+ *
+ * nmlopt_from_str
+ *
+ * Parses and returns successive namelist options from the string str. The regex
+ * preg is used to match valid namelist options, and next stores the context.
+ *
+ * On the initial call, the next argument must be set to 0.
+ *
+ * Inputs:
+ *   preg - a compiled regular-expression that matches namelist options
+ *   next - used for internal state. On the first invocation, next must be set
+ *          to 0.
+ *
+ * Outputs:
+ *   next - an offset used to retain the state; the next value should be passed
+ *          unmodified to subsequent calls to this function.
+ *
+ * Return value: A string containing the next namelist option matching preg that
+ *   was found in the input string, str. If no further namelist options were
+ *   found, a NULL value is returned.
+ *
+ ******************************************************************************/
+char * nmlopt_from_str(regex_t *preg, const char *str, regoff_t *next)/*{{{*/
+{
+	const size_t nmatch = 2;
+	regmatch_t pmatch[nmatch];
+	char *match = NULL;
+
+	if (regexec(preg, str+*next, nmatch, pmatch, 0) != REG_NOMATCH) {
+		if (pmatch[0].rm_so >= 0 && pmatch[0].rm_eo >= 0) {
+			size_t len = (size_t)(pmatch[0].rm_eo - pmatch[0].rm_so);
+			match = malloc(sizeof(char) * (len + 1));
+			strncpy(match, str+*next+pmatch[0].rm_so, len);
+			match[len] = '\0';
+			*next += pmatch[0].rm_eo;
+		}
+	}
+
+	return match;
+}/*}}}*/
+
+
+/******************************************************************************
+ *
+ * nmlopt_type
+ *
+ * Given a namelist option, nmlopt, defined in registry, returns the string from
+ * the registry defining the type of the option (e.g., "integer" or "logical").
+ *
+ * Inputs:
+ *   registry - an XML tree containing the complete Registry file
+ *   nmlopt - a string containing the namelist option whose type is to be found
+ *
+ * Return value: A string identifying the type of the namelist option, or, if
+ *   the namelist option was not found in the Registry, a NULL value..
+ *
+ ******************************************************************************/
+const char * nmlopt_type(ezxml_t registry, const char *nmlopt)/*{{{*/
+{
+	ezxml_t nmlrecs_xml, nmlopt_xml;
+
+	const char *nmloptname, *nmlopttype;
+
+	for (nmlrecs_xml = ezxml_child(registry, "nml_record"); nmlrecs_xml; nmlrecs_xml = nmlrecs_xml->next){
+		for (nmlopt_xml = ezxml_child(nmlrecs_xml, "nml_option"); nmlopt_xml; nmlopt_xml = nmlopt_xml->next){
+			nmloptname = ezxml_attr(nmlopt_xml, "name");
+			nmlopttype = ezxml_attr(nmlopt_xml, "type");
+
+			if (strcmp(nmlopt, nmloptname) == 0) {
+				return nmlopttype;
+			}
+		}
+	}
+
+	return NULL;
+}/*}}}*/

--- a/src/tools/registry/gen_inc.c
+++ b/src/tools/registry/gen_inc.c
@@ -2654,6 +2654,7 @@ int generate_package_logic(ezxml_t registry)/*{{{*/
 	fortprintf(fd, "   function %s_setup_packages_when(configPool, packagePool) result(ierr)\n", corename);
 	fortprintf(fd, "\n");
 	fortprintf(fd, "      use mpas_derived_types, only : mpas_pool_type\n");
+	fortprintf(fd, "      use mpas_log, only : mpas_log_write\n");
 	fortprintf(fd, "\n");
 	fortprintf(fd, "      implicit none\n");
 	fortprintf(fd, "\n");
@@ -2664,6 +2665,9 @@ int generate_package_logic(ezxml_t registry)/*{{{*/
 	fortprintf(fd, "\n");
 	fortprintf(fd, "\n");
 	fortprintf(fd, "      ierr = 0\n");
+	fortprintf(fd, "\n");
+	fortprintf(fd, "      call mpas_log_write('')\n");
+	fortprintf(fd, "      call mpas_log_write('Configuring registry-specified packages...')\n");
 	fortprintf(fd, "\n");
 
 	for (packages_xml = ezxml_child(registry, "packages"); packages_xml; packages_xml = packages_xml->next) {
@@ -2679,6 +2683,9 @@ int generate_package_logic(ezxml_t registry)/*{{{*/
 		}
 	}
 
+	fortprintf(fd, "\n");
+	fortprintf(fd, "      call mpas_log_write('----- done configuring registry-specified packages -----')\n");
+	fortprintf(fd, "      call mpas_log_write('')\n");
 	fortprintf(fd, "\n");
 	fortprintf(fd, "   end function %s_setup_packages_when\n", corename);
 	fortprintf(fd, "\n");
@@ -2751,6 +2758,7 @@ int package_logic_routine(FILE *fd, regex_t *preg, const char *corename,
 	fortprintf(fd, "\n");
 	fortprintf(fd, "      use mpas_kind_types, only : RKIND, StrKIND\n");
 	fortprintf(fd, "      use mpas_derived_types, only : mpas_pool_type\n");
+	fortprintf(fd, "      use mpas_log, only : mpas_log_write\n");
 	fortprintf(fd, "\n");
 	fortprintf(fd, "      implicit none\n");
 	fortprintf(fd, "\n");
@@ -2805,6 +2813,7 @@ int package_logic_routine(FILE *fd, regex_t *preg, const char *corename,
 	fortprintf(fd, "      call mpas_pool_get_package(packagePool, '%sActive', %sActive)\n", packagename, packagename);
 	fortprintf(fd, "\n");
 	fortprintf(fd, "      %sActive = ( %s )\n", packagename, packagewhen);
+	fortprintf(fd, "      call mpas_log_write('  %s : $l', logicArgs=[%sActive])\n", packagename, packagename);
 	fortprintf(fd, "\n");
 	fortprintf(fd, "   end subroutine %s_setup_%s_package\n", corename, packagename);
 	fortprintf(fd, "\n");

--- a/src/tools/registry/gen_inc.h
+++ b/src/tools/registry/gen_inc.h
@@ -39,3 +39,4 @@ int merge_structs_and_var_arrays(ezxml_t currentPosition);
 int merge_streams(ezxml_t registry);
 int parse_structs_from_registry(ezxml_t registry);
 void mangle_name(char *new_name, const size_t new_name_size, const char *old_name);
+int generate_package_logic(ezxml_t registry);

--- a/src/tools/registry/parse.c
+++ b/src/tools/registry/parse.c
@@ -764,6 +764,9 @@ int parse_reg_xml(ezxml_t registry)/*{{{*/
 	// Generate code to read and write fields
 	err = generate_immutable_streams(registry);
 
+	// Generate logic to set packages with the 'active_when' attribute
+	err = generate_package_logic(registry);
+
 	return 0;
 }/*}}}*/
 

--- a/src/tools/registry/parse.c
+++ b/src/tools/registry/parse.c
@@ -751,21 +751,45 @@ int parse_reg_xml(ezxml_t registry)/*{{{*/
 
 	// Parse Packages
 	err = parse_packages_from_registry(registry);
+	if (err) {
+		fprintf(stderr, "Error in parse_packages_from_registry\n");
+		return err;
+	}
 
 	// Parse namelist records
 	err = parse_namelist_records_from_registry(registry);
+	if (err) {
+		fprintf(stderr, "Error in parse_namelist_records_from_registry\n");
+		return err;
+	}
 
 	// Parse dimensions
 	err = parse_dimensions_from_registry(registry);
+	if (err) {
+		fprintf(stderr, "Error in parse_dimensions_from_registry\n");
+		return err;
+	}
 
 	// Parse variable structures
 	err = parse_structs_from_registry(registry);
+	if (err) {
+		fprintf(stderr, "Error in parse_structs_from_registry\n");
+		return err;
+	}
 
 	// Generate code to read and write fields
 	err = generate_immutable_streams(registry);
+	if (err) {
+		fprintf(stderr, "Error in generate_immutable_streams\n");
+		return err;
+	}
 
 	// Generate logic to set packages with the 'active_when' attribute
 	err = generate_package_logic(registry);
+	if (err) {
+		fprintf(stderr, "Error in generate_package_logic\n");
+		return err;
+	}
 
 	return 0;
 }/*}}}*/


### PR DESCRIPTION
This PR enables the package logic code that determines when a package is active
to be automatically generated by the registry through the use of a new XML attribute
for `<package>` elements, `active_when`.

Prior to the changes in this PR, defining a new package in the Registry with
a `<package>` element required code to be written (typically in a core's
`setup_packages` routine) to determine whether that package was active. For simple
conditions -- e.g., a package being active if and only if a logical namelist
option is true -- the need to write boilerplate-type Fortran code to retrieve
package and namelist pointers, check that those pointers are valid, and to
finally set the package variable, was unnecessarily cumbersome.

This PR introduces a new XML attribute, `active_when`, that may be added to
`<package>` elements in the Registry, along with new functionality in the registry
processor to automatically generate package-logic code (the equivalent to what
would otherwise need to be written by hand in a core's `setup_packages` routine)
at compile time.

If provided, the `active_when` attribute contains a Fortran expression that
evaluates to a logical, and that may use any literal constants and namelist
options (which are assumed to begin with the string 'config'). The expression
from the `active_when` attribute is essentially used verbatim in Fortran code to
set the package variable.

For example, consider a package named `foo` that is active if and only if the
namelist option `config_use_physics` is true. This package might have the
following definition in the Registry:
```
  <package name="foo" active_when="config_do_physics"/>
```
Logically, the generated code is equivalent to:
```
  fooActive = ( config_do_physics )
```
As another example, consider the following package definition in the Registry:
```
  <package name="bar" active_when="config_nsteps > 0 .and. .not. config_dryrun"/>
```
The generated Fortran logic would be:
```
  barActive = ( config_nsteps > 0 .and. .not. config_dryrun )
```
Note that in both examples, the package's `active_when` logic is a valid Fortran
logical expression that makes uses of namelist options and literal constants.

In order to make use of this functionality introduced in this PR, a core
must make two changes in its `mpas_<CORE>_core_interface` module:

1) The module should include through a pre-processor directive the
   registry-generated package-logic code, which resides in a file named
   `setup_packages.inc` in the core's `inc/` directory; e.g.,
```
   #include "setup_packages.inc"
```
2) The setup_packages routine in the module should make a call to the generated
   `<CORE>_setup_packages_when` routine, which is defined in the
   `setup_packages.inc` file; e.g.,
```
   call atm_setup_packages_when(configs, packages)
```
The registry-generated package-logic code for packages that employ an
`active_when` attribute also contains calls to `mpas_log_write` to record
information about the activity of packages to a core's log file. For example,
the following messages are now written to the log file if two packages, `foo` and
`bar`, were active and inactive, respectively:
```
 Configuring registry-specified packages...
   foo : T
   bar : F
 ----- done configuring registry-specified packages -----
```