### PR TITLE
Update MMM-physics tag in Externals.cfg to fix .F90 re-compilation issue

### DIFF
--- a/src/core_atmosphere/Externals.cfg
+++ b/src/core_atmosphere/Externals.cfg
@@ -2,7 +2,7 @@
 local_path = ./physics_mmm
 protocol = git
 repo_url = https://github.com/NCAR/MMM-physics.git
-tag = 20240626-MPASv8.2
+tag = 20250616-MPASv8.3
 required = True
 
 [GSL_UGWP]


### PR DESCRIPTION
This PR updates the tag to `20250616-MPASv8.3` for the `MMM-physics` external in the `src/core_atmosphere/Externals.cfg` file to address an issue with `.F90` files not being re-compiled to `.o` files if a `.F90` file was modified. With the updated tag, compiling the atmosphere core, then making changes to any of the `.F90` files in `src/core_atmosphere/physics/physics_mmm/`, then running `make` again (without first cleaning) leads to the modified `.F90` files correctly being re-compiled.