### PR TITLE
Note in description of config_lu_supersample_factor applicability to USGS

### DIFF
--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -198,7 +198,7 @@
 
 	        <nml_option name="config_lu_supersample_factor" type="integer"       default_value="1"
                      units="-"
-                     description="The supersampling factor to be used for 30s or 15s MODIS land use (case 7 only)"
+                     description="The supersampling factor to be used for 30s or 15s MODIS land use, or for 30s USGS land use, as selected by `config_landuse_data' (case 7 only)"
                      possible_values="Positive integer values"/>
 
                 <nml_option name="config_30s_supersample_factor"    type="integer"       default_value="1"


### PR DESCRIPTION
This PR updates the description of the `config_lu_supersample_factor` namelist option to make it clearer that the supersampling will apply to any of the three land use datasets selected by the `config_landuse_data` namelist option, including 30" USGS land use.