### PR TITLE
Fix Linking of PnetCDF in CMake

### DIFF
--- a/cmake/Modules/FindPnetCDF.cmake
+++ b/cmake/Modules/FindPnetCDF.cmake
@@ -133,19 +133,20 @@ set(_new_components)
 if(PnetCDF_Fortran_FOUND AND NOT TARGET PnetCDF::PnetCDF_Fortran)
     add_library(PnetCDF::PnetCDF_Fortran INTERFACE IMPORTED)
     set_target_properties(PnetCDF::PnetCDF_Fortran PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${PnetCDF_INCLUDE_DIR}
-                                                              INTERFACE_LINK_DIRECTORIES ${PnetCDF_LIB_DIR})
+                                                              INTERFACE_LINK_DIRECTORIES ${PnetCDF_LIB_DIR}
+                                                              INTERFACE_LINK_LIBRARIES pnetcdf)
     if(PnetCDF_MODULE_DIR AND NOT PnetCDF_MODULE_DIR STREQUAL PnetCDF_INCLUDE_DIR )
         set_property(TARGET PnetCDF::PnetCDF_Fortran APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${PnetCDF_MODULE_DIR})
     endif()
     set(_new_components 1)
-    target_link_libraries(PnetCDF::PnetCDF_Fortran INTERFACE -lpnetcdf)
 endif()
 
 # PnetCDF::PnetCDF_C imported interface target
 if(PnetCDF_C_FOUND AND NOT TARGET PnetCDF::PnetCDF_C)
     add_library(PnetCDF::PnetCDF_C INTERFACE IMPORTED)
     set_target_properties(PnetCDF::PnetCDF_C PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${PnetCDF_INCLUDE_DIR}
-                                                        INTERFACE_LINK_DIRECTORIES ${PnetCDF_LIB_DIR})
+                                                        INTERFACE_LINK_DIRECTORIES ${PnetCDF_LIB_DIR}
+                                                        INTERFACE_LINK_LIBRARIES pnetcdf)
     set(_new_components 1)
 endif()
 
@@ -153,7 +154,8 @@ endif()
 if(PnetCDF_CXX_FOUND AND NOT TARGET PnetCDF::PnetCDF_CXX)
     add_library(PnetCDF::PnetCDF_CXX INTERFACE IMPORTED)
     set_target_properties(PnetCDF::PnetCDF_CXX PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${PnetCDF_INCLUDE_DIR}
-                                                          INTERFACE_LINK_DIRECTORIES ${PnetCDF_LIB_DIR})
+                                                          INTERFACE_LINK_DIRECTORIES ${PnetCDF_LIB_DIR}
+                                                          INTERFACE_LINK_LIBRARIES pnetcdf)
     set(_new_components 1)
 endif()
 


### PR DESCRIPTION
**Summary:**
This PR resolves an issue with linking the PnetCDF C library in the CMake build system. It ensures that the `PnetCDF::PnetCDF_C` target is correctly created and linked by updating the `FindPnetCDF.cmake` file.

**Changes:**
The primary fix addresses insufficient linking when using `INTERFACE_LINK_DIRECTORIES`. Previously, `PnetCDF::PnetCDF_C` was only setting `INTERFACE_LINK_DIRECTORIES`, which specified the directory for the linker but did not actually link the necessary `pnetcdf` library. This prevented CMake targets from linking with parallel-netcdf when using `target_link_libraries(<target> PnetCDF::PnetCDF_C)`. The update now defines `INTERFACE_LINK_LIBRARIES` as `pnetcdf`, ensuring proper linkage.

**Tests:**
The validity of this change can be verified by compiling the develop branch of MPAS with CMake, enabling SMIOL support, and building it as a shared library. When running `ldd` on `libsmiol.so`, `pnetcdf` should not be listed on the develop branch. However, with this branch, `ldd` will confirm that `libsmiol.so` is correctly linked against parallel-netcdf.