### PR TITLE
Fix OpenACC partially present error for rho_zz_int in atm_advance_scalars_mono_work

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -3483,7 +3483,7 @@ module atm_time_integration
       integer, intent(in) :: cellSolveStart, cellSolveEnd
       procedure (halo_exchange_routine) :: exchange_halo_group
       logical, intent(in), optional :: advance_density
-      real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(inout), optional :: rho_zz_int
+      real (kind=RKIND), dimension(:,:), intent(inout), optional :: rho_zz_int
 
       integer :: ii,jj
       integer, dimension(10) :: ica


### PR DESCRIPTION
This PR fixes an OpenACC "partially present" error for rho_zz_int in the atm_advance_scalars_mono_work routine.

When compiled with OpenACC enabled using the `nvfortran` compiler, running with `config_split_dynamics_transport = false` in the `namelist.atmsophere` file results in a runtime error for `rho_zz_int`:
```
  FATAL ERROR: variable in data clause is partially present on the device: name=rho_zz_int(:,:)
   file:src/core_atmosphere/dynamics/mpas_atm_time_integration.F atm_advance_scalars_mono_work line:3942
```
The `rho_zz_int` array is only used if `local_advance_density` is `.true.` in the `atm_advance_scalars_mono_work` routine, and `local_advance_density` is true if and only if `config_split_dynamics_transport` is true.

Consequently, simulations with `config_split_dynamics_transport = false` in the namelist only allocate the `rho_zz_int` array with dimensions `(1,1)`, rather than the full dimensions `(nVertLevels,nCells+1)` that are required when `local_advance_density` is true.

This difference in the allocated dimensions of `rho_zz_int` apparently causes problems for the OpenACC runtime, which expects `rho_zz_int` to be allocated as indicated by the explicit-shape specification, `dimension(nVertLevels,nCells+1)`, for the `rho_zz_int` dummy argument to `atm_advance_scalars_mono_work`.

To work around the "partially present" error, this PR changes the `rho_zz_int` dummy argument to a deferred shape array, with `dimension(:,:)`.