### PR TITLE
Add 'MODIFIED_IGBP_MODIS_NOAH_15s' to possible_values for config_landuse_data

### DIFF
--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -164,7 +164,7 @@
                 <nml_option name="config_landuse_data"          type="character"     default_value="MODIFIED_IGBP_MODIS_NOAH"
                      units="-"
                      description="The land use classification to use (case 7 only)"
-                     possible_values="`USGS' or `MODIFIED_IGBP_MODIS_NOAH'"/>
+                     possible_values="`USGS', `MODIFIED_IGBP_MODIS_NOAH', or `MODIFIED_IGBP_MODIS_NOAH_15s'"/>
 
                 <nml_option name="config_soilcat_data"          type="character"     default_value="STATSGO"
                      units="-"


### PR DESCRIPTION
This PR adds `MODIFIED_IGBP_MODIS_NOAH_15s` to the `possible_values` attribute for the `config_landuse_data` namelist option in the `init_atmosphere` core `Registry.xml` file. Merge commit bcf13cf0 (PR #1322) added the option of using 15-arc-second MODIS land cover data, though the possible values for the `config_landuse_data` option were not updated to reflect this.