### PR TITLE
Add error handling to MPAS_stream_mgr_remove_alarm and remove redundant logging

### DIFF
--- a/src/core_test/mpas_test_core.F
+++ b/src/core_test/mpas_test_core.F
@@ -164,11 +164,12 @@ module test_core
       end if
       !$omp end parallel
 
+      ! Run stream tests
       call test_core_streams_test(domain, threadErrs, iErr)
       if ( iErr == 0 ) then
-         call mpas_log_write('Stream I/O tests: SUCCESS')
+         call mpas_log_write('Stream tests: SUCCESS')
       else
-         call mpas_log_write('Stream I/O tests: FAILURE', MPAS_LOG_ERR)
+         call mpas_log_write('Stream tests: FAILURE', MPAS_LOG_ERR)
       end if
 
       ! Run string util tests

--- a/src/core_test/mpas_test_core_streams.F
+++ b/src/core_test/mpas_test_core_streams.F
@@ -19,7 +19,7 @@ module test_core_streams
 
    !***********************************************************************
    !
-   !  routine test_core_streams_test
+   !  routine test_read_write_real_streams
    !
    !> \brief   tests reading/writing single- and double-precision streams
    !> \author  Michael Duda
@@ -35,7 +35,7 @@ module test_core_streams
    !>  that are created by this routine.
    !
    !-----------------------------------------------------------------------
-   subroutine test_core_streams_test(domain, threadErrs, ierr)
+   subroutine test_read_write_real_streams(domain, threadErrs, ierr)
 
       use mpas_stream_manager
 
@@ -389,6 +389,171 @@ module test_core_streams
          ierr = 1
          call mpas_log_write('Error destroying ''R8_stream''.', MPAS_LOG_ERR)
          return
+      end if
+
+   end subroutine test_read_write_real_streams
+
+   !***********************************************************************
+   !  Subroutine test_remove_alarm
+   !
+   !> \brief   Tests the functionality of adding and removing alarms from
+   !>          input and output streams in the stream manager.
+   !>
+   !> \details This subroutine creates a stream, adds an alarm to both
+   !>          the stream and the clock, and verifies the correct handling
+   !>          of alarms in different scenarios. It ensures that alarms
+   !>          cannot be removed from the opposite list and can be removed
+   !>          from the correct list. The stream type (input or output)
+   !>          is passed as an argument to test both scenarios.
+   !>
+   !> \param domain      The domain object that contains the stream manager
+   !>                    and clock.
+   !> \param streamType  The type of the stream being tested (input or output).
+   !> \param ierr        The error code that indicates the result of the test.
+   !
+   !-----------------------------------------------------------------------
+   subroutine test_remove_alarm(domain, streamType, ierr)
+      use mpas_stream_manager
+      use mpas_timekeeping
+
+      implicit none
+
+      ! Arguments
+      type (domain_type), intent(inout) :: domain
+      integer, intent(in) :: streamType  ! MPAS_STREAM_INPUT or MPAS_STREAM_OUTPUT
+      integer, intent(out) :: ierr
+
+      ! Local variables
+      character(len = :), allocatable :: streamID
+      character(len = :), allocatable :: alarmID
+      character(len = :), allocatable :: fileName
+      integer :: oppositeType
+      type(MPAS_Time_type) :: alarmTime
+      integer :: err
+
+      ierr = 0
+      err = 0
+
+      ! Assign IDs and file name based on type
+      if (streamType == MPAS_STREAM_INPUT) then
+         streamID = 'test_input_alarm_stream'
+         alarmID = 'test_input_alarm'
+         fileName = 'test_input_alarm_stream.nc'
+         oppositeType = MPAS_STREAM_OUTPUT
+      else if (streamType == MPAS_STREAM_OUTPUT) then
+         streamID = 'test_output_alarm_stream'
+         alarmID = 'test_output_alarm'
+         fileName = 'test_output_alarm_stream.nc'
+         oppositeType = MPAS_STREAM_INPUT
+      else
+         call mpas_log_write('Invalid stream type passed to test_remove_alarm.', MPAS_LOG_ERR)
+         ierr = 1
+         return
+      end if
+
+      ! Create the stream
+      call MPAS_stream_mgr_create_stream(domain % streamManager, streamID, streamType, fileName, &
+            realPrecision = MPAS_IO_SINGLE_PRECISION, &
+            clobberMode = MPAS_STREAM_CLOBBER_TRUNCATE, &
+            ierr = err)
+      if (err /= MPAS_STREAM_MGR_NOERR) then
+         call mpas_log_write('Error creating stream.', MPAS_LOG_ERR)
+         ierr = ierr + abs(err)
+      end if
+
+      ! Add alarm to the clock
+      call mpas_add_clock_alarm(domain % clock, alarmID, alarmTime, ierr = err)
+      if (err /= 0) then
+         call mpas_log_write('Error adding alarm to clock.', MPAS_LOG_ERR)
+         ierr = ierr + abs(err)
+      end if
+
+      ! Add alarm to the stream
+      call MPAS_stream_mgr_add_alarm(domain % streamManager, streamID, alarmID, streamType, ierr = err)
+      if (err /= MPAS_STREAM_MGR_NOERR) then
+         call mpas_log_write('Error adding alarm to stream.', MPAS_LOG_ERR)
+         ierr = ierr + abs(err)
+      end if
+
+      ! Try removing from opposite list — should fail
+      call MPAS_stream_mgr_remove_alarm(domain % streamManager, streamID, alarmID, oppositeType, ierr = err)
+      if (err /= MPAS_STREAM_MGR_ERROR) then
+         if (streamType == MPAS_STREAM_INPUT) then
+            call mpas_log_write('Expected error when removing input alarm from output alarm list.', MPAS_LOG_ERR)
+         else
+            call mpas_log_write('Expected error when removing output alarm from input alarm list.', MPAS_LOG_ERR)
+         end if
+         err = 1
+         ierr = ierr + abs(err)
+      end if
+
+      ! Remove from correct list — should succeed
+      call MPAS_stream_mgr_remove_alarm(domain % streamManager, streamID, alarmID, streamType, ierr = err)
+      if (err /= MPAS_STREAM_MGR_NOERR) then
+         call mpas_log_write('Error removing alarm from stream.', MPAS_LOG_ERR)
+         ierr = ierr + abs(err)
+      end if
+
+   end subroutine test_remove_alarm
+
+   !***********************************************************************
+   !  Subroutine test_core_streams_test
+   !
+   !> \brief   Core test suite for stream I/O and alarm management in MPAS.
+   !>
+   !> \details This subroutine tests the functionality of reading/writing
+   !>          real-valued streams and managing alarms in streams. It calls
+   !>          individual tests for stream I/O operations and for adding/removing
+   !>          alarms from input and output streams. The results of each test
+   !>          are logged with a success or failure message.
+   !>
+   !> \param domain      The domain object that contains the stream manager
+   !>                    and clock.
+   !> \param threadErrs  An array to store any errors encountered during
+   !>                    the test.
+   !> \param ierr        The error code that indicates the result of the test.
+   !
+   !-----------------------------------------------------------------------
+   subroutine test_core_streams_test(domain, threadErrs, ierr)
+
+      use mpas_log
+
+      implicit none
+
+      type (domain_type), intent(inout) :: domain
+      integer, dimension(:), intent(out) :: threadErrs
+      integer, intent(out) :: ierr
+
+      integer :: test_status
+
+      ierr = 0
+      test_status = 0
+
+      call mpas_log_write('Testing reading/writing real-valued streams')
+      call test_read_write_real_streams(domain, threadErrs, test_status)
+      if (test_status == 0) then
+         call mpas_log_write('Stream I/O tests: SUCCESS')
+      else
+         call mpas_log_write('Stream I/O tests: FAILURE', MPAS_LOG_ERR)
+         ierr = ierr + abs(test_status)
+      end if
+
+      call mpas_log_write('Testing removing an output alarm from a stream.')
+      call test_remove_alarm(domain, MPAS_STREAM_OUTPUT, test_status)
+      if (test_status == 0) then
+         call mpas_log_write('Removing output alarm test: SUCCESS')
+      else
+         call mpas_log_write('Removing output alarm test: FAILURE', MPAS_LOG_ERR)
+         ierr = ierr + abs(test_status)
+      end if
+
+      call mpas_log_write('Testing removing an input alarm from a stream.')
+      call test_remove_alarm(domain, MPAS_STREAM_INPUT, test_status)
+      if (test_status == 0) then
+         call mpas_log_write('Removing input alarm test: SUCCESS')
+      else
+         call mpas_log_write('Removing input alarm test: FAILURE', MPAS_LOG_ERR)
+         ierr = ierr + abs(test_status)
       end if
 
    end subroutine test_core_streams_test

--- a/src/framework/mpas_stream_list.F
+++ b/src/framework/mpas_stream_list.F
@@ -2,8 +2,8 @@ module mpas_stream_list
 
 #define COMMA ,
 #define LIST_DEBUG_WRITE(M) ! call mpas_log_write(M)
-#define LIST_WARN_WRITE(M) call mpas_log_write( M , messageType=MPAS_LOG_WARN)
-#define LIST_ERROR_WRITE(M) call mpas_log_write( M , messageType=MPAS_LOG_ERR)
+#define LIST_WARN_WRITE(M) ! call mpas_log_write( M , messageType=MPAS_LOG_WARN)
+#define LIST_ERROR_WRITE(M) ! call mpas_log_write( M , messageType=MPAS_LOG_ERR)
 
     use mpas_kind_types, only : StrKIND
     use mpas_log

--- a/src/framework/mpas_stream_manager.F
+++ b/src/framework/mpas_stream_manager.F
@@ -1383,8 +1383,18 @@ module mpas_stream_manager
            nullify(alarmNode)
            if (direction == MPAS_STREAM_INPUT) then
                call MPAS_stream_list_remove(stream % alarmList_in, alarmID, alarmNode, ierr=ierr)
+               if (ierr /= MPAS_STREAM_LIST_NOERR) then
+                   if (present(ierr)) ierr = MPAS_STREAM_MGR_ERROR
+                   STREAM_ERROR_WRITE('Problems unlinking alarm from alarmList_in for stream: '//trim(streamID))
+                   return
+               end if
            else if (direction == MPAS_STREAM_OUTPUT) then
                call MPAS_stream_list_remove(stream % alarmList_out, alarmID, alarmNode, ierr=ierr)
+               if (ierr /= MPAS_STREAM_LIST_NOERR) then
+                   if (present(ierr)) ierr = MPAS_STREAM_MGR_ERROR
+                   STREAM_ERROR_WRITE('Problems unlinking alarm from alarmList_out for stream: '//trim(streamID))
+                   return
+               end if
            else
                if (present(ierr)) ierr = MPAS_STREAM_MGR_ERROR
                STREAM_ERROR_WRITE('Requested to remove alarm from invalid direction from stream '//trim(streamID))
@@ -1396,6 +1406,11 @@ module mpas_stream_manager
            !
            if (associated(alarmNode)) then
                call MPAS_stream_list_remove(alarmNode % xref % streamList, streamID, streamNode, ierr=ierr)
+               if (ierr /= MPAS_STREAM_LIST_NOERR) then
+                   if (present(ierr)) ierr = MPAS_STREAM_MGR_ERROR
+                   STREAM_ERROR_WRITE('Problems while removing stream from alarms streamList.')
+                   return
+               end if
            else
                if (direction == MPAS_STREAM_INPUT) then
                    STREAM_ERROR_WRITE('Input alarm '//trim(alarmID)//' does not exist on stream '//trim(streamID))
@@ -1417,9 +1432,19 @@ module mpas_stream_manager
                if (direction == MPAS_STREAM_INPUT) then
                    STREAM_ERROR_WRITE('Input alarm '//trim(alarmID)//' has no associated streams and will be deleted.')
                    call MPAS_stream_list_remove(manager % alarms_in, alarmID, alarmNode, ierr=ierr)
+                   if (ierr /= MPAS_STREAM_LIST_NOERR) then
+                       if (present(ierr)) ierr = MPAS_STREAM_MGR_ERROR
+                       STREAM_ERROR_WRITE('Problems while removing stream from list of input alarm')
+                       return
+                   end if
                else
                    STREAM_ERROR_WRITE('Output alarm '//trim(alarmID)//' has no associated streams and will be deleted.')
                    call MPAS_stream_list_remove(manager % alarms_out, alarmID, alarmNode, ierr=ierr)
+                   if (ierr /= MPAS_STREAM_LIST_NOERR) then
+                       if (present(ierr)) ierr = MPAS_STREAM_MGR_ERROR
+                       STREAM_ERROR_WRITE('Problems while removing stream from list of output alarm')
+                       return
+                   end if
                end if
            end if
         end if


### PR DESCRIPTION
This PR introduces error checking to the `MPAS_stream_mgr_remove_alarm` subroutine in `mpas_stream_manager.F`, ensuring that errors returned by the `mpas_stream_list_remove` subroutine are correctly handled. Previously, specific logic paths (e.g., passing an incorrect direction to `MPAS_stream_mgr_remove_alarm`) would log an error without affecting the state of the code. This issue has been addressed by adding the necessary error handling, which now ensures the correct error codes are set and logged when errors occur.

Additionally, redundant error logging in the `mpas_stream_list_module` (specifically in the `mpas_stream_list_remove` subroutine) has been removed, as the newly added error checking now handles and logs these errors correctly.

### Testing:
The changes can be verified by running the test core. The stream tests, which tested this error checking, in commit [7bc8ea0f518d59a9f30557446b70bb656d452e5f](https://github.com/MPAS-Dev/MPAS-Model/tree/7bc8ea0f518d59a9f30557446b70bb656d452e5f) (the first commit in this PR), are now passing, confirming that the issue has been resolved.
