### PR TITLE
Fix the q2 diagnostics in NoahMP

### DIFF
--- a/src/core_atmosphere/physics/physics_noahmp/drivers/mpas/EnergyVarOutTransferMod.F90
+++ b/src/core_atmosphere/physics/physics_noahmp/drivers/mpas/EnergyVarOutTransferMod.F90
@@ -136,7 +136,7 @@ contains
     NoahmpIO%CHB2XY  (I) = noahmp%energy%state%ExchCoeffSh2mBare
     NoahmpIO%Q2MVXY  (I) = noahmp%energy%state%SpecHumidity2mVeg /(1.0-noahmp%energy%state%SpecHumidity2mVeg)  ! spec humidity to mixing ratio
     NoahmpIO%Q2MBXY  (I) = noahmp%energy%state%SpecHumidity2mBare/(1.0-noahmp%energy%state%SpecHumidity2mBare)
-    NoahmpIO%Q2MXY   (I) = noahmp%energy%state%SpecHumidity2m/(1.0-noahmp%energy%state%SpecHumidity2m)
+    NoahmpIO%Q2MXY   (I) = NoahmpIO%Q2MBXY(I) * ( 1 - NoahmpIO%FVEGXY(I) ) + NoahmpIO%Q2MVXY(I) * NoahmpIO%FVEGXY(I)
     NoahmpIO%IRRSPLH (I) = NoahmpIO%IRRSPLH(I) + &
                              (noahmp%energy%flux%HeatLatentIrriEvap * noahmp%config%domain%MainTimeStep)
     NoahmpIO%TSLB    (I,1:NumSoilLayer)       = noahmp%energy%state%TemperatureSoilSnow(1:NumSoilLayer)


### PR DESCRIPTION
This PR is to fix the high q2 issue in urban grids in NoahMP, posted here in this thread:
https://forum.mmm.ucar.edu/threads/high-urban-moisture-with-noah-mp-in-mpas-atmosphere-8-2-3.22160/#post-53574

Essentially, the fix is to correct the q2 diagnostics in NoahMP in hotfix-v8.3.1:
in the Noah-MP source file: EnergyVarOutTransferMod.F90
Line 139: [MPAS-Model/src/core_atmosphere/physics/physics_noahmp/drivers/mpas/EnergyVarOutTransferMod.F90 at ac3866c1e5b05f6d4f5bd41aeab7d3882bace514 · MPAS-Dev/MPAS-Model](https://github.com/MPAS-Dev/MPAS-Model/blob/ac3866c1e5b05f6d4f5bd41aeab7d3882bace514/src/core_atmosphere/physics/physics_noahmp/drivers/mpas/EnergyVarOutTransferMod.F90#L139)
change it to the following:
NoahmpIO%Q2MXY(I) = NoahmpIO%Q2MBXY(I) * ( 1 - NoahmpIO%FVEGXY(I) ) + NoahmpIO%Q2MVXY(I) * NoahmpIO%FVEGXY(I)

I have done a short test with the hotfix-8.3.1 version and with this q2_diag fix, and show this fix will help reduce the high q2 over urban points. please see the figure below:
![image](https://github.com/user-attachments/assets/cb694338-5447-403a-9bdb-f54aab33469c)

@cenlinhe @barlage 

