### PR TITLE
Remove 'pointer' attribute from 'inlist' argument to mpas_dmpar_scatter_ints

### DIFF
--- a/src/framework/mpas_dmpar.F
+++ b/src/framework/mpas_dmpar.F
@@ -1378,7 +1378,7 @@ include 'mpif.h'
       integer, intent(in) :: noutlist !< Input: Number integers to receive
       integer, dimension(nprocs), intent(in) :: displs !< Input: Displacement in sending array
       integer, dimension(nprocs), intent(in) :: counts !< Input: Number of integers to distribute
-      integer, dimension(:), pointer :: inlist !< Input: List of integers to send
+      integer, dimension(:), intent(in) :: inlist !< Input: List of integers to send
       integer, dimension(noutlist), intent(inout) :: outlist !< Output: List of received integers
 
 #ifdef _MPI


### PR DESCRIPTION
This PR removes the `pointer` attribute from the `inlist` dummy argument of the `mpas_dmpar_scatter_ints` routine.

The `pointer` attribute is unnecessary for the `inlist` argument, and requiring the `inlist` argument to be a pointer precluded the use of `mpas_dmpar_scatter_ints` for arrays that are not pointers, e.g., allocatable arrays or array constructors. Additionally, since the `inlist` argument is used only as the first argument to `MPI_Scatterv` (i.e., as the `sendbuf` argument of `MPI_Scatterv`), it can be declared as an `intent(in)` in the `mpas_dmpar_scatter_ints` routine.

The changes in this PR have also been found to resolve runtime errors occurring with certain compiler and MPI library combinations, specifically, nvfortran and OpenMPI 5.x.