### PR TITLE
Convert config_apply_lbcs from a logical pointer to a simple logical scalar

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -78,7 +78,7 @@ module atm_time_integration
    real (kind=RKIND), dimension(:,:), allocatable :: rt_driving_values ! regional_MPAS addition 
    real (kind=RKIND), dimension(:,:), allocatable :: rho_driving_values ! regional_MPAS addition 
    integer, dimension(:), pointer :: bdyMaskEdge ! regional_MPAS addition
-   logical, pointer :: config_apply_lbcs
+   logical :: config_apply_lbcs
    
    ! Used in compute_solve_diagnostics
    real (kind=RKIND), allocatable, dimension(:,:) :: ke_vertex
@@ -402,13 +402,16 @@ module atm_time_integration
       real (kind=RKIND) :: Time_new
       type (mpas_pool_type), pointer :: state
       character (len=StrKIND), pointer :: config_time_integration
+      logical, pointer :: config_apply_lbcs_ptr
 
 
       clock => domain % clock
       block => domain % blocklist
 
       call mpas_pool_get_config(block % configs, 'config_time_integration', config_time_integration)
-      call mpas_pool_get_config(block % configs, 'config_apply_lbcs', config_apply_lbcs)
+      call mpas_pool_get_config(block % configs, 'config_apply_lbcs', config_apply_lbcs_ptr)
+
+      config_apply_lbcs = config_apply_lbcs_ptr
 
       if (trim(config_time_integration) == 'SRK3') then
          call atm_srk3(domain, dt, itimestep, exchange_halo_group)


### PR DESCRIPTION
This PR converts the `config_apply_lbcs` variable from a `logical, pointer` to a simple `logical` scalar variable.

The module variable `config_apply_lbcs` in the `atm_time_integration` module was previously declared as a `logical, pointer` variable; however, this module-level `config_apply_lbcs` variable is used in OpenACC parallel regions in several routines. Since OpenACC implicitly copies scalar variables but not pointers, this PR converts the module-level `config_apply_lbcs` variable to a simple logical scalar. Code in the `atm_timestep` routine for setting `config_apply_lbcs` now retrieves a local pointer variable, which is then assigned to `config_apply_lbcs`.