### PR TITLE
Fix DEBUG build issues due to Fortran-only LDFLAGS for the 'intel' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -667,10 +667,10 @@ intel:   # BUILDTARGET Intel oneAPI Fortran, C, and C++ compiler suite
 	"CFLAGS_OPT = -O3" \
 	"CXXFLAGS_OPT = -O3" \
 	"LDFLAGS_OPT = -O3" \
-	"FFLAGS_DEBUG = -g -convert big_endian -free -check all -fpe0 -traceback" \
+	"FFLAGS_DEBUG = -g -convert big_endian -free -check bounds,pointers,arg_temp_created,format,shape,contiguous -fpe0 -traceback" \
 	"CFLAGS_DEBUG = -g -traceback" \
 	"CXXFLAGS_DEBUG = -g -traceback" \
-	"LDFLAGS_DEBUG = -g -check all -fpe0 -traceback" \
+	"LDFLAGS_DEBUG = -g -traceback" \
 	"FFLAGS_OMP = -qopenmp" \
 	"CFLAGS_OMP = -qopenmp" \
 	"PICFLAG = -fpic" \


### PR DESCRIPTION
This PR fixes `DEBUG` build issues due to the use of Fortran-only `LDFLAGS` in the `intel` build target.

With the introduction of build tests for the PnetCDF library in merge commit 9a073c2f, builds of MPAS with `DEBUG=true` were broken for the `intel` build target. Two of the options, `-check all` and `-fpe0` that were included in the definition of `LDFLAGS_DEBUG` for the `intel` build target only apply to Fortran, while the test program for the PnetCDF library is pure C, resulting in the build-time error message:
```
  *********************************************************
  ERROR: Test PnetCDF C program could not be compiled by mpicc.
  Please ensure you have a working PnetCDF library installed.

  The following compilation command failed with errors:
  mpicc pnetcdf.c  -I<path to pnetcdf>/include -g -traceback -DSINGLE_PRECISION -g -check all -fpe0 -traceback -L<path to pnetcdf>/lib -lpnetcdf -o pnetcdf.out

  Test program pnetcdf.c and output pnetcdf.log have been left
  in the top-level MPAS directory for further debugging
  *********************************************************
```
The underlying error messages from the `icx` compiler identify the `-check` and `-fpe0` options as the source of the failure:
```
  icx: error: unknown argument: '-check'
  icx: error: unknown argument: '-fpe0'
```
This PR removes `-check all` and `-fpe0` from the definition of `LDFLAGS_DEBUG` for the `intel` target, and since `-check all` must be specified during both compilation and linking, the `-check all` option in `FFLAGS_DEBUG` is
replaced with `-check bounds,pointers,arg_temp_created,format,shape,contiguous`, which includes most of the checks provided by `all`, though omitting, most notably, checks for the use of uninitialized memory.