### PR TITLE
Fix buffer overflow in C string allocation for attribute name

### DIFF
--- a/src/framework/mpas_stream_inquiry.F
+++ b/src/framework/mpas_stream_inquiry.F
@@ -249,7 +249,7 @@ contains
         call mpas_f_to_c_string(streamname, c_streamname)
 
         if (present(attname)) then
-            allocate(c_attname(len(attname)))
+            allocate(c_attname(len(attname)+1))
             call mpas_f_to_c_string(attname, c_attname)
             c_attname_ptr = c_loc(c_attname)
         else


### PR DESCRIPTION
This PR fixes a buffer overflow bug caused by underallocating the `c_attname` character array, which is passed to C functions when querying attributes from stream information.

The original code failed to allocate space for the required `c_null_char` terminator when constructing a C-compatible string. As a result, the `c_attname` array was not properly null-terminated, leading to a buffer overflow and undefined behavior when the string was accessed by C code.

The fix adopted in this PR is to ensure that the allocation of the `c_attname` array includes space for the null terminator (`len_trim(attname) + 1`) and that the string is properly null-terminated before being passed to the C interface. 


