### PR TITLE
Eliminate intermediate refl10cm_p array when capturing 3-d refl10cm

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
@@ -149,9 +149,6 @@
        if(.not.allocated(rainprod_p)) allocate(rainprod_p(ims:ime,kms:kme,jms:jme))
        if(.not.allocated(evapprod_p)) allocate(evapprod_p(ims:ime,kms:kme,jms:jme))
 
-       !3D radar reflectivity
-       if(.not.allocated(refl10cm_p)) allocate(refl10cm_p(ims:ime,kms:kme,jms:jme))
-
     microp2_select: select case(trim(microp_scheme))
        case("mp_thompson","mp_thompson_aerosols")
           if(.not.allocated(ntc_p)) allocate(ntc_p(ims:ime,jms:jme))
@@ -232,9 +229,6 @@
        !precipitation flux:
        if(allocated(rainprod_p)) deallocate(rainprod_p)
        if(allocated(evapprod_p)) deallocate(evapprod_p)
-
-       ! 3D radar reflectivity
-       if(allocated(refl10cm_p)) deallocate(refl10cm_p)
 
     microp2_select: select case(trim(microp_scheme))
        case("mp_thompson","mp_thompson_aerosols")
@@ -671,6 +665,7 @@
 
 !local pointers:
  character(len=StrKIND),pointer:: microp_scheme
+ real(kind=RKIND),dimension(:,:),pointer:: refl10cm
  real(kind=RKIND),dimension(:),pointer:: refl10cm_max,refl10cm_1km,refl10cm_1km_max
 
 !local variables and arrays:
@@ -682,6 +677,7 @@
 
  call mpas_pool_get_config(configs,'config_microp_scheme',microp_scheme)
 
+ call mpas_pool_get_array(diag_physics,'refl10cm',refl10cm)
  call mpas_pool_get_array(diag_physics,'refl10cm_max',refl10cm_max)
  call mpas_pool_get_array(diag_physics,'refl10cm_1km',refl10cm_1km)
  call mpas_pool_get_array(diag_physics,'refl10cm_1km_max',refl10cm_1km_max)
@@ -719,7 +715,7 @@
           kp = 1
           do k = kts,kte
              dBZ1d(k) = max(-35._RKIND,dBZ1d(k))
-             refl10cm_p(i,k,j) = dBZ1d(k)
+             refl10cm(k,i) = dBZ1d(k)
              if(zp(k) .lt. 1000.) kp = k
           enddo
           refl10cm_max(i) = maxval(dBZ1d(:))
@@ -771,7 +767,7 @@
           kp = 1
           do k = kts,kte
              dBZ1d(k) = max(-35._RKIND,dBZ1d(k))
-             refl10cm_p(i,k,j) = dBZ1d(k)
+             refl10cm(k,i) = dBZ1d(k)
              if(zp(k) .lt. 1000.) kp = k
           enddo
           refl10cm_max(i) = maxval(dBZ1d(:))

--- a/src/core_atmosphere/physics/mpas_atmphys_interface.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_interface.F
@@ -928,8 +928,6 @@
           re_cloud(k,i) = recloud_p(i,k,j)
           re_ice(k,i)   = reice_p(i,k,j)
           re_snow(k,i)  = resnow_p(i,k,j)
-
-          refl10cm(k,i) = refl10cm_p(i,k,j)
        enddo
        enddo
        enddo

--- a/src/core_atmosphere/physics/mpas_atmphys_vars.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_vars.F
@@ -284,8 +284,7 @@
     evapprod_p,       &!
     recloud_p,        &!
     reice_p,          &!
-    resnow_p,         &!
-    refl10cm_p         !
+    resnow_p           !
 
 !... for Thompson cloud microphysics parameterization, including aerosol-aware option:
  real(kind=RKIND),dimension(:,:),allocatable:: &


### PR DESCRIPTION
This PR eliminates the intermediate `refl10cm_p` array when capturing the 3-d `refl10cm` field.

The 3-d `refl10cm` field is captured from 1-d columns of computed 10 cm radar reflectivity when either the Thompson, Thompson aerosol-aware, or WSM6 microphysics schemes is used. Prior to this PR, the 1-d columns of reflectivity were saved to a transposed `refl10cm_p` array in the `compute_radar_reflectivity` routine, and `refl10cm_p` was then copied to `refl10cm` in the `microphysics_to_MPAS` routine.

Since the `compute_radar_reflectivity` subroutine already accesses other registry-defined fields through calls to `mpas_pool_get_array`, the `refl10cm` field can be accessed directly in that subroutine, eliminating the need for the intermediate `refl10cm_p` array.