### PR TITLE
Add computation of edgeNormalVectors for case 13 in the init_atmosphere core

### DIFF
--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -5823,6 +5823,7 @@ call mpas_log_write('Done with soil consistency check')
       use mpas_dmpar, only : mpas_dmpar_exch_halo_field, mpas_dmpar_min_real, mpas_dmpar_max_real
       use mpas_stream_manager, only : MPAS_stream_mgr_stream_exists, MPAS_stream_mgr_read
       use mpas_derived_types, only : MPAS_STREAM_MGR_NOERR
+      use mpas_vector_operations, only : mpas_initialize_vectors
 
       implicit none
 
@@ -5992,6 +5993,13 @@ call mpas_log_write('Done with soil consistency check')
       !
       call atm_initialize_advection_rk(mesh, nCells, nEdges, maxEdges, on_a_sphere, sphere_radius)
       call atm_initialize_deformation_weights(mesh, nCells, on_a_sphere, sphere_radius)
+
+
+      !
+      ! Compute edgeNormalVectors, cellTangentPlane, and localVerticalUnitVectors
+      ! (NB: these are the same fields computed by the mpas_rbf_interp_initialize routine)
+      !
+      call mpas_initialize_vectors(mesh)
 
 
       !


### PR DESCRIPTION
This PR adds the computation of the `edgeNormalVectors`, `cellTangentPlane`, and `localVerticalUnitVectors` fields for MPAS-A initialization case 13 (CAM-MPAS 3-d grid) through a call to the `mpas_initialize_vectors` routine. These fields may be useful for alternative initialization workflows for CAM-MPAS.