### PR TITLE
Online distributed graph partitioning using PT-Scotch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -760,12 +760,13 @@ endif
 endif
 
 ifneq "$(SCOTCH)" ""
-	override CPPFLAGS += "-DMPAS_SCOTCH"
-	FCINCLUDES += -I$(SCOTCH)/src/include
-	LIBS +=  -L$(SCOTCH)/lib -lscotch -lscotcherr
-        SCOTCH_MESSAGE = "MPAS has been linked with the Scotch Graph Paritioning library."
-else
-        SCOTCH_MESSAGE = "MPAS was NOT linked with the Scotch Graph Paritioning library."
+	SCOTCH_FCINCLUDES += -I$(SCOTCH)/src/include
+	SCOTCH_LIBS += -L$(SCOTCH)/lib -lscotch -lscotcherr
+	SCOTCH_FFLAGS = -DMPAS_SCOTCH
+
+	FCINCLUDES += $(SCOTCH_FCINCLUDES)
+	LIBS += $(SCOTCH_LIBS)
+	override CPPFLAGS += $(SCOTCH_FFLAGS)
 endif
 
 ifneq "$(PNETCDF)" ""
@@ -1423,6 +1424,33 @@ musica_fortran_test:
 	$(eval MUSICA_FORTRAN_VERSION := $(shell pkg-config --modversion musica-fortran))
 	$(if $(findstring 1,$(MUSICA_FORTRAN_TEST)), $(info Built a simple test program with MUSICA-Fortran version $(MUSICA_FORTRAN_VERSION)), )
 
+scotch_fortran_test:
+	@#
+	@# Create a Fortran test program that will link against the SCOTCH library
+	@#
+	$(info Checking for a working MUSICA-Fortran library...)
+	$(eval SCOTCH_FORTRAN_TEST := $(shell $\
+		printf "program test_scotch_fortran\n$\
+		&   include \"scotchf.h\"\n$\
+    	&   doubleprecision :: scotchgraph (scotch_graphdim)\n$\
+		&   integer :: ierr\n$\
+		&   ierr = 0\n$\
+		&   call scotchfgraphinit(scotchgraph (1), ierr)\n$\
+		&   call scotchfgraphexit(scotchgraph(1))\n$\
+		end program test_scotch_fortran\n" | sed 's/&/ /' > test_scotch_fortran.f90; $\
+		$\
+		$(FC) $(SCOTCH_FCINCLUDES) $(SCOTCH_FFLAGS) test_scotch_fortran.f90 -o test_scotch_fortran.x $(SCOTCH_LIBS) > /dev/null 2>&1; $\
+		scotch_fortran_status=$$?; $\
+		rm -f test_scotch_fortran.f90 test_scotch_fortran.x; $\
+		if [ $$scotch_fortran_status -eq 0 ]; then $\
+			printf "1"; $\
+		else $\
+			printf "0"; $\
+		fi $\
+	))
+	$(if $(findstring 0,$(SCOTCH_FORTRAN_TEST)), $(error Could not build a simple test program with Scotch))
+	$(if $(findstring 1,$(SCOTCH_FORTRAN_TEST)), $(info Built a simple test program with Scotch ))
+
 pnetcdf_test:
 	@#
 	@# Create test C programs that look for PNetCDF header file and some symbols in it
@@ -1477,6 +1505,13 @@ MAIN_DEPS += musica_fortran_test
 MUSICA_MESSAGE = "MPAS was linked with the MUSICA-Fortran library version $(MUSICA_FORTRAN_VERSION)."
 else
 MUSICA_MESSAGE = "MPAS was not linked with the MUSICA-Fortran library."
+endif
+
+ifneq "$(SCOTCH_FFLAGS)" ""
+MAIN_DEPS += scotch_fortran_test
+SCOTCH_MESSAGE = "MPAS has been linked with the Scotch graph partitioning library."
+else
+SCOTCH_MESSAGE = "MPAS was NOT linked with the Scotch graph partitioning library."
 endif
 
 mpas_main: $(MAIN_DEPS)

--- a/Makefile
+++ b/Makefile
@@ -760,8 +760,8 @@ endif
 endif
 
 ifneq "$(SCOTCH)" ""
-	SCOTCH_FCINCLUDES += -I$(SCOTCH)/src/include
-	SCOTCH_LIBS += -L$(SCOTCH)/lib -lscotch -lscotcherr
+	SCOTCH_FCINCLUDES += -I$(SCOTCH)/include
+	SCOTCH_LIBS += -L$(SCOTCH)/lib64 -lptscotch -lscotch  -lptscotcherr -lm
 	SCOTCH_FFLAGS = -DMPAS_SCOTCH
 
 	FCINCLUDES += $(SCOTCH_FCINCLUDES)
@@ -1431,7 +1431,7 @@ scotch_fortran_test:
 	$(info Checking for a working MUSICA-Fortran library...)
 	$(eval SCOTCH_FORTRAN_TEST := $(shell $\
 		printf "program test_scotch_fortran\n$\
-		&   include \"scotchf.h\"\n$\
+		&   include \"ptscotchf.h\"\n$\
     	&   doubleprecision :: scotchgraph (scotch_graphdim)\n$\
 		&   integer :: ierr\n$\
 		&   ierr = 0\n$\

--- a/Makefile
+++ b/Makefile
@@ -759,11 +759,14 @@ endif
 	LIBS += $(NCLIB)
 endif
 
-export SCOTCH_ROOT=/glade/derecho/scratch/agopal/scotch/build
-
-FCINCLUDES += -I$(SCOTCH_ROOT)/src/include
-
-LIBS +=  -L$(SCOTCH_ROOT)/lib -lscotch -lscotcherr
+ifneq "$(SCOTCH)" ""
+	override CPPFLAGS += "-DMPAS_SCOTCH"
+	FCINCLUDES += -I$(SCOTCH)/src/include
+	LIBS +=  -L$(SCOTCH)/lib -lscotch -lscotcherr
+        SCOTCH_MESSAGE = "MPAS has been linked with the Scotch Graph Paritioning library."
+else
+        SCOTCH_MESSAGE = "MPAS was NOT linked with the Scotch Graph Paritioning library."
+endif
 
 ifneq "$(PNETCDF)" ""
 ifneq ($(wildcard $(PNETCDF)/lib/libpnetcdf.*), )
@@ -1513,6 +1516,7 @@ mpas_main: $(MAIN_DEPS)
 	@echo $(OPENMP_OFFLOAD_MESSAGE)
 	@echo $(OPENACC_MESSAGE)
 	@echo $(MUSICA_MESSAGE)
+	@echo $(SCOTCH_MESSAGE)
 	@echo $(SHAREDLIB_MESSAGE)
 ifeq "$(AUTOCLEAN)" "true"
 	@echo $(AUTOCLEAN_MESSAGE)

--- a/Makefile
+++ b/Makefile
@@ -759,6 +759,11 @@ endif
 	LIBS += $(NCLIB)
 endif
 
+export SCOTCH_ROOT=/glade/derecho/scratch/agopal/scotch/build
+
+FCINCLUDES += -I$(SCOTCH_ROOT)/src/include
+
+LIBS +=  -L$(SCOTCH_ROOT)/lib -lscotch -lscotcherr
 
 ifneq "$(PNETCDF)" ""
 ifneq ($(wildcard $(PNETCDF)/lib/libpnetcdf.*), )

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -319,7 +319,7 @@
         </nml_record>
 
         <nml_record name="decomposition" in_defaults="true">
-                <nml_option name="config_block_decomp_file_prefix" type="character" default_value="x1.40962.graph.info.part."
+                <nml_option name="config_block_decomp_file_prefix" type="character" default_value=""
                      units="-"
                      description="Prefix of graph decomposition file, to be suffixed with the MPI task count"
                      possible_values="Any valid filename"/>

--- a/src/framework/mpas_block_decomp.F
+++ b/src/framework/mpas_block_decomp.F
@@ -75,7 +75,7 @@ module mpas_block_decomp
       integer, dimension(:,:), allocatable :: sorted_local_cell_list
 
       integer, dimension(:), allocatable :: global_block_id_arr, owning_proc_arr
-      integer :: i, global_block_id, local_block_id, owning_proc, iunit, istatus, vind, j, k
+      integer :: i, global_block_id, local_block_id, owning_proc, iunit, istatus, j, k
       integer :: blocks_per_proc, err, ierr
       integer, dimension(:), pointer :: local_nvertices
       character (len=StrKIND) :: filename, msg
@@ -111,28 +111,36 @@ module mpas_block_decomp
         if (dminfo % my_proc_id == IO_NODE) then
          if ( trim(blockFilePrefix) == '' ) then
                call mpas_log_write('blockFilePrefix is not set: Using LibScotch for graph partitioning')
-               do vind=1,partial_global_graph_info % nVerticesTotal
-                  nTotalEdgesGraph = nTotalEdgesGraph + nEdgesOnCellFull% array(vind)
-                  ! do j=1,nEdgesOnCellFull% array(vind)
-                  !    call mpas_log_write('vind=$i j=$i adj= $i', intArgs=(/vind,j,cellsOnCellFull%array(j,vind)/) )
+               do i=1,partial_global_graph_info % nVerticesTotal
+                  do j=1,nEdgesOnCellFull% array(i)
+                     
+                     if (cellsOnCellFull%array(j,i) == 0) cycle
+                     nTotalEdgesGraph = nTotalEdgesGraph + 1
+                     !nTotalEdgesGraph = nTotalEdgesGraph + nEdgesOnCellFull% array(i)
+                  ! do j=1,nEdgesOnCellFull% array(i)
+                  !    call mpas_log_write('i=$i j=$i adj= $i', intArgs=(/i,j,cellsOnCellFull%array(j,i)/) )
                   ! end do
+                  end do
                end do 
-  
+               call mpas_log_write('nTotalEdgesGraph is $i', intArgs=(/nTotalEdgesGraph/))
                allocate(edgetab(nTotalEdgesGraph))
                allocate(verttab(partial_global_graph_info % nVerticesTotal + 1))
                !allocate(parttab(partial_global_graph_info % nVerticesTotal))
   
-               !do vind=1,partial_global_graph_info % nVerticesTotal
-                  !call mpas_log_write('proc=$i  vind= $i part= $i', intArgs=(/dminfo % my_proc_id, vind,parttab(vind)/))
-                  !call mpas_log_write('vind=$i j=$i adj= $i', intArgs=(/vind,j,cellsOnCellFull%array(j,vind)/) )
+               !do i=1,partial_global_graph_info % nVerticesTotal
+                  !call mpas_log_write('proc=$i  i= $i part= $i', intArgs=(/dminfo % my_proc_id, i,parttab(i)/))
+                  !call mpas_log_write('i=$i j=$i adj= $i', intArgs=(/i,j,cellsOnCellFull%array(j,i)/) )
                !end do 
   
                k = 1
-               do vind=1,partial_global_graph_info % nVerticesTotal
-                  verttab(vind) = k 
-                  !call mpas_log_write('vind=$i verttab= $i', intArgs=(/vind,verttab(vind)/) )
-                  do j=1,nEdgesOnCellFull% array(vind)
-                     edgetab(k) = cellsOnCellFull%array(j,vind)
+               do i=1,partial_global_graph_info % nVerticesTotal
+                  verttab(i) = k 
+                  !call mpas_log_write('i=$i verttab= $i', intArgs=(/i,verttab(i)/) )
+                  do j=1,nEdgesOnCellFull% array(i)
+                     
+                     if (cellsOnCellFull%array(j,i) == 0) cycle
+
+                     edgetab(k) = cellsOnCellFull%array(j,i)
                      !call mpas_log_write('k=$i edgetab= $i', intArgs=(/k,edgetab(k)/) )
                      k = k + 1
                   end do
@@ -154,6 +162,12 @@ module mpas_block_decomp
                IF (IERR .NE. 0) THEN
                      call mpas_log_write('Cannot build Scotch Graph', MPAS_LOG_CRIT)
                ENDIF
+
+               ! CALL SCOTCHFGRAPHSAVE (SCOTCHGRAPH (1), 1, IERR)
+               ! IF (IERR .NE. 0) THEN
+               !    PRINT *, 'ERROR : MAIN : Invalid graph output'
+               !    STOP
+               ! ENDIF
   
                CALL SCOTCHFGRAPHCHECK (SCOTCHGRAPH (1), IERR)
                IF (IERR .NE. 0) THEN

--- a/src/framework/mpas_block_decomp.F
+++ b/src/framework/mpas_block_decomp.F
@@ -25,7 +25,10 @@ module mpas_block_decomp
    use mpas_derived_types
    use mpas_io_units
    use mpas_log
+   
+   #ifdef MPAS_SCOTCH
    include "scotchf.h"
+   #endif
 
    type graph
       integer :: nVerticesTotal
@@ -75,7 +78,7 @@ module mpas_block_decomp
       integer, dimension(:,:), allocatable :: sorted_local_cell_list
 
       integer, dimension(:), allocatable :: global_block_id_arr, owning_proc_arr
-      integer :: i, global_block_id, local_block_id, owning_proc, iunit, istatus, j, k
+      integer :: i, global_block_id, local_block_id, owning_proc, iunit, ounit, istatus, ostatus, j, k
       integer :: blocks_per_proc, err, ierr
       integer, dimension(:), pointer :: local_nvertices
       character (len=StrKIND) :: filename, msg
@@ -84,9 +87,11 @@ module mpas_block_decomp
       integer :: nTotalEdgesGraph = 0
       integer, dimension(:), allocatable :: edgetab, verttab, parttab
 
-      doubleprecision :: stradat (SCOTCH_STRATDIM)
-      doubleprecision :: SCOTCHGRAPH (SCOTCH_GRAPHDIM)
-      integer :: n_size      
+      logical :: useScotch
+#ifdef MPAS_SCOTCH
+      doubleprecision :: stradat (scotch_stratdim)
+      doubleprecision :: scotchgraph (scotch_graphdim)
+#endif
 
       no_blocks = .false.
 
@@ -109,8 +114,50 @@ module mpas_block_decomp
         allocate(owning_proc_arr(partial_global_graph_info % nVerticesTotal))
 
         if (dminfo % my_proc_id == IO_NODE) then
+         useScotch = .false.
          if ( trim(blockFilePrefix) == '' ) then
-               call mpas_log_write('blockFilePrefix is not set: Using LibScotch for graph partitioning')
+            call mpas_log_write('Namelist option config_block_decomp_file_prefix is set to \'\' ', MPAS_LOG_ERR)
+#ifdef MPAS_SCOTCH
+            useScotch = .true.
+#else
+            call mpas_log_write('Either build MPAS with the Scotch library or provide a valid file prefix for config_block_decomp_file_prefix', MPAS_LOG_CRIT)
+#endif
+         else
+            if (dminfo % total_blocks < 10) then
+               write(filename,'(a,i1)') trim(blockFilePrefix), dminfo % total_blocks
+            else if (dminfo % total_blocks < 100) then
+               write(filename,'(a,i2)') trim(blockFilePrefix), dminfo % total_blocks
+            else if (dminfo % total_blocks < 1000) then
+               write(filename,'(a,i3)') trim(blockFilePrefix), dminfo % total_blocks
+            else if (dminfo % total_blocks < 10000) then
+               write(filename,'(a,i4)') trim(blockFilePrefix), dminfo % total_blocks
+            else if (dminfo % total_blocks < 100000) then
+               write(filename,'(a,i5)') trim(blockFilePrefix), dminfo % total_blocks
+            else if (dminfo % total_blocks < 1000000) then
+               write(filename,'(a,i6)') trim(blockFilePrefix), dminfo % total_blocks
+            else if (dminfo % total_blocks < 10000000) then
+               write(filename,'(a,i7)') trim(blockFilePrefix), dminfo % total_blocks
+            else if (dminfo % total_blocks < 100000000) then
+               write(filename,'(a,i8)') trim(blockFilePrefix), dminfo % total_blocks
+            end if
+
+            call mpas_new_unit(iunit)
+            open(unit=iunit, file=trim(filename), form='formatted', status='old', iostat=istatus)
+            
+            if (istatus /= 0) then
+               call mpas_log_write('Could not open block decomposition file for $i blocks.', MPAS_LOG_WARN, intArgs=(/dminfo % total_blocks/) )
+               call mpas_log_write('Filename: '//trim(filename),MPAS_LOG_WARN)
+#ifdef MPAS_SCOTCH
+               useScotch = .true.
+#else             
+               call mpas_log_write('Either build MPAS with Scotch library or provide a valid file prefix for config_block_decomp_file_prefix', MPAS_LOG_CRIT)
+#endif
+            end if
+         end if
+
+         if (useScotch) then
+#ifdef MPAS_SCOTCH
+               call mpas_log_write('Using LibScotch for graph partitioning')
                do i=1,partial_global_graph_info % nVerticesTotal
                   do j=1,nEdgesOnCellFull% array(i)
                      
@@ -149,33 +196,28 @@ module mpas_block_decomp
       
                !call mpas_log_write('nvertices =$i  nTotalEdgesGraph= $i', intArgs=(/partial_global_graph_info % nVerticesTotal, nTotalEdgesGraph/))
   
-               CALL scotchfstratinit (stradat (1), IERR)
-               CALL SCOTCHFGRAPHINIT (SCOTCHGRAPH (1), IERR)
-               IF (IERR .NE. 0) THEN
-               call mpas_log_write('Cannot initialize Scotch Graph', MPAS_LOG_CRIT)
-               ENDIF
+               call scotchfstratinit (stradat (1), ierr)
+               call scotchfgraphinit (scotchgraph (1), ierr)
+
+               if (ierr .ne. 0) then
+                  call mpas_log_write('Cannot initialize Scotch Graph', MPAS_LOG_CRIT)
+               endif
   
-               CALL SCOTCHFGRAPHBUILD (SCOTCHGRAPH (1), 1, partial_global_graph_info % nVerticesTotal, &
+               CALL scotchfgraphbuild (scotchgraph (1), 1, partial_global_graph_info % nVerticesTotal, &
                                        verttab (1), verttab (2), &
                                        verttab (1), verttab (1), &
-                                       nTotalEdgesGraph, edgetab (1), edgetab (1), IERR)
-               IF (IERR .NE. 0) THEN
-                     call mpas_log_write('Cannot build Scotch Graph', MPAS_LOG_CRIT)
-               ENDIF
+                                       nTotalEdgesGraph, edgetab (1), edgetab (1), ierr)
+               if (ierr .ne. 0) then
+                  call mpas_log_write('Cannot build Scotch Graph', MPAS_LOG_CRIT)
+               endif
 
-               ! CALL SCOTCHFGRAPHSAVE (SCOTCHGRAPH (1), 1, IERR)
-               ! IF (IERR .NE. 0) THEN
-               !    PRINT *, 'ERROR : MAIN : Invalid graph output'
-               !    STOP
-               ! ENDIF
+               ! Only needed during development/debugging. 
+               !call scotchfgraphcheck (scotchgraph (1), ierr)
+               !if (ierr .ne. 0) then
+               !   call mpas_log_write('Cannot check Scotch Graph', MPAS_LOG_CRIT)
+               !endif
   
-               CALL SCOTCHFGRAPHCHECK (SCOTCHGRAPH (1), IERR)
-               IF (IERR .NE. 0) THEN
-               call mpas_log_write('Cannot check Scotch Graph', MPAS_LOG_CRIT)
-               ENDIF
-  
-               !CALL scotchfgraphpart( SCOTCHGRAPH (1), dminfo % total_blocks, stradat (1) ,parttab(1),  IERR)
-               CALL scotchfgraphpart( SCOTCHGRAPH (1), dminfo % total_blocks, stradat (1) ,global_block_id_arr(1),  IERR)
+               call scotchfgraphpart( scotchgraph (1), dminfo % total_blocks, stradat (1) ,global_block_id_arr(1),  IERR)
   
                call scotchfgraphexit (SCOTCHGRAPH (1))
                call scotchfstratexit (stradat (1))
@@ -188,34 +230,20 @@ module mpas_block_decomp
                   !call mpas_log_write('vert: $i, global_block_id: $i, owning_proc: $i ', intArgs=(/i,global_block_id_arr(i),owning_proc/) )
                   local_nvertices(owning_proc+1) = local_nvertices(owning_proc+1) + 1
                end do
-  
-           else
 
-               if (dminfo % total_blocks < 10) then
-                  write(filename,'(a,i1)') trim(blockFilePrefix), dminfo % total_blocks
-               else if (dminfo % total_blocks < 100) then
-                  write(filename,'(a,i2)') trim(blockFilePrefix), dminfo % total_blocks
-               else if (dminfo % total_blocks < 1000) then
-                  write(filename,'(a,i3)') trim(blockFilePrefix), dminfo % total_blocks
-               else if (dminfo % total_blocks < 10000) then
-                  write(filename,'(a,i4)') trim(blockFilePrefix), dminfo % total_blocks
-               else if (dminfo % total_blocks < 100000) then
-                  write(filename,'(a,i5)') trim(blockFilePrefix), dminfo % total_blocks
-               else if (dminfo % total_blocks < 1000000) then
-                  write(filename,'(a,i6)') trim(blockFilePrefix), dminfo % total_blocks
-               else if (dminfo % total_blocks < 10000000) then
-                  write(filename,'(a,i7)') trim(blockFilePrefix), dminfo % total_blocks
-               else if (dminfo % total_blocks < 100000000) then
-                  write(filename,'(a,i8)') trim(blockFilePrefix), dminfo % total_blocks
-               end if
-
-               call mpas_new_unit(iunit)
-               open(unit=iunit, file=trim(filename), form='formatted', status='old', iostat=istatus)
-               
                if (istatus /= 0) then
-                  call mpas_log_write('Could not open block decomposition file for $i blocks.', MPAS_LOG_ERR, intArgs=(/dminfo % total_blocks/) )
-                  call mpas_log_write('Filename: '//trim(filename), MPAS_LOG_CRIT)
+                  call mpas_log_write('Writing out Scotch Graph paritioning data to '//trim(filename))
+                  call mpas_new_unit(ounit)
+                  open(unit=ounit, file=trim(filename), form='formatted', status='new', action="write", iostat=ostatus)
+                  do i=1,partial_global_graph_info % nVerticesTotal
+                     write(unit=ounit, fmt='(i0)', iostat=err) global_block_id_arr(i)
+                     !write(unit=ounit, fmt='(*(i0,1x))', iostat=err) global_block_id_arr(i)
+                  end do
+                  close(unit=ounit)
+                  call mpas_release_unit(ounit)
                end if
+  #endif
+           else
 
                call mpas_log_write('Using block decomposition file: '//trim(filename))
 

--- a/src/framework/mpas_block_decomp.F
+++ b/src/framework/mpas_block_decomp.F
@@ -25,6 +25,7 @@ module mpas_block_decomp
    use mpas_derived_types
    use mpas_io_units
    use mpas_log
+   include "scotchf.h"
 
    type graph
       integer :: nVerticesTotal
@@ -49,7 +50,7 @@ module mpas_block_decomp
 !
 !-----------------------------------------------------------------------
    subroutine mpas_block_decomp_cells_for_proc(dminfo, partial_global_graph_info, local_cell_list, block_id, block_start, &
-                                               block_count, numBlocks, explicitProcDecomp, blockFilePrefix, procFilePrefix)!{{{
+                                               block_count, cellsOnCellFull, nEdgesOnCellFull, numBlocks, explicitProcDecomp, blockFilePrefix, procFilePrefix)!{{{
 
       implicit none
 
@@ -59,6 +60,8 @@ module mpas_block_decomp
       integer, dimension(:), pointer :: block_id !< Output: list of global block id's this processor owns
       integer, dimension(:), pointer :: block_start !< Output: offset in local_cell_list for this blocks list of cells
       integer, dimension(:), pointer :: block_count !< Output: number of cells in blocks
+      type (field2dInteger), intent(in) :: cellsOnCellFull
+      type (field1dInteger), intent(in) :: nEdgesOnCellFull
 
       integer, intent(in) :: numBlocks !< Input: Number of blocks (from config_num_blocks)
       logical, intent(in) :: explicitProcDecomp !< Input: Logical flag controlling if blocks are explicitly assigned to processors
@@ -71,12 +74,19 @@ module mpas_block_decomp
       integer, dimension(:), allocatable :: local_block_list
       integer, dimension(:,:), allocatable :: sorted_local_cell_list
 
-      integer :: i, global_block_id, local_block_id, owning_proc, iunit, istatus
-      integer :: blocks_per_proc, err
+      integer, dimension(:), allocatable :: global_block_id_arr, owning_proc_arr
+      integer :: i, global_block_id, local_block_id, owning_proc, iunit, istatus, vind, j, k
+      integer :: blocks_per_proc, err, ierr
       integer, dimension(:), pointer :: local_nvertices
-      character (len=StrKIND) :: filename
+      character (len=StrKIND) :: filename, msg
 
       logical :: no_blocks
+      integer :: nTotalEdgesGraph = 0
+      integer, dimension(:), allocatable :: edgetab, verttab, parttab
+
+      doubleprecision :: stradat (SCOTCH_STRATDIM)
+      doubleprecision :: SCOTCHGRAPH (SCOTCH_GRAPHDIM)
+      integer :: n_size      
 
       no_blocks = .false.
 
@@ -95,71 +105,158 @@ module mpas_block_decomp
         allocate(local_nvertices(dminfo % nprocs))
         allocate(global_start(dminfo % nprocs))
         allocate(global_list(partial_global_graph_info % nVerticesTotal))
+        allocate(global_block_id_arr(partial_global_graph_info % nVerticesTotal))
+        allocate(owning_proc_arr(partial_global_graph_info % nVerticesTotal))
 
         if (dminfo % my_proc_id == IO_NODE) then
+         if ( trim(blockFilePrefix) == '' ) then
+               call mpas_log_write('blockFilePrefix is not set: Using LibScotch for graph partitioning')
+               do vind=1,partial_global_graph_info % nVerticesTotal
+                  nTotalEdgesGraph = nTotalEdgesGraph + nEdgesOnCellFull% array(vind)
+                  ! do j=1,nEdgesOnCellFull% array(vind)
+                  !    call mpas_log_write('vind=$i j=$i adj= $i', intArgs=(/vind,j,cellsOnCellFull%array(j,vind)/) )
+                  ! end do
+               end do 
+  
+               allocate(edgetab(nTotalEdgesGraph))
+               allocate(verttab(partial_global_graph_info % nVerticesTotal + 1))
+               !allocate(parttab(partial_global_graph_info % nVerticesTotal))
+  
+               !do vind=1,partial_global_graph_info % nVerticesTotal
+                  !call mpas_log_write('proc=$i  vind= $i part= $i', intArgs=(/dminfo % my_proc_id, vind,parttab(vind)/))
+                  !call mpas_log_write('vind=$i j=$i adj= $i', intArgs=(/vind,j,cellsOnCellFull%array(j,vind)/) )
+               !end do 
+  
+               k = 1
+               do vind=1,partial_global_graph_info % nVerticesTotal
+                  verttab(vind) = k 
+                  !call mpas_log_write('vind=$i verttab= $i', intArgs=(/vind,verttab(vind)/) )
+                  do j=1,nEdgesOnCellFull% array(vind)
+                     edgetab(k) = cellsOnCellFull%array(j,vind)
+                     !call mpas_log_write('k=$i edgetab= $i', intArgs=(/k,edgetab(k)/) )
+                     k = k + 1
+                  end do
+               end do 
+               verttab(partial_global_graph_info % nVerticesTotal+1) = nTotalEdgesGraph + 1
+      
+               !call mpas_log_write('nvertices =$i  nTotalEdgesGraph= $i', intArgs=(/partial_global_graph_info % nVerticesTotal, nTotalEdgesGraph/))
+  
+               CALL scotchfstratinit (stradat (1), IERR)
+               CALL SCOTCHFGRAPHINIT (SCOTCHGRAPH (1), IERR)
+               IF (IERR .NE. 0) THEN
+               call mpas_log_write('Cannot initialize Scotch Graph', MPAS_LOG_CRIT)
+               ENDIF
+  
+               CALL SCOTCHFGRAPHBUILD (SCOTCHGRAPH (1), 1, partial_global_graph_info % nVerticesTotal, &
+                                       verttab (1), verttab (2), &
+                                       verttab (1), verttab (1), &
+                                       nTotalEdgesGraph, edgetab (1), edgetab (1), IERR)
+               IF (IERR .NE. 0) THEN
+                     call mpas_log_write('Cannot build Scotch Graph', MPAS_LOG_CRIT)
+               ENDIF
+  
+               CALL SCOTCHFGRAPHCHECK (SCOTCHGRAPH (1), IERR)
+               IF (IERR .NE. 0) THEN
+               call mpas_log_write('Cannot check Scotch Graph', MPAS_LOG_CRIT)
+               ENDIF
+  
+               !CALL scotchfgraphpart( SCOTCHGRAPH (1), dminfo % total_blocks, stradat (1) ,parttab(1),  IERR)
+               CALL scotchfgraphpart( SCOTCHGRAPH (1), dminfo % total_blocks, stradat (1) ,global_block_id_arr(1),  IERR)
+  
+               call scotchfgraphexit (SCOTCHGRAPH (1))
+               call scotchfstratexit (stradat (1))
 
-           if (dminfo % total_blocks < 10) then
-              write(filename,'(a,i1)') trim(blockFilePrefix), dminfo % total_blocks
-           else if (dminfo % total_blocks < 100) then
-              write(filename,'(a,i2)') trim(blockFilePrefix), dminfo % total_blocks
-           else if (dminfo % total_blocks < 1000) then
-              write(filename,'(a,i3)') trim(blockFilePrefix), dminfo % total_blocks
-           else if (dminfo % total_blocks < 10000) then
-              write(filename,'(a,i4)') trim(blockFilePrefix), dminfo % total_blocks
-           else if (dminfo % total_blocks < 100000) then
-              write(filename,'(a,i5)') trim(blockFilePrefix), dminfo % total_blocks
-           else if (dminfo % total_blocks < 1000000) then
-              write(filename,'(a,i6)') trim(blockFilePrefix), dminfo % total_blocks
-           else if (dminfo % total_blocks < 10000000) then
-              write(filename,'(a,i7)') trim(blockFilePrefix), dminfo % total_blocks
-           else if (dminfo % total_blocks < 100000000) then
-              write(filename,'(a,i8)') trim(blockFilePrefix), dminfo % total_blocks
-           end if
+               local_nvertices(:) = 0
+               do i=1,partial_global_graph_info % nVerticesTotal
+                  !global_block_id_arr(i) = parttab(i)
+                  call mpas_get_owning_proc(dminfo, global_block_id_arr(i), owning_proc)
+                  owning_proc_arr(i) = owning_proc
+                  !call mpas_log_write('vert: $i, global_block_id: $i, owning_proc: $i ', intArgs=(/i,global_block_id_arr(i),owning_proc/) )
+                  local_nvertices(owning_proc+1) = local_nvertices(owning_proc+1) + 1
+               end do
+  
+           else
 
-           call mpas_new_unit(iunit)
-           open(unit=iunit, file=trim(filename), form='formatted', status='old', iostat=istatus)
+               if (dminfo % total_blocks < 10) then
+                  write(filename,'(a,i1)') trim(blockFilePrefix), dminfo % total_blocks
+               else if (dminfo % total_blocks < 100) then
+                  write(filename,'(a,i2)') trim(blockFilePrefix), dminfo % total_blocks
+               else if (dminfo % total_blocks < 1000) then
+                  write(filename,'(a,i3)') trim(blockFilePrefix), dminfo % total_blocks
+               else if (dminfo % total_blocks < 10000) then
+                  write(filename,'(a,i4)') trim(blockFilePrefix), dminfo % total_blocks
+               else if (dminfo % total_blocks < 100000) then
+                  write(filename,'(a,i5)') trim(blockFilePrefix), dminfo % total_blocks
+               else if (dminfo % total_blocks < 1000000) then
+                  write(filename,'(a,i6)') trim(blockFilePrefix), dminfo % total_blocks
+               else if (dminfo % total_blocks < 10000000) then
+                  write(filename,'(a,i7)') trim(blockFilePrefix), dminfo % total_blocks
+               else if (dminfo % total_blocks < 100000000) then
+                  write(filename,'(a,i8)') trim(blockFilePrefix), dminfo % total_blocks
+               end if
 
-           if (istatus /= 0) then
-              call mpas_log_write('Could not open block decomposition file for $i blocks.', MPAS_LOG_ERR, intArgs=(/dminfo % total_blocks/) )
-              call mpas_log_write('Filename: '//trim(filename), MPAS_LOG_CRIT)
-           end if
+               call mpas_new_unit(iunit)
+               open(unit=iunit, file=trim(filename), form='formatted', status='old', iostat=istatus)
+               
+               if (istatus /= 0) then
+                  call mpas_log_write('Could not open block decomposition file for $i blocks.', MPAS_LOG_ERR, intArgs=(/dminfo % total_blocks/) )
+                  call mpas_log_write('Filename: '//trim(filename), MPAS_LOG_CRIT)
+               end if
 
-           local_nvertices(:) = 0
-           do i=1,partial_global_graph_info % nVerticesTotal
-              read(unit=iunit, fmt=*, iostat=err) global_block_id
+               call mpas_log_write('Using block decomposition file: '//trim(filename))
 
-              if ( err .ne. 0 ) then
-                 call mpas_log_write('Decomoposition file: ' // trim(filename) // ' contains less than $i cells', &
-                                      MPAS_LOG_CRIT, intArgs=(/partial_global_graph_info % nVerticesTotal/) )
-              end if
-              call mpas_get_owning_proc(dminfo, global_block_id, owning_proc)
-              local_nvertices(owning_proc+1) = local_nvertices(owning_proc+1) + 1
-           end do
+               call mpas_log_write('First read pass ')
+               local_nvertices(:) = 0
+               do i=1,partial_global_graph_info % nVerticesTotal
+                  read(unit=iunit, fmt=*, iostat=err) global_block_id
+                  global_block_id_arr(i) = global_block_id
 
-           read(unit=iunit, fmt=*, iostat=err)
+                  if ( err .ne. 0 ) then
+                     call mpas_log_write('Decomoposition file: ' // trim(filename) // ' contains less than $i cells', &
+                                          MPAS_LOG_CRIT, intArgs=(/partial_global_graph_info % nVerticesTotal/) )
+                  end if
+                  call mpas_get_owning_proc(dminfo, global_block_id, owning_proc)
+                  owning_proc_arr(i) = owning_proc
+                  !call mpas_log_write('vert: $i, global_block_id: $i, owning_proc: $i ', intArgs=(/i,global_block_id,owning_proc/) )
+                  local_nvertices(owning_proc+1) = local_nvertices(owning_proc+1) + 1
+                  !call mpas_log_write('owning_proc+1: $i local_nvertices= $i', intArgs=(/owning_proc+1, local_nvertices(owning_proc+1)/))
+               end do
 
-           if ( err == 0 ) then
-              call mpas_log_write('Decomposition file: ' // trim(filename) // ' contains more than $i cells', &
-                                   MPAS_LOG_CRIT, intArgs=(/partial_global_graph_info % nVerticesTotal/) )
+               read(unit=iunit, fmt=*, iostat=err)
+
+               if ( err == 0 ) then
+                  call mpas_log_write('Decomposition file: ' // trim(filename) // ' contains more than $i cells', &
+                                       MPAS_LOG_CRIT, intArgs=(/partial_global_graph_info % nVerticesTotal/) )
+               end if
+
+               close(unit=iunit)
+               call mpas_release_unit(iunit)
            end if
 
            global_start(1) = 1
            do i=2,dminfo % nprocs
               global_start(i) = global_start(i-1) + local_nvertices(i-1)
+              !call mpas_log_write('i: $i global_start= $i', intArgs=(/i, global_start(i)/))
            end do
 
-           rewind(unit=iunit)
+           !rewind(unit=iunit)
+           call mpas_log_write('Second read pass ')
 
            do i=1,partial_global_graph_info % nVerticesTotal
-              read(unit=iunit, fmt=*, iostat=err) global_block_id
-              call mpas_get_owning_proc(dminfo, global_block_id, owning_proc)
+              !read(unit=iunit, fmt=*, iostat=err) global_block_id
+              !call mpas_get_owning_proc(dminfo, global_block_id, owning_proc)
+              global_block_id = global_block_id_arr(i)
+              owning_proc = owning_proc_arr(i)
               global_list(global_start(owning_proc+1)) = i
+              !call mpas_log_write('owning_proc+1: $i global_start= $i global_list=$i', intArgs=(/owning_proc+1, global_start(owning_proc+1), global_list(global_start(owning_proc+1))/))
               global_start(owning_proc+1) = global_start(owning_proc+1) + 1
+              !call mpas_log_write('global_start(owning_proc+1): $i', intArgs=(/global_start(owning_proc+1)/))
            end do
 
            global_start(1) = 0
            do i=2,dminfo % nprocs
               global_start(i) = global_start(i-1) + local_nvertices(i-1)
+              !call mpas_log_write('i: $i global_start= $i', intArgs=(/i, global_start(i)/))
            end do
 
            call mpas_dmpar_bcast_ints(dminfo, dminfo % nprocs, local_nvertices)
@@ -173,28 +270,34 @@ module mpas_block_decomp
            global_start(1) = 1
            do i=2,dminfo % nprocs
               global_start(i) = global_start(i-1) + local_nvertices(i-1)
+              !call mpas_log_write('i: $i global_start= $i', intArgs=(/i, global_start(i)/))
            end do
 
-           rewind(unit=iunit)
+           !rewind(unit=iunit)
+           call mpas_log_write('Third read pass ')
 
            do i=1,partial_global_graph_info % nVerticesTotal
-              read(unit=iunit, fmt=*) global_block_id
-              call mpas_get_owning_proc(dminfo, global_block_id, owning_proc)
+              !read(unit=iunit, fmt=*) global_block_id
+              !call mpas_get_owning_proc(dminfo, global_block_id, owning_proc)
+              global_block_id = global_block_id_arr(i)
+              owning_proc = owning_proc_arr(i)
               global_list(global_start(owning_proc+1)) = global_block_id
+              !call mpas_log_write('owning_proc+1: $i global_start= $i global_list=$i', intArgs=(/owning_proc+1, global_start(owning_proc+1), global_list(global_start(owning_proc+1))/))
               global_start(owning_proc+1) = global_start(owning_proc+1) + 1
+              !call mpas_log_write('global_start(owning_proc+1): $i', intArgs=(/global_start(owning_proc+1)/))
            end do
 
            ! Recompute global start after second read of global_block_list
            global_start(1) = 0
            do i=2,dminfo % nprocs
               global_start(i) = global_start(i-1) + local_nvertices(i-1)
+              !call mpas_log_write('i: $i global_start= $i', intArgs=(/i, global_start(i)/))
            end do
 
            call mpas_dmpar_scatter_ints(dminfo, dminfo % nprocs, local_nvertices(dminfo % my_proc_id + 1), &
                                    global_start, local_nvertices, global_list, local_block_list)
 
-           close(unit=iunit)
-           call mpas_release_unit(iunit)
+           
 
         else
 

--- a/src/framework/mpas_block_decomp.F
+++ b/src/framework/mpas_block_decomp.F
@@ -26,9 +26,8 @@ module mpas_block_decomp
    use mpas_io_units
    use mpas_log
    
-#ifdef MPAS_SCOTCH
-#include "scotchf.h"
-#endif
+#include "ptscotchf.h"
+!!#include "scotchf.h"
 
    type graph
       integer :: nVerticesTotal
@@ -53,9 +52,10 @@ module mpas_block_decomp
 !
 !-----------------------------------------------------------------------
    subroutine mpas_block_decomp_cells_for_proc(dminfo, partial_global_graph_info, local_cell_list, block_id, block_start, &
-                                               block_count, cellsOnCellFull, nEdgesOnCellFull, numBlocks, explicitProcDecomp, blockFilePrefix, procFilePrefix)!{{{
+                                               block_count, numBlocks, explicitProcDecomp, blockFilePrefix, procFilePrefix)!{{{
 
-      use mpas_timer, only : mpas_timer_start, mpas_timer_stop
+      use mpas_timer, only : mpas_timer_start, mpas_timer_stop, mpas_timer_write, mpas_timer_write_header
+      use mpi
 
       implicit none
 
@@ -65,8 +65,6 @@ module mpas_block_decomp
       integer, dimension(:), pointer :: block_id !< Output: list of global block id's this processor owns
       integer, dimension(:), pointer :: block_start !< Output: offset in local_cell_list for this blocks list of cells
       integer, dimension(:), pointer :: block_count !< Output: number of cells in blocks
-      type (field2dInteger), intent(in) :: cellsOnCellFull
-      type (field1dInteger), intent(in) :: nEdgesOnCellFull
 
       integer, intent(in) :: numBlocks !< Input: Number of blocks (from config_num_blocks)
       logical, intent(in) :: explicitProcDecomp !< Input: Logical flag controlling if blocks are explicitly assigned to processors
@@ -79,21 +77,23 @@ module mpas_block_decomp
       integer, dimension(:), allocatable :: local_block_list
       integer, dimension(:,:), allocatable :: sorted_local_cell_list
 
-      integer, dimension(:), allocatable :: global_block_id_arr, owning_proc_arr
+      integer, dimension(:), allocatable :: global_block_id_arr, local_block_id_arr, owning_proc_arr
       integer :: i, global_block_id, local_block_id, owning_proc, iunit, ounit, istatus, ostatus, j, k
       integer :: blocks_per_proc, err, ierr
       integer, dimension(:), pointer :: local_nvertices
       character (len=StrKIND) :: filename, msg
 
       logical :: no_blocks
-      integer :: nTotalEdgesGraph = 0
+      integer :: nTotalEdgesGraph = 0, nLocEdgesGraph = 0, edgelocsiz = 0
       integer, dimension(:), allocatable :: edgetab, verttab, parttab
 
       logical :: useScotch
-#ifdef MPAS_SCOTCH
+
       doubleprecision :: stradat (scotch_stratdim)
       doubleprecision :: scotchgraph (scotch_graphdim)
-#endif
+      doubleprecision :: scotchdgraph (SCOTCH_DGRAPHDIM)
+      integer :: localcomm, mpi_ierr
+
 
       no_blocks = .false.
 
@@ -115,171 +115,130 @@ module mpas_block_decomp
         allocate(global_start(dminfo % nprocs))
         allocate(global_list(partial_global_graph_info % nVerticesTotal))
         allocate(global_block_id_arr(partial_global_graph_info % nVerticesTotal))
+        allocate(local_block_id_arr(partial_global_graph_info % nVertices))
         allocate(owning_proc_arr(partial_global_graph_info % nVerticesTotal))
+ 
+         call mpas_timer_start('scotch')
 
-        if (dminfo % my_proc_id == IO_NODE) then
-         useScotch = .false.
-         if ( trim(blockFilePrefix) == '' ) then
-            call mpas_log_write("Namelist option config_block_decomp_file_prefix is set to ''", MPAS_LOG_ERR)
-#ifdef MPAS_SCOTCH
-            useScotch = .true.
-#else
-            call mpas_log_write('Either build MPAS with the Scotch library or provide a valid file prefix for config_block_decomp_file_prefix', MPAS_LOG_CRIT)
-#endif
-         else
-            if (dminfo % total_blocks < 10) then
-               write(filename,'(a,i1)') trim(blockFilePrefix), dminfo % total_blocks
-            else if (dminfo % total_blocks < 100) then
-               write(filename,'(a,i2)') trim(blockFilePrefix), dminfo % total_blocks
-            else if (dminfo % total_blocks < 1000) then
-               write(filename,'(a,i3)') trim(blockFilePrefix), dminfo % total_blocks
-            else if (dminfo % total_blocks < 10000) then
-               write(filename,'(a,i4)') trim(blockFilePrefix), dminfo % total_blocks
-            else if (dminfo % total_blocks < 100000) then
-               write(filename,'(a,i5)') trim(blockFilePrefix), dminfo % total_blocks
-            else if (dminfo % total_blocks < 1000000) then
-               write(filename,'(a,i6)') trim(blockFilePrefix), dminfo % total_blocks
-            else if (dminfo % total_blocks < 10000000) then
-               write(filename,'(a,i7)') trim(blockFilePrefix), dminfo % total_blocks
-            else if (dminfo % total_blocks < 100000000) then
-               write(filename,'(a,i8)') trim(blockFilePrefix), dminfo % total_blocks
-            end if
+         call mpas_log_write('Using LibScotch for graph partitioning')
+         do i=1,partial_global_graph_info % nVertices
+            do j=1,partial_global_graph_info % nAdjacent(i)
+               
+               if (partial_global_graph_info % adjacencyList(j,i) == 0) cycle
+               nLocEdgesGraph = nLocEdgesGraph + 1
+               !nTotalEdgesGraph = nTotalEdgesGraph + nEdgesOnCellFull% array(i)
 
-            call mpas_new_unit(iunit)
-            open(unit=iunit, file=trim(filename), form='formatted', status='old', iostat=istatus)
+               ! do j=1,partial_global_graph_info % nAdjacent(i)
+               !    call mpas_log_write('i=$i j=$i adj= $i', intArgs=(/i,j,partial_global_graph_info % adjacencyList(j,i)/) )
+               ! end do
+            end do
+         end do
+         
+         call mpas_dmpar_sum_int(dminfo, nLocEdgesGraph, nTotalEdgesGraph)
+         
+         call mpas_log_write('nLocEdgesGraph is $i', intArgs=(/nLocEdgesGraph/))
+         call mpas_log_write('nTotalEdgesGraph is $i', intArgs=(/nTotalEdgesGraph/))
+         allocate(edgetab(nLocEdgesGraph))
+         allocate(verttab(partial_global_graph_info % nVertices + 1))
+         !allocate(parttab(partial_global_graph_info % nVerticesTotal))
+
+         ! do i=1,partial_global_graph_info % nVertices
+         !    !call mpas_log_write('proc=$i  i= $i part= $i', intArgs=(/dminfo % my_proc_id, i,parttab(i)/))
+         !    call mpas_log_write('i=$i j=$i adj= $i', intArgs=(/i,j,partial_global_graph_info % adjacencyList(j,i)/) )
+         ! end do 
+
+            k = 1
+            do i=1,partial_global_graph_info % nVertices
+               verttab(i) = k 
+               !call mpas_log_write('i=$i verttab= $i', intArgs=(/i,verttab(i)/) )
+               !call mpas_log_write('i=$i vertexID= $i', intArgs=(/i,partial_global_graph_info % vertexID(i)/) )
+               do j=1,partial_global_graph_info % nAdjacent(i)
+                  
+                  if (partial_global_graph_info % adjacencyList(j,i) == 0) cycle
+
+                  edgetab(k) = partial_global_graph_info % adjacencyList(j,i)
+                  !call mpas_log_write('k=$i edgetab= $i', intArgs=(/k,edgetab(k)/) )
+                  k = k + 1
+               end do
+            end do 
+            verttab(partial_global_graph_info % nVertices+1) = nLocEdgesGraph + 1
+   
+            call mpas_log_write('nvertices =$i  nLocEdgesGraph= $i', intArgs=(/partial_global_graph_info % nVertices, nLocEdgesGraph/))
+
+            call MPI_Comm_dup(MPI_COMM_WORLD, localcomm, mpi_ierr)
+            if (mpi_ierr .ne. 0) then
+                  call mpas_log_write('Cannot duplicate communicator')
+            endif
+            call mpas_log_write('duplicate communicator is $i', intArgs=(/localcomm/) )
+            call mpas_log_write('dminfo communicator is $i', intArgs=(/dminfo % comm/) )
+            call scotchfdgraphinit(scotchdgraph(1),  localcomm, ierr)
+            if (ierr .ne. 0) then
+                  call mpas_log_write('Cannot initialize D Scotch Graph', MPAS_LOG_CRIT)
+            endif
+
+            edgelocsiz = maxval(verttab) - 1
+
+            call scotchfdgraphbuild (scotchdgraph(1), &
+                                     1, &
+                                     partial_global_graph_info % nVertices, &
+                                     partial_global_graph_info % nVertices, & ! vertlocmax
+                                     verttab (1), & ! vertloctab
+                                     verttab (2), & ! 
+                                     verttab (1), &
+                                     verttab (1), &
+                                     nLocEdgesGraph, &
+                                     edgelocsiz, &
+                                     edgetab(1), &
+                                     edgetab(1), &
+                                     edgetab(1), ierr)
+
+            if (ierr .ne. 0) then
+               call mpas_log_write('Cannot build Scotch Graph', MPAS_LOG_CRIT)
+            endif
+            call MPI_Barrier(dminfo % comm, mpi_ierr)
+
+            call mpas_log_write('Graph build successful ')
+
+
+            call scotchfstratinit (stradat (1), ierr)
             
-            if (istatus /= 0) then
-               call mpas_log_write('Could not open block decomposition file for $i blocks.', MPAS_LOG_WARN, intArgs=(/dminfo % total_blocks/) )
-               call mpas_log_write('Filename: '//trim(filename),MPAS_LOG_WARN)
-#ifdef MPAS_SCOTCH
-               useScotch = .true.
-#else             
-               call mpas_log_write('Either build MPAS with Scotch library or provide a valid file prefix for config_block_decomp_file_prefix', MPAS_LOG_CRIT)
-#endif
-            end if
-         end if
+            ! CALL scotchfgraphbuild (scotchgraph (1), 1, partial_global_graph_info % nVerticesTotal, &
+            !                         verttab (1), verttab (2), &
+            !                         verttab (1), verttab (1), &
+            !                         nTotalEdgesGraph, edgetab (1), edgetab (1), ierr)
+            
 
-         if (useScotch) then
-#ifdef MPAS_SCOTCH
-               call mpas_timer_start('scotch_graph_partitioning')
-               call mpas_log_write('Using LibScotch for graph partitioning')
-               do i=1,partial_global_graph_info % nVerticesTotal
-                  do j=1,nEdgesOnCellFull% array(i)
-                     
-                     if (cellsOnCellFull%array(j,i) == 0) cycle
-                     nTotalEdgesGraph = nTotalEdgesGraph + 1
-                     !nTotalEdgesGraph = nTotalEdgesGraph + nEdgesOnCellFull% array(i)
-                  ! do j=1,nEdgesOnCellFull% array(i)
-                  !    call mpas_log_write('i=$i j=$i adj= $i', intArgs=(/i,j,cellsOnCellFull%array(j,i)/) )
-                  ! end do
-                  end do
-               end do 
-               call mpas_log_write('nTotalEdgesGraph is $i', intArgs=(/nTotalEdgesGraph/))
-               allocate(edgetab(nTotalEdgesGraph))
-               allocate(verttab(partial_global_graph_info % nVerticesTotal + 1))
-               !allocate(parttab(partial_global_graph_info % nVerticesTotal))
-  
-               !do i=1,partial_global_graph_info % nVerticesTotal
-                  !call mpas_log_write('proc=$i  i= $i part= $i', intArgs=(/dminfo % my_proc_id, i,parttab(i)/))
-                  !call mpas_log_write('i=$i j=$i adj= $i', intArgs=(/i,j,cellsOnCellFull%array(j,i)/) )
-               !end do 
-  
-               k = 1
-               do i=1,partial_global_graph_info % nVerticesTotal
-                  verttab(i) = k 
-                  !call mpas_log_write('i=$i verttab= $i', intArgs=(/i,verttab(i)/) )
-                  do j=1,nEdgesOnCellFull% array(i)
-                     
-                     if (cellsOnCellFull%array(j,i) == 0) cycle
+         ! if (dminfo % my_proc_id == IO_NODE) then
+         !    call scotchfdgraphscatter (scotchdgraph(1), scotchgraph(1) , ierr)
+         ! else 
+         !    call scotchfdgraphscatter (scotchdgraph(1), scotchdgraph(1) , ierr)
+         ! end if
+         call mpas_timer_start('scotch_part')
+         call scotchfdgraphpart (scotchdgraph(1), dminfo % total_blocks, stradat (1), local_block_id_arr(1), ierr)
+         !call scotchfdgraphpart(scotchgraph (1), dminfo % total_blocks, stradat (1) ,global_block_id_arr(1),  IERR)
+         call mpas_log_write('Graph parition successful ')
 
-                     edgetab(k) = cellsOnCellFull%array(j,i)
-                     !call mpas_log_write('k=$i edgetab= $i', intArgs=(/k,edgetab(k)/) )
-                     k = k + 1
-                  end do
-               end do 
-               verttab(partial_global_graph_info % nVerticesTotal+1) = nTotalEdgesGraph + 1
-      
-               !call mpas_log_write('nvertices =$i  nTotalEdgesGraph= $i', intArgs=(/partial_global_graph_info % nVerticesTotal, nTotalEdgesGraph/))
-  
-               call scotchfstratinit (stradat (1), ierr)
-               call scotchfgraphinit (scotchgraph (1), ierr)
+         call mpas_timer_stop('scotch_part')
+         call mpas_timer_stop('scotch')
+         call mpas_timer_stop('mpas_block_decomp_cells_for_proc')
+         call mpas_timer_stop('bootstrap_framework_phase1')
+         call mpas_timer_stop('initialize')
+         call mpas_timer_stop('total time')
+         call mpas_timer_write_header()
+         call mpas_timer_write()
 
-               if (ierr .ne. 0) then
-                  call mpas_log_write('Cannot initialize Scotch Graph', MPAS_LOG_CRIT)
-               endif
-  
-               CALL scotchfgraphbuild (scotchgraph (1), 1, partial_global_graph_info % nVerticesTotal, &
-                                       verttab (1), verttab (2), &
-                                       verttab (1), verttab (1), &
-                                       nTotalEdgesGraph, edgetab (1), edgetab (1), ierr)
-               if (ierr .ne. 0) then
-                  call mpas_log_write('Cannot build Scotch Graph', MPAS_LOG_CRIT)
-               endif
+         call scotchfdgraphexit (scotchdgraph (1))
+         call scotchfstratexit (stradat (1))
 
-               ! Only needed during development/debugging. 
-               !call scotchfgraphcheck (scotchgraph (1), ierr)
-               !if (ierr .ne. 0) then
-               !   call mpas_log_write('Cannot check Scotch Graph', MPAS_LOG_CRIT)
-               !endif
-  
-               call scotchfgraphpart( scotchgraph (1), dminfo % total_blocks, stradat (1) ,global_block_id_arr(1),  IERR)
-  
-               call scotchfgraphexit (SCOTCHGRAPH (1))
-               call scotchfstratexit (stradat (1))
+         local_nvertices(:) = 0
+         do i=1,partial_global_graph_info % nVertices
+            !global_block_id_arr(i) = parttab(i)
+            call mpas_get_owning_proc(dminfo, local_block_id_arr(i), owning_proc)
+            owning_proc_arr(i) = owning_proc
+            call mpas_log_write('vert: $i, global_block_id: $i, owning_proc: $i ', intArgs=(/i,local_block_id_arr(i),owning_proc/) )
+            local_nvertices(owning_proc+1) = local_nvertices(owning_proc+1) + 1
+         end do
 
-               local_nvertices(:) = 0
-               do i=1,partial_global_graph_info % nVerticesTotal
-                  !global_block_id_arr(i) = parttab(i)
-                  call mpas_get_owning_proc(dminfo, global_block_id_arr(i), owning_proc)
-                  owning_proc_arr(i) = owning_proc
-                  !call mpas_log_write('vert: $i, global_block_id: $i, owning_proc: $i ', intArgs=(/i,global_block_id_arr(i),owning_proc/) )
-                  local_nvertices(owning_proc+1) = local_nvertices(owning_proc+1) + 1
-               end do
-
-               ! if (istatus /= 0) then
-               !    call mpas_log_write('Writing out Scotch Graph paritioning data to '//trim(filename))
-               !    call mpas_new_unit(ounit)
-               !    open(unit=ounit, file=trim(filename), form='formatted', status='new', action="write", iostat=ostatus)
-               !    do i=1,partial_global_graph_info % nVerticesTotal
-               !       write(unit=ounit, fmt='(i0)', iostat=err) global_block_id_arr(i)
-               !       !write(unit=ounit, fmt='(*(i0,1x))', iostat=err) global_block_id_arr(i)
-               !    end do
-               !    close(unit=ounit)
-               !    call mpas_release_unit(ounit)
-               ! end if
-               call mpas_timer_stop('scotch_graph_partitioning')
-#endif
-           else
-
-               call mpas_log_write('Using block decomposition file: '//trim(filename))
-
-               call mpas_log_write('First read pass ')
-               local_nvertices(:) = 0
-               do i=1,partial_global_graph_info % nVerticesTotal
-                  read(unit=iunit, fmt=*, iostat=err) global_block_id
-                  global_block_id_arr(i) = global_block_id
-
-                  if ( err .ne. 0 ) then
-                     call mpas_log_write('Decomoposition file: ' // trim(filename) // ' contains less than $i cells', &
-                                          MPAS_LOG_CRIT, intArgs=(/partial_global_graph_info % nVerticesTotal/) )
-                  end if
-                  call mpas_get_owning_proc(dminfo, global_block_id, owning_proc)
-                  owning_proc_arr(i) = owning_proc
-                  !call mpas_log_write('vert: $i, global_block_id: $i, owning_proc: $i ', intArgs=(/i,global_block_id,owning_proc/) )
-                  local_nvertices(owning_proc+1) = local_nvertices(owning_proc+1) + 1
-                  !call mpas_log_write('owning_proc+1: $i local_nvertices= $i', intArgs=(/owning_proc+1, local_nvertices(owning_proc+1)/))
-               end do
-
-               read(unit=iunit, fmt=*, iostat=err)
-
-               if ( err == 0 ) then
-                  call mpas_log_write('Decomposition file: ' // trim(filename) // ' contains more than $i cells', &
-                                       MPAS_LOG_CRIT, intArgs=(/partial_global_graph_info % nVerticesTotal/) )
-               end if
-
-               close(unit=iunit)
-               call mpas_release_unit(iunit)
-           end if
 
            global_start(1) = 1
            do i=2,dminfo % nprocs
@@ -306,7 +265,7 @@ module mpas_block_decomp
               global_start(i) = global_start(i-1) + local_nvertices(i-1)
               !call mpas_log_write('i: $i global_start= $i', intArgs=(/i, global_start(i)/))
            end do
-
+         if (dminfo % my_proc_id == IO_NODE) then
            call mpas_dmpar_bcast_ints(dminfo, dminfo % nprocs, local_nvertices)
            allocate(local_cell_list(local_nvertices(dminfo % my_proc_id + 1)))
            allocate(local_block_list(local_nvertices(dminfo % my_proc_id + 1)))

--- a/src/framework/mpas_block_decomp.F
+++ b/src/framework/mpas_block_decomp.F
@@ -55,6 +55,8 @@ module mpas_block_decomp
    subroutine mpas_block_decomp_cells_for_proc(dminfo, partial_global_graph_info, local_cell_list, block_id, block_start, &
                                                block_count, cellsOnCellFull, nEdgesOnCellFull, numBlocks, explicitProcDecomp, blockFilePrefix, procFilePrefix)!{{{
 
+      use mpas_timer, only : mpas_timer_start, mpas_timer_stop
+
       implicit none
 
       type (dm_info), intent(inout) :: dminfo !< Input: domain information
@@ -94,6 +96,8 @@ module mpas_block_decomp
 #endif
 
       no_blocks = .false.
+
+      call mpas_timer_start('mpas_block_decomp_cells_for_proc')
 
       if (numBlocks == 0) then
         dminfo % total_blocks = dminfo % nProcs
@@ -157,6 +161,7 @@ module mpas_block_decomp
 
          if (useScotch) then
 #ifdef MPAS_SCOTCH
+               call mpas_timer_start('scotch_graph_partitioning')
                call mpas_log_write('Using LibScotch for graph partitioning')
                do i=1,partial_global_graph_info % nVerticesTotal
                   do j=1,nEdgesOnCellFull% array(i)
@@ -231,17 +236,18 @@ module mpas_block_decomp
                   local_nvertices(owning_proc+1) = local_nvertices(owning_proc+1) + 1
                end do
 
-               if (istatus /= 0) then
-                  call mpas_log_write('Writing out Scotch Graph paritioning data to '//trim(filename))
-                  call mpas_new_unit(ounit)
-                  open(unit=ounit, file=trim(filename), form='formatted', status='new', action="write", iostat=ostatus)
-                  do i=1,partial_global_graph_info % nVerticesTotal
-                     write(unit=ounit, fmt='(i0)', iostat=err) global_block_id_arr(i)
-                     !write(unit=ounit, fmt='(*(i0,1x))', iostat=err) global_block_id_arr(i)
-                  end do
-                  close(unit=ounit)
-                  call mpas_release_unit(ounit)
-               end if
+               ! if (istatus /= 0) then
+               !    call mpas_log_write('Writing out Scotch Graph paritioning data to '//trim(filename))
+               !    call mpas_new_unit(ounit)
+               !    open(unit=ounit, file=trim(filename), form='formatted', status='new', action="write", iostat=ostatus)
+               !    do i=1,partial_global_graph_info % nVerticesTotal
+               !       write(unit=ounit, fmt='(i0)', iostat=err) global_block_id_arr(i)
+               !       !write(unit=ounit, fmt='(*(i0,1x))', iostat=err) global_block_id_arr(i)
+               !    end do
+               !    close(unit=ounit)
+               !    call mpas_release_unit(ounit)
+               ! end if
+               call mpas_timer_stop('scotch_graph_partitioning')
 #endif
            else
 
@@ -429,6 +435,8 @@ module mpas_block_decomp
            block_count(1) = 0
         end if
       end if
+
+      call mpas_timer_stop('mpas_block_decomp_cells_for_proc')
 
    end subroutine mpas_block_decomp_cells_for_proc!}}}
 

--- a/src/framework/mpas_block_decomp.F
+++ b/src/framework/mpas_block_decomp.F
@@ -26,7 +26,9 @@ module mpas_block_decomp
    use mpas_io_units
    use mpas_log
 
+#ifdef MPAS_SCOTCH
 #include "ptscotchf.h"
+#endif
 
    type graph
       integer :: nVerticesTotal
@@ -80,10 +82,12 @@ module mpas_block_decomp
       integer :: i, global_block_id, local_block_id, owning_proc, iunit, ounit, istatus, ostatus, j, k
       integer :: blocks_per_proc, err, ierr
       integer, dimension(:), pointer :: local_nvertices
+      integer :: num_local_vertices !< Number of local vertices for this processor
       character (len=StrKIND) :: filename, msg
 
       logical :: no_blocks
       logical :: useScotch
+#ifdef MPAS_SCOTCH
       integer :: nLocEdgesGraph = 0, edgelocsiz = 0
       integer, dimension(:), allocatable :: edgetab, verttab, parttab
       doubleprecision :: stradat (scotch_stratdim)
@@ -92,8 +96,9 @@ module mpas_block_decomp
       doubleprecision :: scotchdgraph_redist (SCOTCH_DGRAPHDIM)
       integer :: localcomm, mpi_ierr
       integer, dimension(:), allocatable :: indxtab
-      integer :: vertglbnbr, vertlocnbr, vertlocmax, vertgstnbr, vertlocidx, vendlocidx, velolocidx, vlbllocidx
+      integer :: vertglbnbr, vertlocmax, vertgstnbr, vertlocidx, vendlocidx, velolocidx, vlbllocidx
       integer :: edgeglbnbr, edgelocnbr, edgelocidx, edgegstidx, edlolocidx, comm, baseval
+#endif
 
       no_blocks = .false.
 
@@ -117,6 +122,53 @@ module mpas_block_decomp
         allocate(local_block_id_arr(partial_global_graph_info % nVertices))
         allocate(owning_proc_arr(partial_global_graph_info % nVerticesTotal))
  
+        useScotch = .false.
+       if (dminfo % my_proc_id == IO_NODE) then
+         if ( trim(blockFilePrefix) == '' ) then
+            call mpas_log_write("Namelist option config_block_decomp_file_prefix is set to ''", MPAS_LOG_ERR)
+#ifdef MPAS_SCOTCH
+            useScotch = .true.
+#else
+            call mpas_log_write('Either build MPAS with the Scotch library or provide a valid file prefix for config_block_decomp_file_prefix', MPAS_LOG_CRIT)
+#endif
+         else
+            if (dminfo % total_blocks < 10) then
+               write(filename,'(a,i1)') trim(blockFilePrefix), dminfo % total_blocks
+            else if (dminfo % total_blocks < 100) then
+               write(filename,'(a,i2)') trim(blockFilePrefix), dminfo % total_blocks
+            else if (dminfo % total_blocks < 1000) then
+               write(filename,'(a,i3)') trim(blockFilePrefix), dminfo % total_blocks
+            else if (dminfo % total_blocks < 10000) then
+               write(filename,'(a,i4)') trim(blockFilePrefix), dminfo % total_blocks
+            else if (dminfo % total_blocks < 100000) then
+               write(filename,'(a,i5)') trim(blockFilePrefix), dminfo % total_blocks
+            else if (dminfo % total_blocks < 1000000) then
+               write(filename,'(a,i6)') trim(blockFilePrefix), dminfo % total_blocks
+            else if (dminfo % total_blocks < 10000000) then
+               write(filename,'(a,i7)') trim(blockFilePrefix), dminfo % total_blocks
+            else if (dminfo % total_blocks < 100000000) then
+               write(filename,'(a,i8)') trim(blockFilePrefix), dminfo % total_blocks
+            end if
+
+            call mpas_new_unit(iunit)
+            open(unit=iunit, file=trim(filename), form='formatted', status='old', iostat=istatus)
+            
+            if (istatus /= 0) then
+               call mpas_log_write('Could not open block decomposition file for $i blocks.', MPAS_LOG_WARN, intArgs=(/dminfo % total_blocks/) )
+               call mpas_log_write('Filename: '//trim(filename),MPAS_LOG_WARN)
+#ifdef MPAS_SCOTCH
+               useScotch = .true.
+#else             
+               call mpas_log_write('Either build MPAS with Scotch library or provide a valid file prefix for config_block_decomp_file_prefix', MPAS_LOG_CRIT)
+#endif
+            end if ! istatus /= 0
+         end if  ! trim(blockFilePrefix) == ''
+      end if ! dminfo % my_proc_id == IO_NODE
+
+      call mpas_dmpar_bcast_logical(dminfo, useScotch)
+
+      if (useScotch) then ! Using PT-Scotch across all MPI ranks
+#ifdef MPAS_SCOTCH
          call mpas_timer_start('scotch')
 
          call mpas_log_write('Using LibScotch for graph partitioning')
@@ -125,14 +177,11 @@ module mpas_block_decomp
                
                if (partial_global_graph_info % adjacencyList(j,i) == 0) cycle
                nLocEdgesGraph = nLocEdgesGraph + 1
-               
-
                ! do j=1,partial_global_graph_info % nAdjacent(i)
                !    call mpas_log_write('i=$i j=$i adj= $i', intArgs=(/i,j,partial_global_graph_info % adjacencyList(j,i)/) )
                ! end do
             end do
          end do
-         
          call mpas_log_write('nLocEdgesGraph is $i', intArgs=(/nLocEdgesGraph/))
          allocate(edgetab(nLocEdgesGraph))
          allocate(verttab(partial_global_graph_info % nVertices + 1))
@@ -192,7 +241,8 @@ module mpas_block_decomp
             if (ierr .ne. 0) then
                call mpas_log_write('Cannot build Scotch Graph', MPAS_LOG_CRIT)
             endif
-            !call MPI_Barrier(dminfo % comm, mpi_ierr)
+            
+            ! Only needed during development/debugging. 
             call scotchfdgraphcheck (scotchdgraph(1), ierr)
             if (ierr .ne. 0) then
                call mpas_log_write(' Scotch Graph check not successfull', MPAS_LOG_CRIT)
@@ -205,30 +255,31 @@ module mpas_block_decomp
          call mpas_timer_start('scotch_part')
          call scotchfdgraphpart (scotchdgraph(1), dminfo % nProcs, stradat (1), local_block_id_arr(1), ierr)
          !call scotchfdgraphpart (scotchdgraph(1), dminfo % total_blocks, stradat (1), local_block_id_arr(1), ierr)
+         call mpas_timer_stop('scotch_part')
          call mpas_log_write('Graph parition successful ')
 
          call scotchfdgraphredist(scotchdgraph(1), local_block_id_arr(1),scotchdgraph(1), -1 ,-1, scotchdgraph_redist(1), ierr)
          call mpas_log_write('Graph redist successful ')
 
          allocate(indxtab(5*partial_global_graph_info % nVertices))
-         call scotchfdgraphdata(scotchdgraph_redist(1), indxtab(1), baseval, vertglbnbr, vertlocnbr, vertlocmax, vertgstnbr, &
+         call scotchfdgraphdata(scotchdgraph_redist(1), indxtab(1), baseval, vertglbnbr, num_local_vertices, vertlocmax, vertgstnbr, &
                                 vertlocidx, vendlocidx, velolocidx, vlbllocidx, edgeglbnbr, edgelocnbr, &
                                  edgelocsiz, edgelocidx, edgegstidx, edlolocidx, comm, ierr )
 
-         call mpas_log_write('vertlocnbr $i vertlocidx $i ', intArgs=(/vertlocnbr,vertlocidx/) )
+         call mpas_log_write('vertlocnbr $i vertlocidx $i ', intArgs=(/num_local_vertices,vertlocidx/) )
          call mpas_log_write('vertgstnbr $i vertlocmax $i ', intArgs=(/vertgstnbr,vertlocmax/) )
          call mpas_log_write('edgelocsiz $i edgelocidx $i ', intArgs=(/edgelocsiz,edgelocidx/) )
          call mpas_log_write('edgegstidx $i edlolocidx $i ', intArgs=(/edgegstidx,edlolocidx/) )
          call mpas_log_write('vertglbnbr $i ierr $i ', intArgs=(/vertglbnbr,ierr/) )
 
-         ! do i=1,vertlocnbr
+         ! do i=1,num_local_vertices
          !    call mpas_log_write('i: $i, vertlocidx: $i', intArgs=(/i,indxtab(vertlocidx+i-1)/) )
          ! end do
-         ! do i=1,vertlocnbr
+         ! do i=1,num_local_vertices
          !    call mpas_log_write('i: $i, vlbllocidx: $i', intArgs=(/i,indxtab(vlbllocidx+i-1)/) )
          ! end do
-         call mpas_timer_stop('scotch_part')
-         call mpas_timer_stop('scotch')
+         
+         
          ! call mpas_timer_stop('mpas_block_decomp_cells_for_proc')
          ! call mpas_timer_stop('bootstrap_framework_phase1')
          ! call mpas_timer_stop('initialize')
@@ -236,24 +287,113 @@ module mpas_block_decomp
          !call mpas_timer_write_header()
          !call mpas_timer_write()
 
-         allocate(local_cell_list(vertlocnbr))
-         allocate(local_block_list(vertlocnbr))
+         allocate(local_cell_list(num_local_vertices))
+         allocate(local_block_list(num_local_vertices))
 
-         do i=1,vertlocnbr
+         do i=1,num_local_vertices
             local_cell_list(i)=indxtab(vlbllocidx+i-1)
             local_block_list(i)=dminfo % my_proc_id
             !call mpas_log_write('local_cell_list: $i, local_block_list: $i', intArgs=(/local_cell_list(i),local_block_list(i)/) )
          end do
 
+         ! Calling scotchfdgraphexit 
          call scotchfdgraphexit (scotchdgraph (1))
          call scotchfdgraphexit (scotchdgraph_redist (1))
          call scotchfstratexit (stradat (1))
-         call mpas_log_write('post1 successful ')
+         call mpas_timer_stop('scotch')
+         call mpas_log_write('Scotch parition successful ')
+#endif
+      else  ! useScotch = .false.
+         if (dminfo % my_proc_id == IO_NODE) then
+               call mpas_log_write('Using block decomposition file: '//trim(filename))
 
+               local_nvertices(:) = 0
+               do i=1,partial_global_graph_info % nVerticesTotal
+                  read(unit=iunit, fmt=*, iostat=err) global_block_id
 
-         ! do i=1,partial_global_graph_info % nVertices         
-         !    call mpas_log_write('vert: $i, partloctab: $i', intArgs=(/i,local_block_id_arr(i)/) )
-         ! end do
+                  if ( err .ne. 0 ) then
+                     call mpas_log_write('Decomoposition file: ' // trim(filename) // ' contains less than $i cells', &
+                                          MPAS_LOG_CRIT, intArgs=(/partial_global_graph_info % nVerticesTotal/) )
+                  end if
+                  call mpas_get_owning_proc(dminfo, global_block_id, owning_proc)
+                  local_nvertices(owning_proc+1) = local_nvertices(owning_proc+1) + 1
+               end do
+
+               read(unit=iunit, fmt=*, iostat=err)
+
+               if ( err == 0 ) then
+                  call mpas_log_write('Decomposition file: ' // trim(filename) // ' contains more than $i cells', &
+                                       MPAS_LOG_CRIT, intArgs=(/partial_global_graph_info % nVerticesTotal/) )    
+               end if
+
+           global_start(1) = 1
+           do i=2,dminfo % nprocs
+              global_start(i) = global_start(i-1) + local_nvertices(i-1)
+           end do
+
+           rewind(unit=iunit)
+
+           do i=1,partial_global_graph_info % nVerticesTotal
+              read(unit=iunit, fmt=*, iostat=err) global_block_id
+              call mpas_get_owning_proc(dminfo, global_block_id, owning_proc)
+              global_list(global_start(owning_proc+1)) = i
+              global_start(owning_proc+1) = global_start(owning_proc+1) + 1
+           end do
+
+           global_start(1) = 0
+           do i=2,dminfo % nprocs
+              global_start(i) = global_start(i-1) + local_nvertices(i-1)
+           end do
+
+           call mpas_dmpar_bcast_ints(dminfo, dminfo % nprocs, local_nvertices)
+           allocate(local_cell_list(local_nvertices(dminfo % my_proc_id + 1)))
+           allocate(local_block_list(local_nvertices(dminfo % my_proc_id + 1)))
+
+           call mpas_dmpar_scatter_ints(dminfo, dminfo % nprocs, local_nvertices(dminfo % my_proc_id + 1), &
+                                   global_start, local_nvertices, global_list, local_cell_list)
+
+           ! Reset global start for second read of global_block_list
+           global_start(1) = 1
+           do i=2,dminfo % nprocs
+              global_start(i) = global_start(i-1) + local_nvertices(i-1)
+           end do
+
+           rewind(unit=iunit)
+
+           do i=1,partial_global_graph_info % nVerticesTotal
+              read(unit=iunit, fmt=*) global_block_id
+              call mpas_get_owning_proc(dminfo, global_block_id, owning_proc)
+              global_list(global_start(owning_proc+1)) = global_block_id
+              global_start(owning_proc+1) = global_start(owning_proc+1) + 1
+           end do
+
+           ! Recompute global start after second read of global_block_list
+           global_start(1) = 0
+           do i=2,dminfo % nprocs
+              global_start(i) = global_start(i-1) + local_nvertices(i-1)
+           end do
+
+           call mpas_dmpar_scatter_ints(dminfo, dminfo % nprocs, local_nvertices(dminfo % my_proc_id + 1), &
+                                   global_start, local_nvertices, global_list, local_block_list)
+
+           close(unit=iunit)
+           call mpas_release_unit(iunit)
+           
+        else ! dminfo % my_proc_id == IO_NODE
+
+           call mpas_dmpar_bcast_ints(dminfo, dminfo % nprocs, local_nvertices)
+           allocate(local_cell_list(local_nvertices(dminfo % my_proc_id + 1)))
+           allocate(local_block_list(local_nvertices(dminfo % my_proc_id + 1)))
+
+           call mpas_dmpar_scatter_ints(dminfo, dminfo % nprocs, local_nvertices(dminfo % my_proc_id + 1), &
+                                   global_start, local_nvertices, global_list, local_cell_list)
+
+           call mpas_dmpar_scatter_ints(dminfo, dminfo % nprocs, local_nvertices(dminfo % my_proc_id + 1), &
+                                   global_start, local_nvertices, global_list, local_block_list)
+        end if ! dminfo % my_proc_id == IO_NODE
+        num_local_vertices = local_nvertices(dminfo % my_proc_id + 1)
+        deallocate(local_nvertices)
+      end if ! useScotch
 
         if(blocks_per_proc == 0) then
            no_blocks = .true.
@@ -269,7 +409,7 @@ module mpas_block_decomp
            block_start(1) = 0
            block_count(1) = 0
         else
-           allocate(sorted_local_cell_list(2, vertlocnbr))
+           allocate(sorted_local_cell_list(2, num_local_vertices))
            allocate(block_id(blocks_per_proc))
            allocate(block_start(blocks_per_proc))
            allocate(block_count(blocks_per_proc))
@@ -279,7 +419,7 @@ module mpas_block_decomp
              block_count = 0
            end do
    
-           do i = 1,vertlocnbr
+           do i = 1,num_local_vertices
              call mpas_get_local_block_id(dminfo, local_block_list(i), local_block_id)
      
              block_id(local_block_id+1) = local_block_list(i)
@@ -290,9 +430,9 @@ module mpas_block_decomp
              block_count(local_block_id+1) = block_count(local_block_id+1) + 1
            end do
    
-           call mpas_quicksort(vertlocnbr, sorted_local_cell_list)
+           call mpas_quicksort(num_local_vertices, sorted_local_cell_list)
    
-           do i = 1, vertlocnbr
+           do i = 1, num_local_vertices
              local_cell_list(i) = sorted_local_cell_list(2, i)
            end do
    
@@ -302,7 +442,6 @@ module mpas_block_decomp
 
            deallocate(sorted_local_cell_list)
            deallocate(local_block_list)
-           deallocate(local_nvertices)
            deallocate(global_start)
            deallocate(global_list)
         end if

--- a/src/framework/mpas_block_decomp.F
+++ b/src/framework/mpas_block_decomp.F
@@ -92,7 +92,12 @@ module mpas_block_decomp
       doubleprecision :: stradat (scotch_stratdim)
       doubleprecision :: scotchgraph (scotch_graphdim)
       doubleprecision :: scotchdgraph (SCOTCH_DGRAPHDIM)
+      doubleprecision :: scotchdgraph_redist (SCOTCH_DGRAPHDIM)
       integer :: localcomm, mpi_ierr
+      integer, dimension(:), allocatable :: indxtab
+      integer :: vertglbnbr, vertlocnbr, vertlocmax, vertgstnbr, vertlocidx, vendlocidx, velolocidx, vlbllocidx
+      integer :: edgeglbnbr, edgelocnbr, edgelocidx, edgegstidx, edlolocidx, comm, baseval
+
 
 
       no_blocks = .false.
@@ -114,7 +119,7 @@ module mpas_block_decomp
         allocate(local_nvertices(dminfo % nprocs))
         allocate(global_start(dminfo % nprocs))
         allocate(global_list(partial_global_graph_info % nVerticesTotal))
-        allocate(global_block_id_arr(partial_global_graph_info % nVerticesTotal))
+        !allocate(global_block_id_arr(partial_global_graph_info % nVerticesTotal))
         allocate(local_block_id_arr(partial_global_graph_info % nVertices))
         allocate(owning_proc_arr(partial_global_graph_info % nVerticesTotal))
  
@@ -172,6 +177,7 @@ module mpas_block_decomp
             call mpas_log_write('duplicate communicator is $i', intArgs=(/localcomm/) )
             call mpas_log_write('dminfo communicator is $i', intArgs=(/dminfo % comm/) )
             call scotchfdgraphinit(scotchdgraph(1),  localcomm, ierr)
+            call scotchfdgraphinit(scotchdgraph_redist(1),  localcomm, ierr)
             if (ierr .ne. 0) then
                   call mpas_log_write('Cannot initialize D Scotch Graph', MPAS_LOG_CRIT)
             endif
@@ -195,13 +201,18 @@ module mpas_block_decomp
             if (ierr .ne. 0) then
                call mpas_log_write('Cannot build Scotch Graph', MPAS_LOG_CRIT)
             endif
-            call MPI_Barrier(dminfo % comm, mpi_ierr)
-
+            !call MPI_Barrier(dminfo % comm, mpi_ierr)
+            call scotchfdgraphcheck (scotchdgraph(1), ierr)
+            if (ierr .ne. 0) then
+               call mpas_log_write(' Scotch Graph check not successfull', MPAS_LOG_CRIT)
+            endif
             call mpas_log_write('Graph build successful ')
 
+            
 
             call scotchfstratinit (stradat (1), ierr)
-            
+            call mpas_log_write('After strat init successful ')
+
             ! CALL scotchfgraphbuild (scotchgraph (1), 1, partial_global_graph_info % nVerticesTotal, &
             !                         verttab (1), verttab (2), &
             !                         verttab (1), verttab (1), &
@@ -214,110 +225,65 @@ module mpas_block_decomp
          !    call scotchfdgraphscatter (scotchdgraph(1), scotchdgraph(1) , ierr)
          ! end if
          call mpas_timer_start('scotch_part')
-         call scotchfdgraphpart (scotchdgraph(1), dminfo % total_blocks, stradat (1), local_block_id_arr(1), ierr)
+         call scotchfdgraphpart (scotchdgraph(1), dminfo % nProcs, stradat (1), local_block_id_arr(1), ierr)
+         !call scotchfdgraphpart (scotchdgraph(1), dminfo % total_blocks, stradat (1), local_block_id_arr(1), ierr)
          !call scotchfdgraphpart(scotchgraph (1), dminfo % total_blocks, stradat (1) ,global_block_id_arr(1),  IERR)
          call mpas_log_write('Graph parition successful ')
 
+         call scotchfdgraphredist(scotchdgraph(1), local_block_id_arr(1),scotchdgraph(1), -1 ,-1, scotchdgraph_redist(1), ierr)
+         call mpas_log_write('Graph redist successful ')
+
+         allocate(indxtab(5*partial_global_graph_info % nVertices))
+         call scotchfdgraphdata(scotchdgraph_redist(1), indxtab(1), baseval, vertglbnbr, vertlocnbr, vertlocmax, vertgstnbr, &
+                                vertlocidx, vendlocidx, velolocidx, vlbllocidx, edgeglbnbr, edgelocnbr, &
+                                 edgelocsiz, edgelocidx, edgegstidx, edlolocidx, comm, ierr )
+
+         call mpas_log_write('vertlocnbr $i vertlocidx $i ', intArgs=(/vertlocnbr,vertlocidx/) )
+         call mpas_log_write('vertgstnbr $i vertlocmax $i ', intArgs=(/vertgstnbr,vertlocmax/) )
+         call mpas_log_write('edgelocsiz $i edgelocidx $i ', intArgs=(/edgelocsiz,edgelocidx/) )
+         call mpas_log_write('edgegstidx $i edlolocidx $i ', intArgs=(/edgegstidx,edlolocidx/) )
+         call mpas_log_write('vertglbnbr $i ierr $i ', intArgs=(/vertglbnbr,ierr/) )
+
+         ! do i=1,vertlocnbr
+         !    call mpas_log_write('i: $i, vertlocidx: $i', intArgs=(/i,indxtab(vertlocidx+i-1)/) )
+         ! end do
+         ! do i=1,vertlocnbr
+         !    call mpas_log_write('i: $i, vlbllocidx: $i', intArgs=(/i,indxtab(vlbllocidx+i-1)/) )
+         ! end do
+
+         !call MPI_Scatterv(inlist, counts, displs, MPI_INTEGERKIND, outlist, noutlist, MPI_INTEGERKIND, IO_NODE, dminfo % comm, mpi_ierr)
+         !call MPI_Gatherv( local_block_id_arr, partial_global_graph_info % nVertices, MPI_INTEGERKIND, rbuf, rcounts, displs, MPI_INTEGERKIND, IO_NODE, dminfo % comm, mpi_ierr)
+
+
+
          call mpas_timer_stop('scotch_part')
          call mpas_timer_stop('scotch')
-         call mpas_timer_stop('mpas_block_decomp_cells_for_proc')
-         call mpas_timer_stop('bootstrap_framework_phase1')
-         call mpas_timer_stop('initialize')
-         call mpas_timer_stop('total time')
-         call mpas_timer_write_header()
-         call mpas_timer_write()
+         ! call mpas_timer_stop('mpas_block_decomp_cells_for_proc')
+         ! call mpas_timer_stop('bootstrap_framework_phase1')
+         ! call mpas_timer_stop('initialize')
+         ! call mpas_timer_stop('total time')
+         !call mpas_timer_write_header()
+         !call mpas_timer_write()
 
-         call scotchfdgraphexit (scotchdgraph (1))
-         call scotchfstratexit (stradat (1))
+         allocate(local_cell_list(vertlocnbr))
+         allocate(local_block_list(vertlocnbr))
 
-         local_nvertices(:) = 0
-         do i=1,partial_global_graph_info % nVertices
-            !global_block_id_arr(i) = parttab(i)
-            call mpas_get_owning_proc(dminfo, local_block_id_arr(i), owning_proc)
-            owning_proc_arr(i) = owning_proc
-            call mpas_log_write('vert: $i, global_block_id: $i, owning_proc: $i ', intArgs=(/i,local_block_id_arr(i),owning_proc/) )
-            local_nvertices(owning_proc+1) = local_nvertices(owning_proc+1) + 1
+         do i=1,vertlocnbr
+            local_cell_list(i)=indxtab(vlbllocidx+i-1)
+            local_block_list(i)=dminfo % my_proc_id
+            !call mpas_log_write('local_cell_list: $i, local_block_list: $i', intArgs=(/local_cell_list(i),local_block_list(i)/) )
          end do
 
+         call scotchfdgraphexit (scotchdgraph (1))
+         call scotchfdgraphexit (scotchdgraph_redist (1))
+         call scotchfstratexit (stradat (1))
 
-           global_start(1) = 1
-           do i=2,dminfo % nprocs
-              global_start(i) = global_start(i-1) + local_nvertices(i-1)
-              !call mpas_log_write('i: $i global_start= $i', intArgs=(/i, global_start(i)/))
-           end do
+         call mpas_log_write('post1 successful ')
 
-           !rewind(unit=iunit)
-           call mpas_log_write('Second read pass ')
 
-           do i=1,partial_global_graph_info % nVerticesTotal
-              !read(unit=iunit, fmt=*, iostat=err) global_block_id
-              !call mpas_get_owning_proc(dminfo, global_block_id, owning_proc)
-              global_block_id = global_block_id_arr(i)
-              owning_proc = owning_proc_arr(i)
-              global_list(global_start(owning_proc+1)) = i
-              !call mpas_log_write('owning_proc+1: $i global_start= $i global_list=$i', intArgs=(/owning_proc+1, global_start(owning_proc+1), global_list(global_start(owning_proc+1))/))
-              global_start(owning_proc+1) = global_start(owning_proc+1) + 1
-              !call mpas_log_write('global_start(owning_proc+1): $i', intArgs=(/global_start(owning_proc+1)/))
-           end do
-
-           global_start(1) = 0
-           do i=2,dminfo % nprocs
-              global_start(i) = global_start(i-1) + local_nvertices(i-1)
-              !call mpas_log_write('i: $i global_start= $i', intArgs=(/i, global_start(i)/))
-           end do
-         if (dminfo % my_proc_id == IO_NODE) then
-           call mpas_dmpar_bcast_ints(dminfo, dminfo % nprocs, local_nvertices)
-           allocate(local_cell_list(local_nvertices(dminfo % my_proc_id + 1)))
-           allocate(local_block_list(local_nvertices(dminfo % my_proc_id + 1)))
-
-           call mpas_dmpar_scatter_ints(dminfo, dminfo % nprocs, local_nvertices(dminfo % my_proc_id + 1), &
-                                   global_start, local_nvertices, global_list, local_cell_list)
-
-           ! Reset global start for second read of global_block_list
-           global_start(1) = 1
-           do i=2,dminfo % nprocs
-              global_start(i) = global_start(i-1) + local_nvertices(i-1)
-              !call mpas_log_write('i: $i global_start= $i', intArgs=(/i, global_start(i)/))
-           end do
-
-           !rewind(unit=iunit)
-           call mpas_log_write('Third read pass ')
-
-           do i=1,partial_global_graph_info % nVerticesTotal
-              !read(unit=iunit, fmt=*) global_block_id
-              !call mpas_get_owning_proc(dminfo, global_block_id, owning_proc)
-              global_block_id = global_block_id_arr(i)
-              owning_proc = owning_proc_arr(i)
-              global_list(global_start(owning_proc+1)) = global_block_id
-              !call mpas_log_write('owning_proc+1: $i global_start= $i global_list=$i', intArgs=(/owning_proc+1, global_start(owning_proc+1), global_list(global_start(owning_proc+1))/))
-              global_start(owning_proc+1) = global_start(owning_proc+1) + 1
-              !call mpas_log_write('global_start(owning_proc+1): $i', intArgs=(/global_start(owning_proc+1)/))
-           end do
-
-           ! Recompute global start after second read of global_block_list
-           global_start(1) = 0
-           do i=2,dminfo % nprocs
-              global_start(i) = global_start(i-1) + local_nvertices(i-1)
-              !call mpas_log_write('i: $i global_start= $i', intArgs=(/i, global_start(i)/))
-           end do
-
-           call mpas_dmpar_scatter_ints(dminfo, dminfo % nprocs, local_nvertices(dminfo % my_proc_id + 1), &
-                                   global_start, local_nvertices, global_list, local_block_list)
-
-           
-
-        else
-
-           call mpas_dmpar_bcast_ints(dminfo, dminfo % nprocs, local_nvertices)
-           allocate(local_cell_list(local_nvertices(dminfo % my_proc_id + 1)))
-           allocate(local_block_list(local_nvertices(dminfo % my_proc_id + 1)))
-
-           call mpas_dmpar_scatter_ints(dminfo, dminfo % nprocs, local_nvertices(dminfo % my_proc_id + 1), &
-                                   global_start, local_nvertices, global_list, local_cell_list)
-
-           call mpas_dmpar_scatter_ints(dminfo, dminfo % nprocs, local_nvertices(dminfo % my_proc_id + 1), &
-                                   global_start, local_nvertices, global_list, local_block_list)
-        end if
+         ! do i=1,partial_global_graph_info % nVertices         
+         !    call mpas_log_write('vert: $i, partloctab: $i', intArgs=(/i,local_block_id_arr(i)/) )
+         ! end do
 
         if(blocks_per_proc == 0) then
            no_blocks = .true.
@@ -333,7 +299,7 @@ module mpas_block_decomp
            block_start(1) = 0
            block_count(1) = 0
         else
-           allocate(sorted_local_cell_list(2, local_nvertices(dminfo % my_proc_id + 1)))
+           allocate(sorted_local_cell_list(2, vertlocnbr))
            allocate(block_id(blocks_per_proc))
            allocate(block_start(blocks_per_proc))
            allocate(block_count(blocks_per_proc))
@@ -343,7 +309,7 @@ module mpas_block_decomp
              block_count = 0
            end do
    
-           do i = 1,local_nvertices(dminfo % my_proc_id +1)
+           do i = 1,vertlocnbr
              call mpas_get_local_block_id(dminfo, local_block_list(i), local_block_id)
      
              block_id(local_block_id+1) = local_block_list(i)
@@ -354,9 +320,9 @@ module mpas_block_decomp
              block_count(local_block_id+1) = block_count(local_block_id+1) + 1
            end do
    
-           call mpas_quicksort(local_nvertices(dminfo % my_proc_id + 1), sorted_local_cell_list)
+           call mpas_quicksort(vertlocnbr, sorted_local_cell_list)
    
-           do i = 1, local_nvertices(dminfo % my_proc_id+1)
+           do i = 1, vertlocnbr
              local_cell_list(i) = sorted_local_cell_list(2, i)
            end do
    
@@ -371,6 +337,8 @@ module mpas_block_decomp
            deallocate(global_list)
         end if
       else
+      
+      call mpas_log_write('post2 successful ')
 
         if (dminfo % my_proc_id == IO_NODE) then
            allocate(local_cell_list(partial_global_graph_info % nVerticesTotal))
@@ -394,6 +362,8 @@ module mpas_block_decomp
            block_count(1) = 0
         end if
       end if
+
+      call mpas_log_write('mpas_block_decomp_cells_for_proc successful ')
 
       call mpas_timer_stop('mpas_block_decomp_cells_for_proc')
 

--- a/src/framework/mpas_block_decomp.F
+++ b/src/framework/mpas_block_decomp.F
@@ -78,7 +78,7 @@ module mpas_block_decomp
       integer, dimension(:), allocatable :: local_block_list
       integer, dimension(:,:), allocatable :: sorted_local_cell_list
 
-      integer, dimension(:), allocatable :: local_block_id_arr, owning_proc_arr
+      integer, dimension(:), allocatable ::global_block_id_arr, local_block_id_arr, owning_proc_arr
       integer :: i, global_block_id, local_block_id, owning_proc, iunit, ounit, istatus, ostatus, j, k
       integer :: blocks_per_proc, err, ierr
       integer, dimension(:), pointer :: local_nvertices
@@ -89,6 +89,7 @@ module mpas_block_decomp
       logical :: useScotch
 #ifdef MPAS_SCOTCH
       integer :: nLocEdgesGraph = 0, edgelocsiz = 0
+      character (len=StrKIND) :: partitionFilePrefix
       integer, dimension(:), allocatable :: edgeloctab, vertloctab
       doubleprecision :: stradat (scotch_stratdim)
       doubleprecision :: scotchgraph (scotch_graphdim)
@@ -118,6 +119,7 @@ module mpas_block_decomp
       if(dminfo % total_blocks > 1) then
         allocate(local_nvertices(dminfo % nprocs))
         allocate(global_start(dminfo % nprocs))
+        allocate(global_block_id_arr(partial_global_graph_info % nVerticesTotal))
         allocate(global_list(partial_global_graph_info % nVerticesTotal))
         allocate(local_block_id_arr(partial_global_graph_info % nVertices))
         allocate(owning_proc_arr(partial_global_graph_info % nVerticesTotal))
@@ -125,7 +127,7 @@ module mpas_block_decomp
         useScotch = .false.
        if (dminfo % my_proc_id == IO_NODE) then
          if ( trim(blockFilePrefix) == '' ) then
-            call mpas_log_write("Namelist option config_block_decomp_file_prefix is set to ''", MPAS_LOG_ERR)
+            call mpas_log_write("Namelist option config_block_decomp_file_prefix is set to ''", MPAS_LOG_WARN)
 #ifdef MPAS_SCOTCH
             useScotch = .true.
 #else
@@ -265,7 +267,7 @@ module mpas_block_decomp
          call mpas_log_write('Graph build successful ')
          ! Initialize the strategy data structure
          call scotchfstratinit (stradat (1), ierr)
-         call mpas_log_write('strategy init success')
+         call mpas_log_write('Scotch strategy init success')
          
          call mpas_timer_start('scotch_graph_partitioning')
          ! Partition the distributed graph and save the result in local_block_id_arr
@@ -319,14 +321,71 @@ module mpas_block_decomp
 
          allocate(local_cell_list(num_local_vertices))
          allocate(local_block_list(num_local_vertices))
-
          ! To look up all the local cells, we simply look at vlblloctab returned in indxtab
          ! NOTE: TODO: local_block_list might not be the same as proc_id when num blocks > 0?
          do i=1,num_local_vertices
             local_cell_list(i)=indxtab(vlbllocidx+i-1)
             local_block_list(i)=dminfo % my_proc_id
-            !call mpas_log_write('local_cell_list: $i, local_block_list: $i', intArgs=(/local_cell_list(i),local_block_list(i)/) )
+            !call mpas_log_write('local_cell_list: $i, local_block_list: $i',MPAS_LOG_ERR, intArgs=(/local_cell_list(i),local_block_list(i)/) )
          end do
+
+         !call mpas_log_write('nVertices $i  num_local_vertices: $i',MPAS_LOG_ERR, intArgs=(/partial_global_graph_info % nVertices,num_local_vertices/))
+         ! do i=1,partial_global_graph_info % nVertices
+         !    call mpas_log_write('local_block_id_arr($i): $i',MPAS_LOG_ERR, intArgs=(/i,local_block_id_arr(i)/))
+         ! end do
+
+         ! Using the local_nvertices array to hold the original number of vertices in
+         ! the partial graph readb by each processor. Might need to use a different array
+         ! to clear up potential confusion.
+         local_nvertices(dminfo % my_proc_id + 1) = partial_global_graph_info % nVertices
+
+         ! call mpas_log_write('local_nvertices($i): $i', MPAS_LOG_ERR, intArgs=(/i,num_local_vertices/))
+
+         ! Gather all the partial_global_graph_info % nVertices to IO_NODE. 
+         ! num_local_vertices is the number of vertices that this processor owns, determined by the
+         ! Scotch paritioning. Whereas artial_global_graph_info % nVertices is the number of vertices
+         ! resident in the partial graph read by this processor. The latter is the correct size of the
+         ! local_block_id_arr. 
+         call MPI_Gather( partial_global_graph_info % nVertices, 1, MPI_INTEGER, local_nvertices, &
+                              1, MPI_INTEGER, 0, localcomm, ierr)
+
+         ! if (dminfo % my_proc_id == IO_NODE) then
+         !    call mpas_log_write('After gathering local_nvertices on IO_NODE: ')
+         !    do i=1, dminfo % nProcs
+         !       call mpas_log_write('local_nvertices: $i', intArgs=(/local_nvertices(i)/) )
+         !    end do
+         ! end if
+         
+         ! Compute the displacements for gathering all the local_block_id_arr to global_block_id_arr
+         global_start(1) = 0
+           do i=2,dminfo % nprocs
+              global_start(i) = global_start(i-1) + local_nvertices(i-1)
+         end do
+         ! do i=1, dminfo % nProcs
+         !       call mpas_log_write('global_start: $i', intArgs=(/global_start(i)/) )
+         ! end do
+
+         ! Gather all the local block ids to global_block_id_arr so IO_NODE can write out the partitioning data
+         call MPI_Gatherv( local_block_id_arr, partial_global_graph_info % nVertices, MPI_INTEGER, global_block_id_arr, &
+                                 local_nvertices, global_start, MPI_INTEGER, 0, localcomm, ierr)
+         ! Write out the paritioning data to a file from IO_NODE
+         if (dminfo % my_proc_id == IO_NODE) then
+            partitionFilePrefix=trim(blockFilePrefix)
+            if (trim(partitionFilePrefix) == '') then
+               write(partitionFilePrefix,'(a,i0,a)') 'x1.',partial_global_graph_info%nVerticesTotal,'.graph.info.part.'
+            end if
+            write(filename,'(a,i0)') trim(partitionFilePrefix), dminfo % total_blocks
+            
+            call mpas_log_write('Writing out Scotch Graph paritioning data to '//trim(filename))
+            call mpas_new_unit(ounit)
+            open(unit=ounit, file=trim(filename), form='formatted', status='new', action="write", iostat=ostatus)
+            do i=1,partial_global_graph_info % nVerticesTotal
+               write(unit=ounit, fmt='(i0)', iostat=err) global_block_id_arr(i)
+               !write(unit=ounit, fmt='(*(i0,1x))', iostat=err) global_block_id_arr(i)
+            end do
+            close(unit=ounit)
+            call mpas_release_unit(ounit)
+         end if
 
          ! Clean up
          call scotchfdgraphexit (scotchdgraph (1))

--- a/src/framework/mpas_block_decomp.F
+++ b/src/framework/mpas_block_decomp.F
@@ -25,9 +25,8 @@ module mpas_block_decomp
    use mpas_derived_types
    use mpas_io_units
    use mpas_log
-   
+
 #include "ptscotchf.h"
-!!#include "scotchf.h"
 
    type graph
       integer :: nVerticesTotal
@@ -54,7 +53,7 @@ module mpas_block_decomp
    subroutine mpas_block_decomp_cells_for_proc(dminfo, partial_global_graph_info, local_cell_list, block_id, block_start, &
                                                block_count, numBlocks, explicitProcDecomp, blockFilePrefix, procFilePrefix)!{{{
 
-      use mpas_timer, only : mpas_timer_start, mpas_timer_stop, mpas_timer_write, mpas_timer_write_header
+      use mpas_timer, only : mpas_timer_start, mpas_timer_stop
       use mpi
 
       implicit none
@@ -77,18 +76,16 @@ module mpas_block_decomp
       integer, dimension(:), allocatable :: local_block_list
       integer, dimension(:,:), allocatable :: sorted_local_cell_list
 
-      integer, dimension(:), allocatable :: global_block_id_arr, local_block_id_arr, owning_proc_arr
+      integer, dimension(:), allocatable :: local_block_id_arr, owning_proc_arr
       integer :: i, global_block_id, local_block_id, owning_proc, iunit, ounit, istatus, ostatus, j, k
       integer :: blocks_per_proc, err, ierr
       integer, dimension(:), pointer :: local_nvertices
       character (len=StrKIND) :: filename, msg
 
       logical :: no_blocks
-      integer :: nTotalEdgesGraph = 0, nLocEdgesGraph = 0, edgelocsiz = 0
-      integer, dimension(:), allocatable :: edgetab, verttab, parttab
-
       logical :: useScotch
-
+      integer :: nLocEdgesGraph = 0, edgelocsiz = 0
+      integer, dimension(:), allocatable :: edgetab, verttab, parttab
       doubleprecision :: stradat (scotch_stratdim)
       doubleprecision :: scotchgraph (scotch_graphdim)
       doubleprecision :: scotchdgraph (SCOTCH_DGRAPHDIM)
@@ -97,8 +94,6 @@ module mpas_block_decomp
       integer, dimension(:), allocatable :: indxtab
       integer :: vertglbnbr, vertlocnbr, vertlocmax, vertgstnbr, vertlocidx, vendlocidx, velolocidx, vlbllocidx
       integer :: edgeglbnbr, edgelocnbr, edgelocidx, edgegstidx, edlolocidx, comm, baseval
-
-
 
       no_blocks = .false.
 
@@ -119,7 +114,6 @@ module mpas_block_decomp
         allocate(local_nvertices(dminfo % nprocs))
         allocate(global_start(dminfo % nprocs))
         allocate(global_list(partial_global_graph_info % nVerticesTotal))
-        !allocate(global_block_id_arr(partial_global_graph_info % nVerticesTotal))
         allocate(local_block_id_arr(partial_global_graph_info % nVertices))
         allocate(owning_proc_arr(partial_global_graph_info % nVerticesTotal))
  
@@ -131,7 +125,7 @@ module mpas_block_decomp
                
                if (partial_global_graph_info % adjacencyList(j,i) == 0) cycle
                nLocEdgesGraph = nLocEdgesGraph + 1
-               !nTotalEdgesGraph = nTotalEdgesGraph + nEdgesOnCellFull% array(i)
+               
 
                ! do j=1,partial_global_graph_info % nAdjacent(i)
                !    call mpas_log_write('i=$i j=$i adj= $i', intArgs=(/i,j,partial_global_graph_info % adjacencyList(j,i)/) )
@@ -139,10 +133,7 @@ module mpas_block_decomp
             end do
          end do
          
-         call mpas_dmpar_sum_int(dminfo, nLocEdgesGraph, nTotalEdgesGraph)
-         
          call mpas_log_write('nLocEdgesGraph is $i', intArgs=(/nLocEdgesGraph/))
-         call mpas_log_write('nTotalEdgesGraph is $i', intArgs=(/nTotalEdgesGraph/))
          allocate(edgetab(nLocEdgesGraph))
          allocate(verttab(partial_global_graph_info % nVertices + 1))
          !allocate(parttab(partial_global_graph_info % nVerticesTotal))
@@ -175,7 +166,7 @@ module mpas_block_decomp
                   call mpas_log_write('Cannot duplicate communicator')
             endif
             call mpas_log_write('duplicate communicator is $i', intArgs=(/localcomm/) )
-            call mpas_log_write('dminfo communicator is $i', intArgs=(/dminfo % comm/) )
+            !call mpas_log_write('dminfo communicator is $i', intArgs=(/dminfo % comm/) )
             call scotchfdgraphinit(scotchdgraph(1),  localcomm, ierr)
             call scotchfdgraphinit(scotchdgraph_redist(1),  localcomm, ierr)
             if (ierr .ne. 0) then
@@ -208,26 +199,12 @@ module mpas_block_decomp
             endif
             call mpas_log_write('Graph build successful ')
 
-            
-
             call scotchfstratinit (stradat (1), ierr)
             call mpas_log_write('After strat init successful ')
-
-            ! CALL scotchfgraphbuild (scotchgraph (1), 1, partial_global_graph_info % nVerticesTotal, &
-            !                         verttab (1), verttab (2), &
-            !                         verttab (1), verttab (1), &
-            !                         nTotalEdgesGraph, edgetab (1), edgetab (1), ierr)
-            
-
-         ! if (dminfo % my_proc_id == IO_NODE) then
-         !    call scotchfdgraphscatter (scotchdgraph(1), scotchgraph(1) , ierr)
-         ! else 
-         !    call scotchfdgraphscatter (scotchdgraph(1), scotchdgraph(1) , ierr)
          ! end if
          call mpas_timer_start('scotch_part')
          call scotchfdgraphpart (scotchdgraph(1), dminfo % nProcs, stradat (1), local_block_id_arr(1), ierr)
          !call scotchfdgraphpart (scotchdgraph(1), dminfo % total_blocks, stradat (1), local_block_id_arr(1), ierr)
-         !call scotchfdgraphpart(scotchgraph (1), dminfo % total_blocks, stradat (1) ,global_block_id_arr(1),  IERR)
          call mpas_log_write('Graph parition successful ')
 
          call scotchfdgraphredist(scotchdgraph(1), local_block_id_arr(1),scotchdgraph(1), -1 ,-1, scotchdgraph_redist(1), ierr)
@@ -250,12 +227,6 @@ module mpas_block_decomp
          ! do i=1,vertlocnbr
          !    call mpas_log_write('i: $i, vlbllocidx: $i', intArgs=(/i,indxtab(vlbllocidx+i-1)/) )
          ! end do
-
-         !call MPI_Scatterv(inlist, counts, displs, MPI_INTEGERKIND, outlist, noutlist, MPI_INTEGERKIND, IO_NODE, dminfo % comm, mpi_ierr)
-         !call MPI_Gatherv( local_block_id_arr, partial_global_graph_info % nVertices, MPI_INTEGERKIND, rbuf, rcounts, displs, MPI_INTEGERKIND, IO_NODE, dminfo % comm, mpi_ierr)
-
-
-
          call mpas_timer_stop('scotch_part')
          call mpas_timer_stop('scotch')
          ! call mpas_timer_stop('mpas_block_decomp_cells_for_proc')
@@ -277,7 +248,6 @@ module mpas_block_decomp
          call scotchfdgraphexit (scotchdgraph (1))
          call scotchfdgraphexit (scotchdgraph_redist (1))
          call scotchfstratexit (stradat (1))
-
          call mpas_log_write('post1 successful ')
 
 
@@ -337,8 +307,6 @@ module mpas_block_decomp
            deallocate(global_list)
         end if
       else
-      
-      call mpas_log_write('post2 successful ')
 
         if (dminfo % my_proc_id == IO_NODE) then
            allocate(local_cell_list(partial_global_graph_info % nVerticesTotal))
@@ -362,7 +330,6 @@ module mpas_block_decomp
            block_count(1) = 0
         end if
       end if
-
       call mpas_log_write('mpas_block_decomp_cells_for_proc successful ')
 
       call mpas_timer_stop('mpas_block_decomp_cells_for_proc')

--- a/src/framework/mpas_block_decomp.F
+++ b/src/framework/mpas_block_decomp.F
@@ -26,9 +26,9 @@ module mpas_block_decomp
    use mpas_io_units
    use mpas_log
    
-   #ifdef MPAS_SCOTCH
-   include "scotchf.h"
-   #endif
+#ifdef MPAS_SCOTCH
+#include "scotchf.h"
+#endif
 
    type graph
       integer :: nVerticesTotal
@@ -116,7 +116,7 @@ module mpas_block_decomp
         if (dminfo % my_proc_id == IO_NODE) then
          useScotch = .false.
          if ( trim(blockFilePrefix) == '' ) then
-            call mpas_log_write('Namelist option config_block_decomp_file_prefix is set to \'\' ', MPAS_LOG_ERR)
+            call mpas_log_write("Namelist option config_block_decomp_file_prefix is set to ''", MPAS_LOG_ERR)
 #ifdef MPAS_SCOTCH
             useScotch = .true.
 #else
@@ -242,7 +242,7 @@ module mpas_block_decomp
                   close(unit=ounit)
                   call mpas_release_unit(ounit)
                end if
-  #endif
+#endif
            else
 
                call mpas_log_write('Using block decomposition file: '//trim(filename))

--- a/src/framework/mpas_block_decomp.F
+++ b/src/framework/mpas_block_decomp.F
@@ -89,7 +89,7 @@ module mpas_block_decomp
       logical :: useScotch
 #ifdef MPAS_SCOTCH
       integer :: nLocEdgesGraph = 0, edgelocsiz = 0
-      integer, dimension(:), allocatable :: edgetab, verttab, parttab
+      integer, dimension(:), allocatable :: edgeloctab, vertloctab
       doubleprecision :: stradat (scotch_stratdim)
       doubleprecision :: scotchgraph (scotch_graphdim)
       doubleprecision :: scotchdgraph (SCOTCH_DGRAPHDIM)
@@ -169,102 +169,147 @@ module mpas_block_decomp
 
       if (useScotch) then ! Using PT-Scotch across all MPI ranks
 #ifdef MPAS_SCOTCH
-         call mpas_timer_start('scotch')
+         call mpas_timer_start('scotch_total')
 
          call mpas_log_write('Using LibScotch for graph partitioning')
+
+         ! Count the number of edges (including to ghost cells) in the portion of graph
+         ! owned by the current rank. Each edge is counted twice, once for each vertex,
+         ! with the exception of edges to ghost vertices, which are counted only once.
          do i=1,partial_global_graph_info % nVertices
             do j=1,partial_global_graph_info % nAdjacent(i)
-               
                if (partial_global_graph_info % adjacencyList(j,i) == 0) cycle
                nLocEdgesGraph = nLocEdgesGraph + 1
-               ! do j=1,partial_global_graph_info % nAdjacent(i)
-               !    call mpas_log_write('i=$i j=$i adj= $i', intArgs=(/i,j,partial_global_graph_info % adjacencyList(j,i)/) )
-               ! end do
+               ! call mpas_log_write('i=$i j=$i adj= $i', intArgs=(/i,j,partial_global_graph_info % adjacencyList(j,i)/) )
             end do
          end do
          call mpas_log_write('nLocEdgesGraph is $i', intArgs=(/nLocEdgesGraph/))
-         allocate(edgetab(nLocEdgesGraph))
-         allocate(verttab(partial_global_graph_info % nVertices + 1))
-         !allocate(parttab(partial_global_graph_info % nVerticesTotal))
 
+         ! Holds the adjacency array for every local vertex
+         allocate(edgeloctab(nLocEdgesGraph))
+         ! Array of start indices in edgeloctab for each local vertex
+         allocate(vertloctab(partial_global_graph_info % nVertices + 1))
+         
          ! do i=1,partial_global_graph_info % nVertices
-         !    !call mpas_log_write('proc=$i  i= $i part= $i', intArgs=(/dminfo % my_proc_id, i,parttab(i)/))
          !    call mpas_log_write('i=$i j=$i adj= $i', intArgs=(/i,j,partial_global_graph_info % adjacencyList(j,i)/) )
          ! end do 
 
-            k = 1
-            do i=1,partial_global_graph_info % nVertices
-               verttab(i) = k 
-               !call mpas_log_write('i=$i verttab= $i', intArgs=(/i,verttab(i)/) )
-               !call mpas_log_write('i=$i vertexID= $i', intArgs=(/i,partial_global_graph_info % vertexID(i)/) )
-               do j=1,partial_global_graph_info % nAdjacent(i)
-                  
-                  if (partial_global_graph_info % adjacencyList(j,i) == 0) cycle
+         ! Fill up edgeloctab and vertloctab
+         k = 1
+         do i=1,partial_global_graph_info % nVertices
+            vertloctab(i) = k 
+            !call mpas_log_write('i=$i vertloctab= $i', intArgs=(/i,vertloctab(i)/) )
+            !call mpas_log_write('i=$i vertexID= $i', intArgs=(/i,partial_global_graph_info % vertexID(i)/) )
+            do j=1,partial_global_graph_info % nAdjacent(i)
+               
+               if (partial_global_graph_info % adjacencyList(j,i) == 0) cycle
 
-                  edgetab(k) = partial_global_graph_info % adjacencyList(j,i)
-                  !call mpas_log_write('k=$i edgetab= $i', intArgs=(/k,edgetab(k)/) )
-                  k = k + 1
-               end do
-            end do 
-            verttab(partial_global_graph_info % nVertices+1) = nLocEdgesGraph + 1
-   
-            call mpas_log_write('nvertices =$i  nLocEdgesGraph= $i', intArgs=(/partial_global_graph_info % nVertices, nLocEdgesGraph/))
+               edgeloctab(k) = partial_global_graph_info % adjacencyList(j,i)
+               !call mpas_log_write('k=$i edgeloctab= $i', intArgs=(/k,edgeloctab(k)/) )
+               k = k + 1
+            end do
+         end do 
+         vertloctab(partial_global_graph_info % nVertices+1) = nLocEdgesGraph + 1
 
-            call MPI_Comm_dup(MPI_COMM_WORLD, localcomm, mpi_ierr)
-            if (mpi_ierr .ne. 0) then
-                  call mpas_log_write('Cannot duplicate communicator')
-            endif
-            call mpas_log_write('duplicate communicator is $i', intArgs=(/localcomm/) )
-            !call mpas_log_write('dminfo communicator is $i', intArgs=(/dminfo % comm/) )
-            call scotchfdgraphinit(scotchdgraph(1),  localcomm, ierr)
-            call scotchfdgraphinit(scotchdgraph_redist(1),  localcomm, ierr)
-            if (ierr .ne. 0) then
-                  call mpas_log_write('Cannot initialize D Scotch Graph', MPAS_LOG_CRIT)
-            endif
+         call mpas_log_write('nvertices =$i  nLocEdgesGraph= $i', intArgs=(/partial_global_graph_info % nVertices, nLocEdgesGraph/))
 
-            edgelocsiz = maxval(verttab) - 1
+         ! Duplicate the communicator to be used by Scotch
+         call MPI_Comm_dup(MPI_COMM_WORLD, localcomm, mpi_ierr)
+         if (mpi_ierr .ne. 0) then
+               call mpas_log_write('Cannot duplicate communicator')
+         endif
+         call mpas_log_write('duplicate communicator is $i', intArgs=(/localcomm/) )
+         
+         ! Initialize the Scotch graph data structure, and an extra one to hold the re-distributed graph
+         call scotchfdgraphinit(scotchdgraph(1),  localcomm, ierr)
+         if (ierr .ne. 0) then
+               call mpas_log_write('Cannot initialize D Scotch Graph', MPAS_LOG_CRIT)
+         endif
+         call scotchfdgraphinit(scotchdgraph_redist(1),  localcomm, ierr)
 
-            call scotchfdgraphbuild (scotchdgraph(1), &
-                                     1, &
-                                     partial_global_graph_info % nVertices, &
-                                     partial_global_graph_info % nVertices, & ! vertlocmax
-                                     verttab (1), & ! vertloctab
-                                     verttab (2), & ! 
-                                     verttab (1), &
-                                     verttab (1), &
-                                     nLocEdgesGraph, &
-                                     edgelocsiz, &
-                                     edgetab(1), &
-                                     edgetab(1), &
-                                     edgetab(1), ierr)
+         ! From Scotch documentation: edgelocsiz is lower-bounded by the minimum size 
+         ! of the edge array required to encompass all used adjacency values; it is 
+         ! therefore at least equal to the maximum of the vendloctab entries, over all 
+         ! local vertices, minus baseval; it can be set to edgelocnbr if the edge array is compact.
+         edgelocsiz = maxval(vertloctab) - 1
 
-            if (ierr .ne. 0) then
-               call mpas_log_write('Cannot build Scotch Graph', MPAS_LOG_CRIT)
-            endif
-            
-            ! Only needed during development/debugging. 
-            call scotchfdgraphcheck (scotchdgraph(1), ierr)
-            if (ierr .ne. 0) then
-               call mpas_log_write(' Scotch Graph check not successfull', MPAS_LOG_CRIT)
-            endif
-            call mpas_log_write('Graph build successful ')
+         ! Build the distributed Scotch graph and save it in scotchdgraph
+         ! Note: Optional arguments veloloctab, vlblloctab, edgegsttab, and edloloctab are not needed here.
+         ! Scotch Fortran interface requires that if veloloctab, vlblloctab are skipped, then we pass a reference
+         ! to vertloctab(1) so that they are treated as null pointers. Similarly, pass reference to edgeloctab for
+         ! the optional edgegsttab and edloloctab arguments.
+         call scotchfdgraphbuild (scotchdgraph(1), &
+                           1, & ! base value value for index arrays (1 in Fortran)
+                           partial_global_graph_info % nVertices, & ! num of local vertices on the calling process
+                           partial_global_graph_info % nVertices, & ! max number of local vertices = num_local_vertices for graphs without holes
+                           vertloctab (1), & ! Array of start indices in edgeloctab for each local vertex
+                           vertloctab (2), & ! vendloctab: Array of after-last indices in edgeloctab
+                           vertloctab (1), & ! veloloctab: Optional array of integer loads for each local vertex
+                           vertloctab (1), & ! vlblloctab: Optional array of labels for each local vertex
+                           nLocEdgesGraph, & ! Number of local edges, including to ghost vertices
+                           edgelocsiz, & ! Defined previously
+                           edgeloctab(1), & ! Holds the adjacency array for every local vertex
+                           edgeloctab(1), & ! edgegsttab: Optional array holding the local and ghost indices
+                           edgeloctab(1), & ! edloloctab: Optional array of integer loads for each local edge
+                           ierr)
 
-            call scotchfstratinit (stradat (1), ierr)
-            call mpas_log_write('After strat init successful ')
-         ! end if
-         call mpas_timer_start('scotch_part')
+         if (ierr .ne. 0) then
+            call mpas_log_write('Cannot build Scotch Graph', MPAS_LOG_CRIT)
+         endif
+         
+         ! Only needed during development/debugging. 
+         call scotchfdgraphcheck (scotchdgraph(1), ierr)
+         if (ierr .ne. 0) then
+            call mpas_log_write(' Scotch Graph check not successfull', MPAS_LOG_CRIT)
+         endif
+         call mpas_log_write('Graph build successful ')
+         ! Initialize the strategy data structure
+         call scotchfstratinit (stradat (1), ierr)
+         call mpas_log_write('strategy init success')
+         
+         call mpas_timer_start('scotch_graph_partitioning')
+         ! Partition the distributed graph and save the result in local_block_id_arr
          call scotchfdgraphpart (scotchdgraph(1), dminfo % nProcs, stradat (1), local_block_id_arr(1), ierr)
-         !call scotchfdgraphpart (scotchdgraph(1), dminfo % total_blocks, stradat (1), local_block_id_arr(1), ierr)
-         call mpas_timer_stop('scotch_part')
+         call mpas_timer_stop('scotch_graph_partitioning')
          call mpas_log_write('Graph parition successful ')
 
-         call scotchfdgraphredist(scotchdgraph(1), local_block_id_arr(1),scotchdgraph(1), -1 ,-1, scotchdgraph_redist(1), ierr)
+         ! After the paritioning above, each processor would not necessarily have information about all of the
+         ! vertices it owns. To obtain this information, Scotch provides a convenience function to redistribute the graph
+         ! to all processors, so that each processor has information about all of the vertices it owns.
+         call scotchfdgraphredist(scotchdgraph(1), & ! Input: original distributed graph
+                                  local_block_id_arr(1), & ! Input: the partition array
+                                  scotchdgraph(1), & ! Optional: permgsttab. Pass ref to original graph to skip it.
+                                   -1 , & ! Optional: vertlocdlt. Pass <0 to skip it.
+                                   -1,  & ! Optional: edgelocdlt. Pass <0 to skip it.
+                                  scotchdgraph_redist(1), & ! Output: re-distributed graph
+                                  ierr)
          call mpas_log_write('Graph redist successful ')
 
+         ! indxtab holds the graph data returned by the call to scotchfdgraphdata
+         ! Not sure how large indxtab needs to be, so currently allocating it to be
+         ! 5 times the number of local vertices
          allocate(indxtab(5*partial_global_graph_info % nVertices))
-         call scotchfdgraphdata(scotchdgraph_redist(1), indxtab(1), baseval, vertglbnbr, num_local_vertices, vertlocmax, vertgstnbr, &
-                                vertlocidx, vendlocidx, velolocidx, vlbllocidx, edgeglbnbr, edgelocnbr, &
-                                 edgelocsiz, edgelocidx, edgegstidx, edlolocidx, comm, ierr )
+
+         ! Input to scotchfdgraphdata is the re-distributed graph scotchdgraph_redist, and all
+         ! the remaining are output arguments.
+         call scotchfdgraphdata(scotchdgraph_redist(1), &
+                           indxtab(1), & ! Holds the data queried from graph, local to this processor
+                           baseval, &  ! returns base value value for index arrays (1 in Fortran)
+                           vertglbnbr, & ! number of global vertices
+                           num_local_vertices, & ! number of local vertices
+                           vertlocmax, & ! max number of local vertices = num_local_vertices for graphs without holes
+                           vertgstnbr, & ! num of local and ghost vertices. -1 unless dgraphGhst is called
+                           vertlocidx, & ! starting index of vertloctab in indxtab
+                           vendlocidx, & ! starting index of vendloctab in indxtab
+                           velolocidx, & ! starting index of veloloctab in indxtab
+                           vlbllocidx, & ! starting index of vlblloctab in indxtab
+                           edgeglbnbr, & ! Global number of arcs. Each edge counts twice.
+                           edgelocnbr, & ! Local number of arcs including to ghost vertices
+                           edgelocsiz, & ! ~ max of vendloctab entries, for local vertices, minus baseval
+                           edgelocidx, & ! starting index of edgeloctab in indxtab 
+                           edgegstidx, & ! starting index of edgegsttab in indxtab
+                           edlolocidx, & ! starting index of edloloctab in indxtab
+                           comm, ierr ) ! communicator used and error code
 
          call mpas_log_write('vertlocnbr $i vertlocidx $i ', intArgs=(/num_local_vertices,vertlocidx/) )
          call mpas_log_write('vertgstnbr $i vertlocmax $i ', intArgs=(/vertgstnbr,vertlocmax/) )
@@ -272,36 +317,27 @@ module mpas_block_decomp
          call mpas_log_write('edgegstidx $i edlolocidx $i ', intArgs=(/edgegstidx,edlolocidx/) )
          call mpas_log_write('vertglbnbr $i ierr $i ', intArgs=(/vertglbnbr,ierr/) )
 
-         ! do i=1,num_local_vertices
-         !    call mpas_log_write('i: $i, vertlocidx: $i', intArgs=(/i,indxtab(vertlocidx+i-1)/) )
-         ! end do
-         ! do i=1,num_local_vertices
-         !    call mpas_log_write('i: $i, vlbllocidx: $i', intArgs=(/i,indxtab(vlbllocidx+i-1)/) )
-         ! end do
-         
-         
-         ! call mpas_timer_stop('mpas_block_decomp_cells_for_proc')
-         ! call mpas_timer_stop('bootstrap_framework_phase1')
-         ! call mpas_timer_stop('initialize')
-         ! call mpas_timer_stop('total time')
-         !call mpas_timer_write_header()
-         !call mpas_timer_write()
-
          allocate(local_cell_list(num_local_vertices))
          allocate(local_block_list(num_local_vertices))
 
+         ! To look up all the local cells, we simply look at vlblloctab returned in indxtab
+         ! NOTE: TODO: local_block_list might not be the same as proc_id when num blocks > 0?
          do i=1,num_local_vertices
             local_cell_list(i)=indxtab(vlbllocidx+i-1)
             local_block_list(i)=dminfo % my_proc_id
             !call mpas_log_write('local_cell_list: $i, local_block_list: $i', intArgs=(/local_cell_list(i),local_block_list(i)/) )
          end do
 
-         ! Calling scotchfdgraphexit 
+         ! Clean up
          call scotchfdgraphexit (scotchdgraph (1))
          call scotchfdgraphexit (scotchdgraph_redist (1))
          call scotchfstratexit (stradat (1))
-         call mpas_timer_stop('scotch')
-         call mpas_log_write('Scotch parition successful ')
+         deallocate(edgeloctab)
+         deallocate(vertloctab)
+         deallocate(indxtab)
+         call MPI_Comm_free(localcomm, mpi_ierr)
+         call mpas_timer_stop('scotch_total')
+         call mpas_log_write('Scotch partition successful')
 #endif
       else  ! useScotch = .false.
          if (dminfo % my_proc_id == IO_NODE) then

--- a/src/framework/mpas_bootstrapping.F
+++ b/src/framework/mpas_bootstrapping.F
@@ -107,8 +107,8 @@ module mpas_bootstrapping
       type (field1dInteger), pointer :: indexToCellIDField
       type (field1dInteger), pointer :: indexToEdgeIDField
       type (field1dInteger), pointer :: indexToVertexIDField
-      type (field1dInteger), pointer :: nEdgesOnCellField, nEdgesOnCellFull
-      type (field2dInteger), pointer :: cellsOnCellField, cellsOnCellFull
+      type (field1dInteger), pointer :: nEdgesOnCellField
+      type (field2dInteger), pointer :: cellsOnCellField
       type (field2dInteger), pointer :: edgesOnCellField
       type (field2dInteger), pointer :: verticesOnCellField
       type (field2dInteger), pointer :: cellsOnEdgeField
@@ -145,7 +145,7 @@ module mpas_bootstrapping
       integer, pointer :: config_num_halos, config_number_of_blocks
       logical, pointer :: config_explicit_proc_decomp
       character (len=StrKIND), pointer :: config_block_decomp_file_prefix, config_proc_decomp_file_prefix
-      integer :: nHalos, j, vind
+      integer :: nHalos
 
 
       call mpas_pool_get_config(domain % configs, 'config_num_halos', config_num_halos)
@@ -431,7 +431,6 @@ module mpas_bootstrapping
       deallocate(block_start)
       deallocate(block_count)
       deallocate(readingBlock)
-
 
       call mpas_timer_stop('bootstrap_framework_phase1')
 

--- a/src/framework/mpas_bootstrapping.F
+++ b/src/framework/mpas_bootstrapping.F
@@ -199,16 +199,6 @@ module mpas_bootstrapping
       !   which cells/edges/vertices are owned by each block, and which are ghost
       !
 
-      allocate(cellsOnCellFull)
-      allocate(cellsOnCellFull % array(maxEdges,nCells))
-      call MPAS_io_inq_var(inputHandle, 'cellsOnCell', ierr=ierr)
-      call mpas_io_get_var(inputHandle, 'cellsOnCell', cellsOnCellFull % array, ierr)
-
-      allocate(nEdgesOnCellFull)
-      allocate(nEdgesOnCellFull % array(nCells))
-      call MPAS_io_inq_var(inputHandle, 'nEdgesOnCell', ierr=ierr)
-      call mpas_io_get_var(inputHandle, 'nEdgesOnCell', nEdgesOnCellFull % array, ierr)
-
       call mpas_io_setup_cell_block_fields(inputHandle, nreadCells, readCellStart, readingBlock, maxEdges, &
                                            indexTocellIDField, xCellField, yCellField, zCellField, nEdgesOnCellField, &
                                            cellsOnCellField, edgesOnCellField, verticesOnCellField, nHalos)

--- a/src/framework/mpas_bootstrapping.F
+++ b/src/framework/mpas_bootstrapping.F
@@ -106,8 +106,8 @@ module mpas_bootstrapping
       type (field1dInteger), pointer :: indexToCellIDField
       type (field1dInteger), pointer :: indexToEdgeIDField
       type (field1dInteger), pointer :: indexToVertexIDField
-      type (field1dInteger), pointer :: nEdgesOnCellField
-      type (field2dInteger), pointer :: cellsOnCellField
+      type (field1dInteger), pointer :: nEdgesOnCellField, nEdgesOnCellFull
+      type (field2dInteger), pointer :: cellsOnCellField, cellsOnCellFull
       type (field2dInteger), pointer :: edgesOnCellField
       type (field2dInteger), pointer :: verticesOnCellField
       type (field2dInteger), pointer :: cellsOnEdgeField
@@ -144,7 +144,7 @@ module mpas_bootstrapping
       integer, pointer :: config_num_halos, config_number_of_blocks
       logical, pointer :: config_explicit_proc_decomp
       character (len=StrKIND), pointer :: config_block_decomp_file_prefix, config_proc_decomp_file_prefix
-      integer :: nHalos
+      integer :: nHalos, j, vind
 
 
       call mpas_pool_get_config(domain % configs, 'config_num_halos', config_num_halos)
@@ -197,6 +197,16 @@ module mpas_bootstrapping
       !   which cells/edges/vertices are owned by each block, and which are ghost
       !
 
+      allocate(cellsOnCellFull)
+      allocate(cellsOnCellFull % array(maxEdges,nCells))
+      call MPAS_io_inq_var(inputHandle, 'cellsOnCell', ierr=ierr)
+      call mpas_io_get_var(inputHandle, 'cellsOnCell', cellsOnCellFull % array, ierr)
+
+      allocate(nEdgesOnCellFull)
+      allocate(nEdgesOnCellFull % array(nCells))
+      call MPAS_io_inq_var(inputHandle, 'nEdgesOnCell', ierr=ierr)
+      call mpas_io_get_var(inputHandle, 'nEdgesOnCell', nEdgesOnCellFull % array, ierr)
+
       call mpas_io_setup_cell_block_fields(inputHandle, nreadCells, readCellStart, readingBlock, maxEdges, &
                                            indexTocellIDField, xCellField, yCellField, zCellField, nEdgesOnCellField, &
                                            cellsOnCellField, edgesOnCellField, verticesOnCellField, nHalos)
@@ -235,7 +245,7 @@ module mpas_bootstrapping
       !    file, but in principle it could call some online, distributed mesh partitioning library.
       !
       call mpas_block_decomp_cells_for_proc(domain % dminfo, partial_global_graph_info, local_cell_list, block_id, block_start, &
-                                            block_count, config_number_of_blocks, config_explicit_proc_decomp, &
+                                            block_count, cellsOnCellFull, nEdgesOnCellFull, config_number_of_blocks, config_explicit_proc_decomp, &
                                             config_block_decomp_file_prefix, config_proc_decomp_file_prefix)
 
       deallocate(partial_global_graph_info % vertexID)

--- a/src/framework/mpas_bootstrapping.F
+++ b/src/framework/mpas_bootstrapping.F
@@ -247,7 +247,7 @@ module mpas_bootstrapping
       !    file, but in principle it could call some online, distributed mesh partitioning library.
       !
       call mpas_block_decomp_cells_for_proc(domain % dminfo, partial_global_graph_info, local_cell_list, block_id, block_start, &
-                                            block_count, cellsOnCellFull, nEdgesOnCellFull, config_number_of_blocks, config_explicit_proc_decomp, &
+                                            block_count, config_number_of_blocks, config_explicit_proc_decomp, &
                                             config_block_decomp_file_prefix, config_proc_decomp_file_prefix)
 
       deallocate(partial_global_graph_info % vertexID)

--- a/src/framework/mpas_bootstrapping.F
+++ b/src/framework/mpas_bootstrapping.F
@@ -81,6 +81,7 @@ module mpas_bootstrapping
 #ifdef MPAS_PIO_SUPPORT
       use pio, only : file_desc_t
 #endif
+      use mpas_timer, only : mpas_timer_start, mpas_timer_stop
 
       implicit none
 
@@ -155,6 +156,7 @@ module mpas_bootstrapping
 
       nHalos = config_num_halos
 
+      call mpas_timer_start('bootstrap_framework_phase1')
 
       inputHandle = MPAS_io_open(trim(mesh_filename), MPAS_IO_READ, mesh_iotype, domain % ioContext, &
                                  pio_file_desc=pio_file_desc, ierr=ierr)
@@ -439,6 +441,9 @@ module mpas_bootstrapping
       deallocate(block_start)
       deallocate(block_count)
       deallocate(readingBlock)
+
+
+      call mpas_timer_stop('bootstrap_framework_phase1')
 
    end subroutine mpas_bootstrap_framework_phase1 !}}}
 


### PR DESCRIPTION
This PR enables the use of MPAS atmosphere core without requiring any graph decomposition files specified as input, if the atmosphere core has been built with the Scotch graph partitioning library (built separately). 


### Building MPAS with Scotch

Instructions to build Scotch are provided later in the description. Once Scotch has been installed, the MPAS atmosphere core can be leveraged to use online graph partitioning by setting the path to Scotch prior to building MPAS.

```
export SCOTCH=/path/to/scotch/installation
make nvhpc CORE=atmosphere
```

If MPAS is built/linked with Scotch successfully, you should see a message stating that at the end of the build output. 

### Usage and run-time behavior

After building MPAS with Scotch, you can still choose whether or not to use online graph partitioning by setting appropriate values for the `config_block_decomp_file_prefix` namelist option.  

- If `config_block_decomp_file_prefix`+`mpi_tasks` points to a valid graph decomp file that already exists in the run directory, then it is used to proceed with the model run without invoking Scotch. 

- If `config_block_decomp_file_prefix==''` or `config_block_decomp_file_prefix`+`mpi_tasks` does not match any valid graph decomp file in the run directory, then Scotch graph partitioning is invoked. During this process, the generated partition is saved as a graph decomp file to the run directory so that it may be reused in the following runs without needing to invoke Scotch again. 

If MPAS has not been built with scotch, any code paths relating to Scotch will not be taken. And an incorrect specification of `config_block_decomp_file_prefix`+`mpi_tasks` should lead to the model halting.

### Downloading and building Scotch

Scotch may be obtained from its gitlab repository or as tarballs from this [link](https://gitlab.inria.fr/scotch/scotch/-/releases)
```
git clone https://gitlab.inria.fr/scotch/scotch.git && cd scotch 
git checkout v7.0.7
```

Build instructions are on this [page](https://gitlab.inria.fr/scotch/scotch#installation)

It can be as simple as 
```
mkdir build && cd build
cmake -DCMAKE_INSTALL_PREFIX=prefix/scotch/install -DMPI_HOME=/your/mpi/path  ..
make -j5
make install
```

To be able to use the distributed graph partitioning provided by PT-Scotch, you will need to pass an appropriate MPI installation path during the Scotch build. 

Other system pre-requisites are Bison and Flex. I have observed that an older Flex version (v2.6.1) on Eris caused the Scotch build to fail. After pulling in a more recent version of Flex [v2.6.4](https://github.com/westes/flex/releases) it seemed to build fine.  Scotch documentation also references the requirement for a Bison version > 3.4. 