### PR TITLE
Changing default value for three namelists

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -2079,7 +2079,7 @@
                      description="logical for configuration of fractional sea-ice"
                      possible_values=".true. for sea-ice between 0 or 1; .false. for sea-ice equal to 0 or 1 (flag)."/>
 
-                <nml_option name="config_sfc_albedo" type="logical" default_value="true" in_defaults="false"
+                <nml_option name="config_sfc_albedo" type="logical" default_value="false" in_defaults="false"
                      units="-"
                      description="logical for configuration of surface albedo"
                      possible_values=".true. for climatologically varying surface albedo; .false. for fixed input data"/>
@@ -2109,12 +2109,12 @@
                      description="logical for configuration of input ozone data in RRMTG long- and short-wave radiation"
                      possible_values=".true. for using monthly-varying ozone data; .false. for using fixed vertical profile"/>
 
-                <nml_option name="config_microp_re" type="logical" default_value="false" in_defaults="false"
+                <nml_option name="config_microp_re" type="logical" default_value="true" in_defaults="false"
                      units="-"
                      description="logical for calculation of the effective radii for cloud water, cloud ice, and snow"
                      possible_values=".true. for calculating effective radii; .false. for using defaults in RRTMG radiation"/>
 
-                <nml_option name="config_ysu_pblmix" type="logical" default_value="false" in_defaults="false"
+                <nml_option name="config_ysu_pblmix" type="logical" default_value="true" in_defaults="false"
                      units="-"
                      description="logical for turning on/off top-down, radiation_driven mixing"
                      possible_values=".true. to turn on top-down radiation_driven mixing; .false. otherwise"/>


### PR DESCRIPTION
This PR changes the default value for the following namelists: config_sfc_albedo (new value = false), config_microp_re (new value = true) and config_ysu_pblmix (new value = true).

With config_sfc_albedo set to false, the model will use table values to define albedo based on landuse values. This should be a better representation for models that have resolution better than the climatological albedo which is at about 5.5 km resolution.

With config_microp_re set to true, this will allow model to compute effective radii from microphysics variables and use them in radiation. This should better represent interactions between microphysics and radiation.

With config_ysu_pblmix set to true, it will account for top-down radiation-driven mixing at the PBL top.