### PR TITLE
Fix bug in vertical interp of humidity for LBCs when levels are given top-to-bottom

### DIFF
--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -5459,7 +5459,6 @@ call mpas_log_write('Done with soil consistency check')
             target_z = 0.5 * (zgrid(k,iCell) + zgrid(k+1,iCell))
             relhum(k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
                                        sorted_arr(:,1:nfglevels_actual-1), order=1, extrap=0)
-            if (target_z < z_fg(1,iCell) .and. k < nVertLevels) relhum(k,iCell) = relhum(k+1,iCell)
          end do
 
 
@@ -5477,7 +5476,6 @@ call mpas_log_write('Done with soil consistency check')
             target_z = 0.5 * (zgrid(k,iCell) + zgrid(k+1,iCell))
             spechum(k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
                                         sorted_arr(:,1:nfglevels_actual-1), order=1, extrap=0)
-            if (target_z < z_fg(1,iCell) .and. k < nVertLevels) spechum(k,iCell) = spechum(k+1,iCell)
          end do
 
 


### PR DESCRIPTION
This PR fixes a bug in the vertical interpolation of humidity for LBCs when first-guess levels are given in top-to-bottom order.

Note: The changes in this PR mirror those in #936, but this PR concerns to the code for producing LBCs rather than the code for producing ICs.

The code in the `init_atm_case_lbc` routine for vertically interpolating relative humidity and specific humidity for LBCs assumed that first-guess levels would be given in bottom-to-top order when attempting to vertically extrapolate to model levels below the lowest first-guess level. The relevant code for relative humidity read as follows -- the code for specific humidity is similar.
```
  if (target_z < z_fg(1,iCell) .and. k < nVertLevels) relhum(k,iCell) = relhum(k+1,iCell)
```
If first-guess levels are not given in bottom-to-top order, then `z_fg(1,iCell)` does not necessarily contain the height of the surface in the first-guess data, resulting in a copy of vertically interpolated relative humidity level `k+1` to level `k`.

The fix adopted in this PR is to simply delete the logic to explicitly copy/extrapolate downward, since both relative humidity and specific humidity are vertically interpolated with `extrap=0`, which specifies constant-value extrapolation. In this case, the lowest *first-guess* level -- rather than the lowest *interpolated* level -- is copied downward.