### PR TITLE
Add 13 to the possible values for config_init_case in init_atmosphere Registry

### DIFF
--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -66,7 +66,7 @@
                                         8 = surface field (SST, sea-ice) update file for use with real-data simulations \newline
                                         9 = lateral boundary conditions update file for use with real-data simulations \newline
                                         13 = CAM-MPAS 3-d grid with specified topography and zeta levels"
-                     possible_values="1 -- 9"/>
+                     possible_values="1 -- 9, or 13"/>
 
                 <nml_option name="config_calendar_type" type="character" default_value="gregorian" in_defaults="false"
                      units="-"


### PR DESCRIPTION
This PR adds initialization case 13 (CAM-MPAS 3-d grid with specified topography and zeta levels) to the `possible_values` attribute for the `config_init_case` namelist option in the `init_atmosphere` core `Registry.xml` file.