### PR TITLE
Copy streams.init_atmosphere in the setup_run_dir.py script for MPAS-A

### DIFF
--- a/testing_and_setup/atmosphere/setup_run_dir.py
+++ b/testing_and_setup/atmosphere/setup_run_dir.py
@@ -148,6 +148,7 @@ if __name__ == '__main__':
     init_files_to_copy = ['default_inputs/' + f
         for f in [
             'namelist.init_atmosphere',
+            'streams.init_atmosphere',
             ]
         ]
 


### PR DESCRIPTION
This PR updates the `setup_run_dir.py` script so that it also copies the `streams.init_atmosphere` file.

The `setup_run_dir.py` script for setting up an MPAS-A run directory previously omitted a copy of the `streams.init_atmosphere` file. This PR adds `streams.init_atmosphere` to the list of files to copy to the run directory for the MPAS-A `init_atmosphere` core.