### PR TITLE
Refactoring duplicate definitions of halo_exchange_routine

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -37,21 +37,8 @@ module atm_time_integration
    
    use mpas_atm_iau  
 
-   !
-   ! Abstract interface for routine used to communicate halos of fields
-   ! in a named group
-   !
-   abstract interface
-      subroutine halo_exchange_routine(domain, halo_group, ierr)
-
-         use mpas_derived_types, only : domain_type
-
-         type (domain_type), intent(inout) :: domain
-         character(len=*), intent(in) :: halo_group
-         integer, intent(out), optional :: ierr
-
-      end subroutine halo_exchange_routine
-   end interface
+   ! Provides definition of halo_exchange_routine
+#include "mpas_halo_interface.inc"
 
    integer :: timerid, secs, u_secs
 

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -13,21 +13,8 @@ module atm_core
    use mpas_log, only : mpas_log_write, mpas_log_info
    use mpas_io_units, only : mpas_new_unit, mpas_release_unit
 
-   !
-   ! Abstract interface for routine used to communicate halos of fields
-   ! in a named group
-   !
-   abstract interface
-      subroutine halo_exchange_routine(domain, halo_group, ierr)
-
-         use mpas_derived_types, only : domain_type
-
-         type (domain_type), intent(inout) :: domain
-         character(len=*), intent(in) :: halo_group
-         integer, intent(out), optional :: ierr
-
-      end subroutine halo_exchange_routine
-   end interface
+   ! Provides definition of halo_exchange_routine
+#include "mpas_halo_interface.inc"
 
    type (MPAS_Clock_type), pointer :: clock
 

--- a/src/core_atmosphere/mpas_atm_halos.F
+++ b/src/core_atmosphere/mpas_atm_halos.F
@@ -10,21 +10,8 @@ module mpas_atm_halos
    use mpas_pool_routines
    use mpas_log, only : mpas_log_write, mpas_log_info
 
-   !
-   ! Abstract interface for routine used to communicate halos of fields
-   ! in a named group
-   !
-   abstract interface
-      subroutine halo_exchange_routine(domain, halo_group, ierr)
-
-         use mpas_derived_types, only : domain_type
-
-         type (domain_type), intent(inout) :: domain
-         character(len=*), intent(in) :: halo_group
-         integer, intent(out), optional :: ierr
-
-      end subroutine halo_exchange_routine
-   end interface
+   ! Provides definition of halo_exchange_routine
+#include "mpas_halo_interface.inc"
 
    procedure (halo_exchange_routine), pointer :: exchange_halo_group
 

--- a/src/core_atmosphere/physics/mpas_atmphys_todynamics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_todynamics.F
@@ -41,21 +41,8 @@
 !   number concentrations due to PBL processes.
 !   Laura D. Fowler (laura@ucar.edu) / 2024-05-16.
 
-!
-! Abstract interface for routine used to communicate halos of fields
-! in a named group
-!
- abstract interface
-    subroutine halo_exchange_routine(domain, halo_group, ierr)
-
-       use mpas_derived_types, only : domain_type
-
-       type (domain_type), intent(inout) :: domain
-       character(len=*), intent(in) :: halo_group
-       integer, intent(out), optional :: ierr
-
-    end subroutine halo_exchange_routine
- end interface
+ ! Provides definition of halo_exchange_routine
+#include "mpas_halo_interface.inc"
 
 
  contains

--- a/src/framework/mpas_halo_interface.inc
+++ b/src/framework/mpas_halo_interface.inc
@@ -1,0 +1,15 @@
+   !
+   ! Abstract interface for routine used to communicate halos of fields
+   ! in a named group
+   !
+   abstract interface
+      subroutine halo_exchange_routine(domain, halo_group, ierr)
+
+         use mpas_derived_types, only : domain_type
+
+         type (domain_type), intent(inout) :: domain
+         character(len=*), intent(in) :: halo_group
+         integer, intent(out), optional :: ierr
+
+      end subroutine halo_exchange_routine
+   end interface


### PR DESCRIPTION
This PR introduces a new include file `mpas_halo_interface` under src/framework in order to remove the repeated definitions of the generic interface halo_exchange_routine and replace them with an include.

This is also preparatory work for https://github.com/MPAS-Dev/MPAS-Model/pull/1355