### PR TITLE
Add start/stop time activation logic to MPAS_Alarm

### DIFF
--- a/src/core_test/Makefile
+++ b/src/core_test/Makefile
@@ -6,6 +6,7 @@ OBJS = mpas_test_core.o \
        mpas_test_core_streams.o \
        mpas_test_core_field_tests.o \
        mpas_test_core_timekeeping_tests.o \
+       mpas_test_core_clock_alarms.o \
        mpas_test_core_sorting.o \
        mpas_halo_testing.o \
        mpas_test_core_string_utils.o \
@@ -42,7 +43,8 @@ mpas_test_core.o: mpas_test_core_halo_exch.o mpas_test_core_streams.o \
                   mpas_test_core_field_tests.o mpas_test_core_timekeeping_tests.o \
                   mpas_test_core_sorting.o mpas_halo_testing.o \
                   mpas_test_core_string_utils.o mpas_test_core_dmpar.o \
-                  mpas_test_core_stream_inquiry.o mpas_test_openacc.o
+                  mpas_test_core_stream_inquiry.o mpas_test_openacc.o \
+                  mpas_test_core_clock_alarms.o
 
 mpas_test_core_halo_exch.o:
 
@@ -51,6 +53,8 @@ mpas_test_core_field_tests.o:
 mpas_test_core_streams.o:
 
 mpas_test_core_sorting.o:
+
+mpas_test_core_clock_alarms.o:
 
 clean:
 	$(RM) *.o *.mod *.f90 libdycore.a

--- a/src/core_test/mpas_test_core.F
+++ b/src/core_test/mpas_test_core.F
@@ -91,12 +91,14 @@ module test_core
       use mpas_vector_operations
       use mpas_geometry_utils
       use test_core_streams, only : test_core_streams_test
+      use mpas_test_core_stream_list, only : mpas_test_stream_list
       use test_core_sorting, only : test_core_test_sorting
       use mpas_halo_testing, only : mpas_halo_tests
       use test_core_string_utils, only : mpas_test_string_utils
       use mpas_test_core_dmpar, only : mpas_test_dmpar
       use mpas_test_core_stream_inquiry, only : mpas_test_stream_inquiry
       use mpas_test_core_openacc, only : mpas_test_openacc
+      use test_core_timekeeping_tests
 
       implicit none
    
@@ -164,12 +166,23 @@ module test_core
       end if
       !$omp end parallel
 
+      ! Run stream tests
       call test_core_streams_test(domain, threadErrs, iErr)
       if ( iErr == 0 ) then
-         call mpas_log_write('Stream I/O tests: SUCCESS')
+         call mpas_log_write('Stream tests: SUCCESS')
       else
-         call mpas_log_write('Stream I/O tests: FAILURE', MPAS_LOG_ERR)
+         call mpas_log_write('Stream tests: FAILURE', MPAS_LOG_ERR)
       end if
+      call mpas_log_write('')
+
+      ! Run stream list tests
+      call mpas_test_stream_list(iErr)
+      if (iErr == 0) then
+          call mpas_log_write('Stream list tests: SUCCESS')
+      else
+          call mpas_log_write('Stream list tests: FAILURE', MPAS_LOG_ERR)
+      end if
+      call mpas_log_write('')
 
       ! Run string util tests
       call mpas_log_write('')
@@ -226,6 +239,69 @@ module test_core
 #else
       call mpas_log_write('MPAS_OPENACC not defined, skipping OpenACC tests')
 #endif
+      call mpas_log_write('')
+
+      ! Test functionality of alarms
+      call mpas_log_write('')
+      call mpas_log_write('Testing backwards clock functionality:')
+      call mpas_alarm_ringing_tests(domain, iErr)
+      if (iErr == 0) then
+         call mpas_log_write('mpas_alarm_ringing_tests: SUCCESS')
+      else
+         call mpas_log_write('mpas_alarm_ringing_tests: FAILED')
+      end if
+
+      ! Test functionality of alarms with defined stop time
+      call mpas_log_write('')
+      call mpas_log_write('Testing mpas_alarm_stop_time:')
+      call mpas_alarm_stop_time_tests(domain, iErr)
+      if (iErr == 0) then
+         call mpas_log_write('mpas_alarm_stop_time_tests: SUCCESS')
+      else
+         call mpas_log_write('mpas_alarm_stop_time_tests: FAILED')
+      end if
+
+      ! Test functionality of alarms with defined stop time when alarm is not reset
+      call mpas_log_write('')
+      call mpas_log_write('Testing mpas_alarm_stop_time_no_reset:')
+      call mpas_alarm_stop_time_no_reset_tests(domain, iErr)
+      if (iErr == 0) then
+         call mpas_log_write('mpas_alarm_stop_time_no_reset_tests: SUCCESS')
+      else
+         call mpas_log_write('mpas_alarm_stop_time_no_reset_tests: FAILED')
+      end if
+
+      ! Test functionality of alarms with defined stop time when alarm is reset
+      call mpas_log_write('')
+      call mpas_log_write('Testing mpas_alarm_start_tests:')
+      call mpas_alarm_start_time_tests(domain, iErr)
+      if (iErr == 0) then
+         call mpas_log_write('mpas_alarm_start_tests: SUCCESS')
+      else
+         call mpas_log_write('mpas_alarm_start_tests: FAILED')
+      end if
+
+      ! Test functionality of alarms with defined start time and stop time
+      call mpas_log_write('')
+      call mpas_log_write('Testing mpas_alarm_start_stop_time:')
+      call mpas_alarm_start_stop_time_tests(domain, iErr)
+      if (iErr == 0) then
+         call mpas_log_write('mpas_alarm_start_stop_time_tests: SUCCESS')
+      else
+         call mpas_log_write('mpas_alarm_start_stop_time_tests: FAILED')
+      end if
+
+      !
+      ! Test functionality of adjustments to alarm reference time
+      !
+      call mpas_log_write('')
+      call mpas_log_write('Testing mpas_adjust_alarm_to_reference_time:')
+      call mpas_adjust_alarm_tests(domain, iErr)
+      if (iErr == 0) then
+         call mpas_log_write('* mpas_adjust_alarm_tests tests - all tests passed: SUCCESS')
+      else
+         call mpas_log_write('* mpas_adjust_alarm_tests tests - $i failed tests: FAILURE', intArgs=[iErr])
+      end if
       call mpas_log_write('')
 
 

--- a/src/core_test/mpas_test_core.F
+++ b/src/core_test/mpas_test_core.F
@@ -98,6 +98,7 @@ module test_core
       use mpas_test_core_stream_inquiry, only : mpas_test_stream_inquiry
       use mpas_test_core_openacc, only : mpas_test_openacc
       use test_core_timekeeping_tests
+      use mpas_test_core_clock_alarms, only : test_core_clock_alarms_test
 
       implicit none
    
@@ -118,167 +119,151 @@ module test_core
       !
       ! Test performance of framework sorting routines
       !
-      call test_core_test_sorting(domain, iErr)
-      if (iErr == 0) then
-         call mpas_log_write(' * Sorting tests: SUCCESS')
-      else
-         call mpas_log_write(' * Sorting tests: FAILURE', MPAS_LOG_ERR)
-      end if
-
-      !
-      ! Test functionality of mpas_halo module
+!     call test_core_test_sorting(domain, iErr)
+!     if (iErr == 0) then
+!        call mpas_log_write(' * Sorting tests: SUCCESS')
+!     else
+!        call mpas_log_write(' * Sorting tests: FAILURE', MPAS_LOG_ERR)
+!     end if
+!!     !
+!     ! Test functionality of mpas_halo module
+!     !
+!     call mpas_log_write('')
+!     call mpas_log_write('Testing mpas_halo module:')
+!     call mpas_halo_tests(domain, iErr)
+!     if (iErr == 0) then
+!        call mpas_log_write('* mpas_halo tests: SUCCESS')
+!     else
+!        call mpas_log_write('* mpas_halo tests: FAILURE', MPAS_LOG_ERR)
+!     end if
+!     call mpas_log_write('')
+!!     iErr = 0
+!!     call mpas_unit_test_fix_periodicity(iErr)
+!     call mpas_unit_test_triangle_signed_area_sphere(iErr)
+!!     call mpas_unit_test_velocity_conversion(iErr)
+!     call mpas_unit_test_wachspress_hexagon(iErr)
+!     call mpas_unit_test_wachspress_triangle(iErr)
+!!     !$omp parallel default(firstprivate) shared(domain, threadErrs)
+!     call test_core_halo_exch_test(domain, threadErrs, iErr)
+!     !$omp end parallel
+!     if ( iErr == 0 ) then
+!        call mpas_log_write(' * Halo Exchange Test: SUCCESS')
+!     else
+!        call mpas_log_write(' * Halo Exchange Test: FAILURE', MPAS_LOG_ERR)
+!     end if
+!!     !$omp parallel default(firstprivate) shared(domain, threadErrs)
+!     call test_core_test_fields(domain, threadErrs, ierr)
+!      if ( iErr == 0 ) then
+!        call mpas_log_write(' * Field Tests: SUCCESS')
+!     else
+!        call mpas_log_write(' * Field Tests: FAILURE', MPAS_LOG_ERR)
+!     end if
+!     !$omp end parallel
+!!     ! Run stream tests
+!     call test_core_streams_test(domain, threadErrs, iErr)
+!     if ( iErr == 0 ) then
+!        call mpas_log_write('Stream tests: SUCCESS')
+!     else
+!        call mpas_log_write('Stream tests: FAILURE', MPAS_LOG_ERR)
+!     end if
+!!     ! Run string util tests
+!     call mpas_log_write('')
+!     call mpas_test_string_utils(iErr)
+!     call mpas_log_write('')
+!!     !
+!     ! Run mpas_dmpar tests
+!     !
+!     call mpas_log_write('')
+!     iErr = mpas_test_dmpar(domain % dminfo)
+!     if (iErr == 0) then
+!         call mpas_log_write('All tests PASSED')
+!     else
+!         call mpas_log_write('$i tests FAILED', intArgs=[iErr])
+!     end if
+!     call mpas_log_write('')
+!      !
+      ! Run clock alarm tests
       !
       call mpas_log_write('')
-      call mpas_log_write('Testing mpas_halo module:')
-      call mpas_halo_tests(domain, iErr)
-      if (iErr == 0) then
-         call mpas_log_write('* mpas_halo tests: SUCCESS')
-      else
-         call mpas_log_write('* mpas_halo tests: FAILURE', MPAS_LOG_ERR)
-      end if
-      call mpas_log_write('')
-
-      iErr = 0
-
-      call mpas_unit_test_fix_periodicity(iErr)
-      call mpas_unit_test_triangle_signed_area_sphere(iErr)
-
-      call mpas_unit_test_velocity_conversion(iErr)
-      call mpas_unit_test_wachspress_hexagon(iErr)
-      call mpas_unit_test_wachspress_triangle(iErr)
-
-      !$omp parallel default(firstprivate) shared(domain, threadErrs)
-      call test_core_halo_exch_test(domain, threadErrs, iErr)
-      !$omp end parallel
+      call mpas_log_write('Testing clock alarms:')
+      call test_core_clock_alarms_test(domain, iErr)
       if ( iErr == 0 ) then
-         call mpas_log_write(' * Halo Exchange Test: SUCCESS')
-      else
-         call mpas_log_write(' * Halo Exchange Test: FAILURE', MPAS_LOG_ERR)
+            call mpas_log_write(' * Clock Alarm Tests: SUCCESS')
+        else
+            call mpas_log_write(' * Clock Alarm Tests: FAILURE', MPAS_LOG_ERR)
       end if
-
-      !$omp parallel default(firstprivate) shared(domain, threadErrs)
-      call test_core_test_fields(domain, threadErrs, ierr)
-       if ( iErr == 0 ) then
-         call mpas_log_write(' * Field Tests: SUCCESS')
-      else
-         call mpas_log_write(' * Field Tests: FAILURE', MPAS_LOG_ERR)
-      end if
-      !$omp end parallel
-
-      ! Run stream tests
-      call test_core_streams_test(domain, threadErrs, iErr)
-      if ( iErr == 0 ) then
-         call mpas_log_write('Stream tests: SUCCESS')
-      else
-         call mpas_log_write('Stream tests: FAILURE', MPAS_LOG_ERR)
-      end if
-
-      ! Run string util tests
-      call mpas_log_write('')
-      call mpas_test_string_utils(iErr)
-      call mpas_log_write('')
-
-      !
-      ! Run mpas_dmpar tests
-      !
-      call mpas_log_write('')
-      iErr = mpas_test_dmpar(domain % dminfo)
-      if (iErr == 0) then
-          call mpas_log_write('All tests PASSED')
-      else
-          call mpas_log_write('$i tests FAILED', intArgs=[iErr])
-      end if
-      call mpas_log_write('')
 
       !
       ! Run mpas_stream_inquiry tests
       !
-      call mpas_log_write('')
-      iErr = mpas_test_stream_inquiry(domain % dminfo)
-      if (iErr == 0) then
-          call mpas_log_write('All tests PASSED')
-      else
-          call mpas_log_write('$i tests FAILED', intArgs=[iErr])
-      end if
-      call mpas_log_write('')
-
-      call test_core_test_intervals(domain, threadErrs, iErr)
-
-      ! Test writing of block write streams, which have the prefix 'block_'
-      block => domain % blocklist
-      do while (associated(block))
-         call mpas_stream_mgr_reset_alarms(domain % streamManager, streamID="block_.*")
-         call mpas_stream_mgr_block_write(domain % streamManager, block, streamID="block_.*", forceWriteNow=.true.)
-         block => block % next
-      end do
-
-      call mpas_stream_mgr_write(domain % streamManager, forceWriteNow=.true.)
-
-      !
-      ! Run mpas_test_openacc
-      !
-      call mpas_log_write('')
-#ifdef MPAS_OPENACC
-      iErr = mpas_test_openacc(domain)
-      if (iErr == 0) then
-          call mpas_log_write('All tests PASSED')
-      else
-          call mpas_log_write('$i tests FAILED', intArgs=[iErr])
-      end if
-#else
-      call mpas_log_write('MPAS_OPENACC not defined, skipping OpenACC tests')
-#endif
-      call mpas_log_write('')
-
-      ! Test functionality of alarms
-      call mpas_log_write('')
-      call mpas_log_write('Testing backwards clock functionality:')
-      call mpas_alarm_ringing_tests(domain, iErr)
-      if (iErr == 0) then
-         call mpas_log_write('mpas_alarm_ringing_tests: SUCCESS')
-      else
-         call mpas_log_write('mpas_alarm_ringing_tests: FAILED')
-      end if
-
-      ! Test functionality of alarms with defined stop time
-      call mpas_log_write('')
-      call mpas_log_write('Testing mpas_alarm_stop_time:')
-      call mpas_alarm_stop_time_tests(domain, iErr)
-      if (iErr == 0) then
-         call mpas_log_write('mpas_alarm_stop_time_tests: SUCCESS')
-      else
-         call mpas_log_write('mpas_alarm_stop_time_tests: FAILED')
-      end if
-
-      ! Test functionality of alarms with defined stop time when alarm is not reset
-      call mpas_log_write('')
-      call mpas_log_write('Testing mpas_alarm_stop_time_no_reset:')
-      call mpas_alarm_stop_time_no_reset_tests(domain, iErr)
-      if (iErr == 0) then
-         call mpas_log_write('mpas_alarm_stop_time_no_reset_tests: SUCCESS')
-      else
-         call mpas_log_write('mpas_alarm_stop_time_no_reset_tests: FAILED')
-      end if
-
-      ! Test functionality of alarms with defined stop time when alarm is reset
-      call mpas_log_write('')
-      call mpas_log_write('Testing mpas_alarm_start_tests:')
-      call mpas_alarm_start_time_tests(domain, iErr)
-      if (iErr == 0) then
-         call mpas_log_write('mpas_alarm_start_tests: SUCCESS')
-      else
-         call mpas_log_write('mpas_alarm_start_tests: FAILED')
-      end if
-
-      ! Test functionality of alarms with defined start time and stop time
-      call mpas_log_write('')
-      call mpas_log_write('Testing mpas_alarm_start_stop_time:')
-      call mpas_alarm_start_stop_time_tests(domain, iErr)
-      if (iErr == 0) then
-         call mpas_log_write('mpas_alarm_start_stop_time_tests: SUCCESS')
-      else
-         call mpas_log_write('mpas_alarm_start_stop_time_tests: FAILED')
-      end if
+!     call mpas_log_write('')
+!     iErr = mpas_test_stream_inquiry(domain % dminfo)
+!     if (iErr == 0) then
+!         call mpas_log_write('All tests PASSED')
+!     else
+!         call mpas_log_write('$i tests FAILED', intArgs=[iErr])
+!     end if
+!     call mpas_log_write('')
+!!     call test_core_test_intervals(domain, threadErrs, iErr)
+!!     ! Test writing of block write streams, which have the prefix 'block_'
+!     block => domain % blocklist
+!     do while (associated(block))
+!        call mpas_stream_mgr_reset_alarms(domain % streamManager, streamID="block_.*")
+!        call mpas_stream_mgr_block_write(domain % streamManager, block, streamID="block_.*", forceWriteNow=.true.)
+!        block => block % next
+!     end do
+!!     call mpas_stream_mgr_write(domain % streamManager, forceWriteNow=.true.)
+!!     !
+!     ! Run mpas_test_openacc
+!     !
+!     call mpas_log_write('')
+!ifdef MPAS_OPENACC
+!     iErr = mpas_test_openacc(domain)
+!     if (iErr == 0) then
+!         call mpas_log_write('All tests PASSED')
+!     else
+!         call mpas_log_write('$i tests FAILED', intArgs=[iErr])
+!     end if
+!else
+!     call mpas_log_write('MPAS_OPENACC not defined, skipping OpenACC tests')
+!endif
+!     call mpas_log_write('')
+!!     ! Test functionality of alarms
+!     call mpas_log_write('')
+!     call mpas_log_write('Testing backwards clock functionality:')
+!     call mpas_alarm_ringing_tests(domain, iErr)
+!     if (iErr == 0) then
+!        call mpas_log_write('mpas_alarm_ringing_tests: SUCCESS')
+!     else
+!        call mpas_log_write('mpas_alarm_ringing_tests: FAILED')
+!     end if
+!!     ! Test functionality of alarms with defined stop time
+!     call mpas_log_write('')
+!     call mpas_log_write('Testing mpas_alarm_stop_time:')
+!     call mpas_alarm_stop_time_tests(domain, iErr)
+!     if (iErr == 0) then
+!        call mpas_log_write('mpas_alarm_stop_time_tests: SUCCESS')
+!     else
+!        call mpas_log_write('mpas_alarm_stop_time_tests: FAILED')
+!     end if
+!!     ! Test functionality of alarms with defined stop time when alarm is not reset
+!     call mpas_log_write('')
+!     call mpas_log_write('Testing mpas_alarm_stop_time_no_reset:')
+!     call mpas_alarm_stop_time_no_reset_tests(domain, iErr)
+!     if (iErr == 0) then
+!        call mpas_log_write('mpas_alarm_stop_time_no_reset_tests: SUCCESS')
+!     else
+!        call mpas_log_write('mpas_alarm_stop_time_no_reset_tests: FAILED')
+!     end if
+!!     ! Test functionality of alarms with defined stop time when alarm is reset
+!     call mpas_log_write('')
+!     call mpas_log_write('Testing mpas_alarm_start_tests:')
+!     call mpas_alarm_start_time_tests(domain, iErr)
+!     if (iErr == 0) then
+!        call mpas_log_write('mpas_alarm_start_tests: SUCCESS')
+!     else
+!        call mpas_log_write('mpas_alarm_start_tests: FAILED')
+!     end if
 
       !
       ! Test functionality of adjustments to alarm reference time

--- a/src/core_test/mpas_test_core.F
+++ b/src/core_test/mpas_test_core.F
@@ -91,7 +91,6 @@ module test_core
       use mpas_vector_operations
       use mpas_geometry_utils
       use test_core_streams, only : test_core_streams_test
-      use mpas_test_core_stream_list, only : mpas_test_stream_list
       use test_core_sorting, only : test_core_test_sorting
       use mpas_halo_testing, only : mpas_halo_tests
       use test_core_string_utils, only : mpas_test_string_utils
@@ -173,16 +172,6 @@ module test_core
       else
          call mpas_log_write('Stream tests: FAILURE', MPAS_LOG_ERR)
       end if
-      call mpas_log_write('')
-
-      ! Run stream list tests
-      call mpas_test_stream_list(iErr)
-      if (iErr == 0) then
-          call mpas_log_write('Stream list tests: SUCCESS')
-      else
-          call mpas_log_write('Stream list tests: FAILURE', MPAS_LOG_ERR)
-      end if
-      call mpas_log_write('')
 
       ! Run string util tests
       call mpas_log_write('')

--- a/src/core_test/mpas_test_core_clock_alarms.F
+++ b/src/core_test/mpas_test_core_clock_alarms.F
@@ -1,0 +1,423 @@
+module mpas_test_core_clock_alarms
+    use mpas_derived_types, only : core_type, domain_type
+    use mpas_timekeeping
+
+    type clock_alarm_fixture_t
+        type(MPAS_Time_type) :: clock_start_time
+        type(MPAS_Time_type) :: clock_stop_time
+        type(MPAS_Time_type) :: alarm_time
+        type(MPAS_Time_type) :: alarm_start_time
+        type(MPAS_Time_type) :: alarm_stop_time
+        type(MPAS_Time_type) :: current_time
+        type(MPAS_TimeInterval_type) :: clock_time_step
+        type(MPAS_TimeInterval_type) :: alarm_start_time_interval
+        type(MPAS_Clock_type) :: clock
+        type(MPAS_Alarm_type) :: alarm
+        character(len = :), allocatable :: alarm_id
+        integer :: window_size
+    end type
+contains
+
+    subroutine setup_clock_alarm_fixture(fixture)
+        implicit none
+        type(clock_alarm_fixture_t), intent(inout) :: fixture
+        integer :: ierr
+        fixture%alarm_id = 'variable_time_interval_alarm'
+        call mpas_set_time(fixture%clock_start_time, YYYY = 2000, MM = 01, DD = 01, H = 0, &
+                M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr)
+        call mpas_set_time(fixture%clock_stop_time, YYYY = 2100, MM = 01, DD = 01, H = 0, &
+                M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr)
+        call mpas_set_timeInterval(fixture%clock_time_step, dt = 3600.0_RKIND, ierr = ierr)
+        call mpas_create_clock(fixture%clock, fixture%clock_start_time, fixture%clock_time_step, &
+                fixture%clock_stop_time, ierr = ierr)
+        call mpas_set_time(fixture%alarm_time, YYYY = 2000, MM = 01, DD = 01, H = 0, &
+                M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr)
+        call mpas_set_time(fixture%alarm_start_time, YYYY = 2000, MM = 01, DD = 11, H = 0, &
+                M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr)
+        call mpas_set_time(fixture%alarm_stop_time, YYYY = 2000, MM = 01, DD = 21, H = 0, &
+                M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr)
+
+        call mpas_set_timeInterval(fixture%alarm_start_time_interval, dt = 3600.0_RKIND, ierr = ierr)
+        call mpas_add_clock_alarm(fixture%clock, fixture%alarm_id, fixture%alarm_time, &
+                alarmTimeInterval = fixture%alarm_start_time_interval, &
+                alarmStartTime = fixture%alarm_start_time, &
+                alarmStopTime = fixture%alarm_stop_time, ierr = ierr)
+        fixture%alarm = fixture%clock%alarmListHead
+        fixture%window_size = 240
+    end subroutine
+
+    subroutine teardown_clock_alarm_fixture(fixture)
+        implicit none
+        type(clock_alarm_fixture_t), intent(inout) :: fixture
+        integer :: ierr
+
+        call mpas_remove_clock_alarm(fixture%clock, fixture%alarm_id, ierr = ierr)
+        call mpas_destroy_clock(fixture%clock, ierr = ierr)
+    end subroutine
+
+    subroutine test_variable_time_interval_alarm_has_start_and_stop_time(fixture, ierr)
+        implicit none
+        type(clock_alarm_fixture_t) :: fixture
+        integer, intent(out) :: ierr
+        ierr = 0
+        call setup_clock_alarm_fixture(fixture)
+        if (fixture%alarm%hasStartTime .eqv. .false.) then
+            ierr = ierr + 1
+        end if
+        if (fixture%alarm%hasStopTime .eqv. .false.) then
+            ierr = ierr + 1
+        end if
+        call teardown_clock_alarm_fixture(fixture)
+    end subroutine
+
+    subroutine test_variable_time_interval_alarm_inactive_before_start(fixture, ierr)
+        implicit none
+        type(clock_alarm_fixture_t) :: fixture
+        integer, intent(out) :: ierr
+        integer :: i
+
+        ierr = 0
+        call setup_clock_alarm_fixture(fixture)
+
+        ! Step just before start
+        do i = 1, fixture%window_size - 1
+            call mpas_advance_clock(fixture%clock, ierr = ierr)
+        end do
+
+        if (mpas_is_alarm_ringing(fixture%clock, fixture%alarm_id, ierr = ierr)) then
+            ierr = ierr + 1
+        end if
+
+        call teardown_clock_alarm_fixture(fixture)
+    end subroutine test_variable_time_interval_alarm_inactive_before_start
+
+
+    subroutine test_variable_time_interval_alarm_triggers_at_start_time(fixture, ierr)
+        implicit none
+        type(clock_alarm_fixture_t), intent(out) :: fixture
+        integer, intent(out) :: ierr
+        integer :: i
+
+        ierr = 0
+        call setup_clock_alarm_fixture(fixture)
+
+        ! Advance to start boundary
+        do i = 1, fixture%window_size
+            !            call mpas_reset_clock_alarm(fixture%clock, fixture%alarm_id)
+            call mpas_advance_clock(fixture%clock)
+        end do
+
+        if (.not. mpas_is_alarm_ringing(fixture%clock, fixture%alarm_id)) then
+            ierr = ierr + 1
+        end if
+
+        call teardown_clock_alarm_fixture(fixture)
+    end subroutine test_variable_time_interval_alarm_triggers_at_start_time
+
+
+    subroutine test_variable_time_interval_alarm_rings_within_window(fixture, ierr)
+        implicit none
+        type(clock_alarm_fixture_t) :: fixture
+        integer, intent(out) :: ierr
+        integer :: i
+
+        ierr = 0
+        call setup_clock_alarm_fixture(fixture)
+
+        ! Step into window
+        do i = 1, fixture%window_size
+            call mpas_advance_clock(fixture%clock, ierr = ierr)
+        end do
+
+        if (.not. mpas_is_alarm_ringing(fixture%clock, fixture%alarm_id, ierr = ierr)) then
+            ierr = ierr + 1
+        end if
+
+        ! Stay inside window
+        do i = 1, fixture%window_size
+            call mpas_reset_clock_alarm(fixture%clock, fixture%alarm_id, ierr = ierr)
+            call mpas_advance_clock(fixture%clock, ierr = ierr)
+            if (.not. mpas_is_alarm_ringing(fixture%clock, fixture%alarm_id, ierr = ierr)) then
+                ierr = ierr + 1
+            end if
+        end do
+
+        call teardown_clock_alarm_fixture(fixture)
+    end subroutine test_variable_time_interval_alarm_rings_within_window
+
+
+    subroutine test_variable_time_interval_alarm_active_at_stop_time(fixture, ierr)
+        implicit none
+        type(clock_alarm_fixture_t) :: fixture
+        integer, intent(out) :: ierr
+        integer :: i
+
+        ierr = 0
+        call setup_clock_alarm_fixture(fixture)
+
+        ! Advance to stop
+        do i = 1, fixture%window_size
+            call mpas_advance_clock(fixture%clock, ierr = ierr)
+        end do
+        call mpas_reset_clock_alarm(fixture%clock, fixture%alarm_id, ierr = ierr)
+        fixture%current_time = mpas_get_clock_time(fixture%clock, MPAS_NOW, ierr = ierr)
+        if (fixture%current_time /= fixture%alarm_start_time) then
+            ierr = ierr + 1
+        end if
+        do i = 1, fixture%window_size
+            call mpas_advance_clock(fixture%clock, ierr = ierr)
+        end do
+        fixture%current_time = mpas_get_clock_time(fixture%clock, MPAS_NOW, ierr = ierr)
+        if (fixture%current_time /= fixture%alarm_stop_time) then
+            ierr = ierr + 1
+        end if
+
+        if (.not. mpas_is_alarm_ringing(fixture%clock, fixture%alarm_id, ierr = ierr)) then
+            ierr = ierr + 1
+        end if
+
+        call teardown_clock_alarm_fixture(fixture)
+    end subroutine test_variable_time_interval_alarm_active_at_stop_time
+
+    !> Alarm should reactivate when stepping backward across stop boundary
+    subroutine test_alarm_reactivates_crossing_stop_backward(fixture, ierr)
+        implicit none
+        type(clock_alarm_fixture_t) :: fixture
+        integer, intent(out) :: ierr
+        integer :: i
+        ierr = 0
+
+        call setup_clock_alarm_fixture(fixture)
+
+        ! Move beyond stop → should be inactive
+        do i = 1, 2 * fixture%window_size + 1
+            call mpas_reset_clock_alarm(fixture%clock, fixture%alarm_id, ierr = ierr)
+            call mpas_advance_clock(fixture%clock, ierr = ierr)
+        end do
+        if (mpas_is_alarm_ringing(fixture%clock, fixture%alarm_id, ierr = ierr)) then
+            write(*, *) 'FAILED: alarm should be inactive after stop'
+            ierr = ierr + 1
+        end if
+
+        ! Flip direction and reset
+        call mpas_set_clock_direction(fixture%clock, MPAS_BACKWARD, ierr = ierr)
+        call mpas_reset_clock_alarm(fixture%clock, fixture%alarm_id, ierr = ierr)
+
+        ! Step back into stop → should be active
+        call mpas_advance_clock(fixture%clock, ierr = ierr)
+        if (.not. mpas_is_alarm_ringing(fixture%clock, fixture%alarm_id, ierr = ierr)) then
+            write(*, *) 'FAILED: alarm should reactivate crossing stop backward'
+            ierr = ierr + 1
+        end if
+
+        call teardown_clock_alarm_fixture(fixture)
+    end subroutine test_alarm_reactivates_crossing_stop_backward
+
+
+    !> Alarm should remain active while stepping backward into window,
+    !! but deactivate once crossing start time
+    subroutine test_alarm_active_crossing_start_backward(fixture, ierr)
+        implicit none
+        type(clock_alarm_fixture_t) :: fixture
+        integer, intent(out) :: ierr
+        integer :: i
+        ierr = 0
+
+        call setup_clock_alarm_fixture(fixture)
+
+        ! Move beyond stop
+        do i = 1, 2 * fixture%window_size + 1
+            call mpas_reset_clock_alarm(fixture%clock, fixture%alarm_id, ierr = ierr)
+            call mpas_advance_clock(fixture%clock, ierr = ierr)
+        end do
+
+        call mpas_set_clock_direction(fixture%clock, MPAS_BACKWARD, ierr = ierr)
+        call mpas_reset_clock_alarm(fixture%clock, fixture%alarm_id, ierr = ierr)
+
+        ! Step back into window until start → alarm should ring
+        do i = 1, fixture%window_size + 1
+            call mpas_reset_clock_alarm(fixture%clock, fixture%alarm_id, ierr = ierr)
+            call mpas_advance_clock(fixture%clock, ierr = ierr)
+        end do
+        if (.not. mpas_is_alarm_ringing(fixture%clock, fixture%alarm_id, ierr = ierr)) then
+            write(*, *) 'FAILED: alarm should be active at start when stepping back'
+            ierr = ierr + 1
+        end if
+
+        call mpas_reset_clock_alarm(fixture%clock, fixture%alarm_id, ierr = ierr)
+
+        ! Step back once more → before start → should be inactive
+        call mpas_advance_clock(fixture%clock, ierr = ierr)
+        if (mpas_is_alarm_ringing(fixture%clock, fixture%alarm_id, ierr = ierr)) then
+            write(*, *) 'FAILED: alarm should be inactive before start when stepping back'
+            ierr = ierr + 1
+        end if
+
+        call teardown_clock_alarm_fixture(fixture)
+    end subroutine test_alarm_active_crossing_start_backward
+
+
+    !> Adjust forward so alarm aligns with reference start time
+    subroutine test_adjust_forward_aligns_to_start(fixture, ierr)
+        implicit none
+        type(clock_alarm_fixture_t) :: fixture
+        integer, intent(out) :: ierr
+        integer :: i
+        ierr = 0
+
+        call setup_clock_alarm_fixture(fixture)
+
+        ! Advance beyond start
+        do i = 1, fixture%window_size
+            call mpas_advance_clock(fixture%clock, ierr = ierr)
+        end do
+
+        fixture%current_time = mpas_get_clock_time(fixture%clock, MPAS_NOW)
+        if (fixture%current_time /= fixture%alarm_start_time) then
+            write(*, *) 'FAILED: current time should be at start time'
+            ierr = ierr + 1
+        end if
+
+        call mpas_reset_clock_alarm(fixture%clock, fixture%alarm_id, ierr = ierr)
+        call mpas_adjust_alarm_to_reference_time(fixture%clock, fixture%alarm_id, fixture%alarm_start_time, ierr = ierr)
+
+        if (.not. eq_t_t(fixture%alarm%prevRingTime, fixture%current_time - fixture%clock_time_step)) then
+            write(*, *) 'FAILED: prevRingTime did not align with adjusted start time'
+            ierr = ierr + 1
+        end if
+
+        call teardown_clock_alarm_fixture(fixture)
+    end subroutine test_adjust_forward_aligns_to_start
+
+
+    subroutine test_variable_time_interval_alarm_inactive_after_stop(fixture, ierr)
+        implicit none
+        type(clock_alarm_fixture_t) :: fixture
+        integer, intent(out) :: ierr
+        integer :: i
+
+        ierr = 0
+        call setup_clock_alarm_fixture(fixture)
+
+        ! Advance to stop
+        do i = 1, fixture%window_size
+            call mpas_advance_clock(fixture%clock, ierr = ierr)
+        end do
+        call mpas_reset_clock_alarm(fixture%clock, fixture%alarm_id, ierr = ierr)
+        fixture%current_time = mpas_get_clock_time(fixture%clock, MPAS_NOW, ierr = ierr)
+        if (fixture%current_time /= fixture%alarm_start_time) then
+            ierr = ierr + 1
+        end if
+        do i = 1, fixture%window_size
+            call mpas_advance_clock(fixture%clock, ierr = ierr)
+        end do
+        fixture%current_time = mpas_get_clock_time(fixture%clock, MPAS_NOW, ierr = ierr)
+        if (fixture%current_time /= fixture%alarm_stop_time) then
+            ierr = ierr + 1
+        end if
+
+        call mpas_reset_clock_alarm(fixture%clock, fixture%alarm_id, ierr = ierr)
+        call mpas_advance_clock(fixture%clock, ierr = ierr)
+
+        if (mpas_is_alarm_ringing(fixture%clock, fixture%alarm_id, ierr = ierr)) then
+            ierr = ierr + 1
+        end if
+
+        call teardown_clock_alarm_fixture(fixture)
+    end subroutine test_variable_time_interval_alarm_inactive_after_stop
+
+
+    subroutine test_core_clock_alarms_test(domain, ierr)
+        implicit none
+        type (domain_type), intent(inout) :: domain
+        integer, intent(out) :: ierr
+        type(clock_alarm_fixture_t), target :: fixture
+        integer :: err
+
+        call mpas_log_write('Clock alarm tests:')
+        ierr = 0
+
+        err = 0
+        call test_variable_time_interval_alarm_has_start_and_stop_time(fixture, err)
+        if (err /= 0) then
+            write(*, *) '    variable_time_interval_alarm has start and stop time - FAILED'
+            ierr = ierr + err
+        else
+            call mpas_log_write('    variable_time_interval_alarm has start and stop time - PASSED')
+        end if
+
+        err = 0
+        call test_variable_time_interval_alarm_inactive_before_start(fixture, err)
+        if (err /= 0) then
+            write(*, *) '    variable_time_interval_alarm inactive before start - FAILED'
+            ierr = ierr + err
+        else
+            call mpas_log_write('    variable_time_interval_alarm inactive before start - PASSED')
+        end if
+
+        err = 0
+        call test_variable_time_interval_alarm_triggers_at_start_time(fixture, err)
+        if (err /= 0) then
+            write(*, *) '    variable_time_interval_alarm triggers at start time - FAILED'
+            ierr = ierr + err
+        else
+            call mpas_log_write('    variable_time_interval_alarm triggers at start time - PASSED')
+        end if
+
+        err = 0
+        call test_variable_time_interval_alarm_rings_within_window(fixture, err)
+        if (err /= 0) then
+            write(*, *) '    variable_time_interval_alarm rings within window - FAILED'
+            ierr = ierr + err
+        else
+            call mpas_log_write('    variable_time_interval_alarm rings within window - PASSED')
+        end if
+
+        err = 0
+        call test_variable_time_interval_alarm_active_at_stop_time(fixture, err)
+        if (err /= 0) then
+            write(*, *) '    variable_time_interval_alarm active at stop time - FAILED'
+            ierr = ierr + err
+        else
+            call mpas_log_write('    variable_time_interval_alarm active at stop time - PASSED')
+        end if
+
+        err = 0
+        call test_variable_time_interval_alarm_inactive_after_stop(fixture, err)
+        if (err /= 0) then
+            write(*, *) '    variable_time_interval_alarm inactive after stop - FAILED'
+            ierr = ierr + err
+        else
+            call mpas_log_write('    variable_time_interval_alarm inactive after stop - PASSED')
+        end if
+
+        ! New tests
+        err = 0
+        call test_alarm_reactivates_crossing_stop_backward(fixture, err)
+        if (err /= 0) then
+            write(*, *) '    variable_time_interval_alarm reactivates crossing stop backward - FAILED'
+            ierr = ierr + err
+        else
+            call mpas_log_write('    variable_time_interval_alarm reactivates crossing stop backward - PASSED')
+        end if
+
+        err = 0
+        call test_alarm_active_crossing_start_backward(fixture, err)
+        if (err /= 0) then
+            write(*, *) '    variable_time_interval_alarm active crossing start backward - FAILED'
+            ierr = ierr + err
+        else
+            call mpas_log_write('    variable_time_interval_alarm active crossing start backward - PASSED')
+        end if
+
+        err = 0
+        call test_adjust_forward_aligns_to_start(fixture, err)
+        if (err /= 0) then
+            write(*, *) '    variable_time_interval_alarm adjust forward aligns to start - FAILED'
+            ierr = ierr + err
+        else
+            call mpas_log_write('    variable_time_interval_alarm adjust forward aligns to start - PASSED')
+        end if
+
+    end subroutine test_core_clock_alarms_test
+end module mpas_test_core_clock_alarms

--- a/src/core_test/mpas_test_core_timekeeping_tests.F
+++ b/src/core_test/mpas_test_core_timekeeping_tests.F
@@ -5,6 +5,9 @@
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
+
+#define MPAS_ADJUST_ALARM_VERBOSE( M ) ! M
+
 module test_core_timekeeping_tests
 
    use mpas_derived_types
@@ -19,9 +22,14 @@ module test_core_timekeeping_tests
    implicit none
    private
 
-   public :: test_core_test_intervals
-
-   contains
+   public :: test_core_test_intervals, &
+         mpas_adjust_alarm_tests, &
+         mpas_alarm_ringing_tests, &
+         mpas_alarm_stop_time_tests, &
+         mpas_alarm_stop_time_no_reset_tests, &
+         mpas_alarm_start_time_tests, &
+         mpas_alarm_start_stop_time_tests
+contains
 
    !***********************************************************************
    !
@@ -40,8 +48,8 @@ module test_core_timekeeping_tests
       integer, dimension(:), intent(out) :: threadErrs
       integer, intent(out) :: err
 
-      character (len=StrKIND) :: int1_str, int2_str
-      character (len=StrKIND) :: ref_str
+      character (len = StrKIND) :: int1_str, int2_str
+      character (len = StrKIND) :: ref_str
 
       integer :: threadNum
       integer :: iErr, err_tmp
@@ -52,12 +60,12 @@ module test_core_timekeeping_tests
       threadNum = mpas_threading_get_thread_num()
       err = 0
 
-      if ( threadNum == 0 ) then
+      if (threadNum == 0) then
          call mpas_log_write(' Performing time interval tests')
 
          call mpas_log_write('  Test 1:')
          call test_core_interval_test('0001-01-01_00:00:00', '0000-01-00_10:00:00', '0001_00:00:00', 31_I8KIND, '0000_10:00:00', err_tmp)
-         if ( err_tmp == 0 ) then
+         if (err_tmp == 0) then
             call mpas_log_write('   Result: PASSED')
          else
             call mpas_log_write(' * Result: FAILED', MPAS_LOG_ERR)
@@ -65,7 +73,7 @@ module test_core_timekeeping_tests
 
          call mpas_log_write('  Test 2:')
          call test_core_interval_test('0001-01-01_00:00:00', '0000-01-00_00:00:00', '0001_00:00:00', 31_I8KIND, '0000_00:00:00', err_tmp)
-         if ( err_tmp == 0 ) then
+         if (err_tmp == 0) then
             call mpas_log_write('   Result: PASSED')
          else
             call mpas_log_write(' * Result: FAILED', MPAS_LOG_ERR)
@@ -73,7 +81,7 @@ module test_core_timekeeping_tests
 
          call mpas_log_write('  Test 3:')
          call test_core_interval_test('0001-02-01_00:00:00', '0000-01-00_10:00:00', '0001_00:00:00', 28_I8KIND, '0000_10:00:00', err_tmp)
-         if ( err_tmp == 0 ) then
+         if (err_tmp == 0) then
             call mpas_log_write('   Result: PASSED')
          else
             call mpas_log_write(' * Result: FAILED', MPAS_LOG_ERR)
@@ -81,7 +89,7 @@ module test_core_timekeeping_tests
 
          call mpas_log_write('  Test 4:')
          call test_core_interval_test('0001-02-01_00:00:00', '0000-01-00_00:00:00', '0001_00:00:00', 28_I8KIND, '0000_00:00:00', err_tmp)
-         if ( err_tmp == 0 ) then
+         if (err_tmp == 0) then
             call mpas_log_write('   Result: PASSED')
          else
             call mpas_log_write(' * Result: FAILED', MPAS_LOG_ERR)
@@ -89,7 +97,7 @@ module test_core_timekeeping_tests
 
          call mpas_log_write('  Test 5:')
          call test_core_interval_test('0001-01-01_00:00:00', '0000-00-00_01:00:00', '0000_00:30:00', 2_I8KIND, '0000_00:00:00', err_tmp)
-         if ( err_tmp == 0 ) then
+         if (err_tmp == 0) then
             call mpas_log_write('   Result: PASSED')
          else
             call mpas_log_write(' * Result: FAILED', MPAS_LOG_ERR)
@@ -97,7 +105,7 @@ module test_core_timekeeping_tests
 
          call mpas_log_write('  Test 6:')
          call test_core_interval_test('0001-01-01_00:00:00', '0001-01-00_00:00:00', '0001-00-00_00:00:00', 1_I8KIND, '0000-00-31_00:00:00', err_tmp)
-         if ( err_tmp == 0 ) then
+         if (err_tmp == 0) then
             call mpas_log_write('   Result: PASSED')
          else
             call mpas_log_write(' * Result: FAILED', MPAS_LOG_ERR)
@@ -105,7 +113,7 @@ module test_core_timekeeping_tests
 
          call mpas_log_write('  Test 7:')
          call test_core_interval_test('0000-01-01_00:00:00', '1850-00-00_00:00:00', '00:00:01', 58341600000_I8KIND, '0000-00-00_00:00:00', err_tmp)
-         if ( err_tmp == 0 ) then
+         if (err_tmp == 0) then
             call mpas_log_write('   Result: PASSED')
          else
             call mpas_log_write(' * Result: FAILED', MPAS_LOG_ERR)
@@ -117,18 +125,19 @@ module test_core_timekeeping_tests
 
       call mpas_timer_stop('timekeeping tests')
 
-   end subroutine test_core_test_intervals!}}}
+   end subroutine test_core_test_intervals
+   !}}}
 
    subroutine test_core_interval_test(ref_str, int1_str, int2_str, expected_divs, expected_remainder_str, ierr)!{{{
-      character (len=*), intent(in) :: ref_str, int1_str, int2_str
-      integer (kind=I8KIND), intent(in) :: expected_divs
-      character (len=*), intent(in) :: expected_remainder_str
+      character (len = *), intent(in) :: ref_str, int1_str, int2_str
+      integer (kind = I8KIND), intent(in) :: expected_divs
+      character (len = *), intent(in) :: expected_remainder_str
       integer, intent(out) :: ierr
 
-      integer (kind=I8KIND) :: divs
+      integer (kind = I8KIND) :: divs
 
-      character (len=StrKIND) :: remainder_str
-      character (len=StrKIND) :: temp_str
+      character (len = StrKIND) :: remainder_str
+      character (len = StrKIND) :: temp_str
 
       type (mpas_time_type) :: ref_time
       type (mpas_timeinterval_type) :: int1, int2, remainder
@@ -144,38 +153,692 @@ module test_core_timekeeping_tests
       call mpas_log_write('      Interval 1: ' // trim(int1_str))
       call mpas_log_write('      Interval 2: ' // trim(int2_str))
 
-      call mpas_set_time(ref_time, dateTimeString=ref_str, ierr=err_tmp)
-      call mpas_set_timeinterval(int1, timeString=int1_str, ierr=err_tmp)
-      call mpas_set_timeinterval(int2, timeString=int2_str, ierr=err_tmp)
-      call mpas_set_timeinterval(expected_remainder, timeString=expected_remainder_str, ierr=err_tmp)
+      call mpas_set_time(ref_time, dateTimeString = ref_str, ierr = err_tmp)
+      call mpas_set_timeinterval(int1, timeString = int1_str, ierr = err_tmp)
+      call mpas_set_timeinterval(int2, timeString = int2_str, ierr = err_tmp)
+      call mpas_set_timeinterval(expected_remainder, timeString = expected_remainder_str, ierr = err_tmp)
 
       call mpas_log_write('      -- Calling interval division')
 
       call mpas_interval_division(ref_time, int1, int2, divs, remainder)
 
-      call mpas_get_timeinterval(remainder, startTimeIn=ref_time, timeString=remainder_str)
+      call mpas_get_timeinterval(remainder, startTimeIn = ref_time, timeString = remainder_str)
 
       call mpas_log_write('      Interval Division summary')
-      write(temp_str,*) '         Divisions: ', divs
+      write(temp_str, *) '         Divisions: ', divs
       call mpas_log_write(trim(temp_str))
       call mpas_log_write('          Remainder: ' // trim(remainder_str))
       call mpas_log_write('')
 
-      if ( divs == expected_divs ) then
+      if (divs == expected_divs) then
          call mpas_log_write('          Div Test: PASSED')
       else
          call mpas_log_write(' **       Div Test: FAILED', MPAS_LOG_ERR)
          ierr = 1
       end if
 
-      if ( remainder == expected_remainder ) then
+      if (remainder == expected_remainder) then
          call mpas_log_write('          Remainder Test: PASSED')
       else
          call mpas_log_write(' **       Remainder Test: FAILED', MPAS_LOG_ERR)
          ierr = 1
       end if
 
+   end subroutine test_core_interval_test
+   !}}}
 
-   end subroutine test_core_interval_test!}}}
+   !***********************************************************************
+   !
+   !  routine mpas_adjust_alarm_tests
+   !
+   !> \brief   Tests functionality of mpas_adjust_alarm_to_reference_time
+   !> \author  Michael Duda
+   !> \date    25 Feb 2025
+   !> \details
+   !>  This routine tests the functionality of the
+   !>  mpas_adjust_alarm_to_reference_time routine for combinations of the
+   !>  following possibilities:
+   !>
+   !>  - The current time is aligned with the new alarm time grid
+   !>  - The current time is not aligned with the new alarm time grid
+   !>
+   !>  - The reference time is before the current time on the clock
+   !>  - The reference time is the same as the current time on the clock
+   !>  - The reference time is after the current time on the clock
+   !>
+   !>  - The clock is running forwards
+   !>  - The clock is running backwards
+   !>
+   !>  Upon return, the ierr arugment is set to the number of failed tests.
+   !
+   !-----------------------------------------------------------------------
+   subroutine mpas_adjust_alarm_tests(domain, ierr)
+
+      use mpas_derived_types, only: domain_type, MPAS_Clock_type, MPAS_Time_type, MPAS_TimeInterval_type
+      use mpas_kind_types, only: StrKIND
+      use mpas_log, only: mpas_log_write
+      use mpas_timekeeping, only: mpas_set_time, mpas_set_timeInterval, mpas_create_clock, &
+            mpas_add_clock_alarm, mpas_is_alarm_ringing, mpas_reset_clock_alarm
+
+      implicit none
+
+      type (domain_type), intent(inout) :: domain
+      integer, intent(out) :: ierr
+
+      integer :: istep
+      integer :: ierr_local
+      character(len = StrKIND) :: test_mesg
+      type (MPAS_Clock_type) :: test_clock
+      type (MPAS_Time_type) :: test_startTime
+      type (MPAS_Time_type) :: test_stopTime
+      type (MPAS_Time_type) :: test_currTime
+      type (MPAS_Time_type) :: test_alarmTime
+      type (MPAS_Time_type) :: test_refTime
+      type (MPAS_TimeInterval_type) :: test_timeStep
+      type (MPAS_TimeInterval_type) :: test_alarmTimeInterval
+      MPAS_ADJUST_ALARM_VERBOSE(character(len = StrKIND) :: timeStamp)
+
+      ierr = 0
+
+      !
+      ! Create a clock with an initial time of 2000-01-01_00 and with a 1-hour 'tick' length
+      ! (The stopping time is set to 2100-01-01_00.)
+      !
+      call mpas_set_time(test_startTime, YYYY = 2000, MM = 01, DD = 01, H = 0, M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr_local)
+      call mpas_set_time(test_stopTime, YYYY = 2100, MM = 01, DD = 01, H = 0, M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr_local)
+      call mpas_set_timeInterval(test_timeStep, dt = 3600.0_RKIND, ierr = ierr_local)
+
+      call mpas_create_clock(test_clock, test_startTime, test_timeStep, test_stopTime, ierr = ierr_local)
+
+      !
+      ! Add a recurring alarm to the clock with an initial reference time of 2000-01-01_00 and
+      ! a ringing interval of 1 day.
+      !
+      call mpas_set_time(test_alarmTime, YYYY = 2000, MM = 01, DD = 01, H = 0, M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr_local)
+      call mpas_set_timeInterval(test_alarmTimeInterval, dt = 86400.0_RKIND, ierr = ierr_local)
+
+      call mpas_add_clock_alarm(test_clock, 'foobar', test_alarmTime, test_alarmTimeInterval, ierr = ierr_local)
+
+#ifdef MPAS_ADVANCE_TEST_CLOCK
+      do istep = 1, 24*365
+          if (mpas_is_alarm_ringing(test_clock, 'foobar', ierr=ierr_local)) then
+              call mpas_reset_clock_alarm(test_clock, 'foobar', ierr=ierr_local)
+              test_currTime = mpas_get_clock_time(test_clock, MPAS_NOW, iErr)
+              call mpas_get_time(test_currTime, dateTimeString=timeStamp)
+              call mpas_log_write('**ALARM** '//trim(timeStamp))
+          end if
+          call mpas_advance_clock(test_clock, ierr=ierr_local)
+      end do
+#endif
+
+      MPAS_ADJUST_ALARM_VERBOSE(test_currTime = mpas_get_clock_time(test_clock, MPAS_NOW, iErr))
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_get_time(test_currTime, dateTimeString = timeStamp))
+
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write(''))
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('Now it is '//trim(timeStamp)))
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write(''))
+
+
+      write(test_mesg, '(a)') '  forward clock, ref_time < now, now is on new alarm time grid: '
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('================================='))
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('Setting ref time to 1999-06-15_00'))
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('---------------------------------'))
+      call mpas_set_time(test_refTime, YYYY = 1999, MM = 6, DD = 15, H = 0, M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr_local)
+      call mpas_adjust_alarm_to_reference_time(test_clock, 'foobar', test_refTime, ierr_local)
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_print_alarm(test_clock, 'foobar', ierr_local))
+      if (mpas_is_alarm_ringing(test_clock, 'foobar', ierr = ierr_local)) then
+         MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('-> Alarm is RINGING'))
+         test_mesg = trim(test_mesg) // ' SUCCESS'
+      else
+         MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('-> Alarm is NOT ringing'))
+         test_mesg = trim(test_mesg) // ' FAILURE'
+         ierr = ierr + 1
+      end if
+      call mpas_log_write(trim(test_mesg))
+      call mpas_reset_clock_alarm(test_clock, 'foobar', ierr = ierr_local)
+
+      write(test_mesg, '(a)') '  forward clock, ref_time > now, now is on new alarm time grid: '
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('================================='))
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('Setting ref time to 2010-02-01_00'))
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('---------------------------------'))
+      call mpas_set_time(test_refTime, YYYY = 2010, MM = 2, DD = 1, H = 0, M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr_local)
+      call mpas_adjust_alarm_to_reference_time(test_clock, 'foobar', test_refTime, ierr_local)
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_print_alarm(test_clock, 'foobar', ierr_local))
+      if (mpas_is_alarm_ringing(test_clock, 'foobar', ierr = ierr_local)) then
+         MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('-> Alarm is RINGING'))
+         test_mesg = trim(test_mesg) // ' SUCCESS'
+      else
+         MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('-> Alarm is NOT ringing'))
+         test_mesg = trim(test_mesg) // ' FAILURE'
+         ierr = ierr + 1
+      end if
+      call mpas_log_write(trim(test_mesg))
+      call mpas_reset_clock_alarm(test_clock, 'foobar', ierr = ierr_local)
+
+      write(test_mesg, '(a)') '  forward clock, ref_time = now, now is on new alarm time grid: '
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('================================='))
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('Setting ref time to 2000-01-01_00'))
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('---------------------------------'))
+      call mpas_set_time(test_refTime, YYYY = 2000, MM = 1, DD = 1, H = 0, M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr_local)
+      call mpas_adjust_alarm_to_reference_time(test_clock, 'foobar', test_refTime, ierr_local)
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_print_alarm(test_clock, 'foobar', ierr_local))
+      if (mpas_is_alarm_ringing(test_clock, 'foobar', ierr = ierr_local)) then
+         MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('-> Alarm is RINGING'))
+         test_mesg = trim(test_mesg) // ' SUCCESS'
+      else
+         MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('-> Alarm is NOT ringing'))
+         test_mesg = trim(test_mesg) // ' FAILURE'
+         ierr = ierr + 1
+      end if
+      call mpas_log_write(trim(test_mesg))
+      call mpas_reset_clock_alarm(test_clock, 'foobar', ierr = ierr_local)
+
+      write(test_mesg, '(a)') '  forward clock, ref_time < now, now is NOT on new alarm time grid: '
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('================================='))
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('Setting ref time to 1999-06-15_08'))
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('---------------------------------'))
+      call mpas_set_time(test_refTime, YYYY = 1999, MM = 6, DD = 15, H = 8, M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr_local)
+      call mpas_adjust_alarm_to_reference_time(test_clock, 'foobar', test_refTime, ierr_local)
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_print_alarm(test_clock, 'foobar', ierr_local))
+      if (mpas_is_alarm_ringing(test_clock, 'foobar', ierr = ierr_local)) then
+         MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('-> Alarm is RINGING'))
+         test_mesg = trim(test_mesg) // ' SUCCESS'
+      else
+         MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('-> Alarm is NOT ringing'))
+         test_mesg = trim(test_mesg) // ' FAILURE'
+         ierr = ierr + 1
+      end if
+      call mpas_log_write(trim(test_mesg))
+      call mpas_reset_clock_alarm(test_clock, 'foobar', ierr = ierr_local)
+
+      write(test_mesg, '(a)') '  forward clock, ref_time > now, now is NOT on new alarm time grid: '
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('================================='))
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('Setting ref time to 2010-02-01_18'))
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('---------------------------------'))
+      call mpas_set_time(test_refTime, YYYY = 2010, MM = 2, DD = 1, H = 18, M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr_local)
+      call mpas_adjust_alarm_to_reference_time(test_clock, 'foobar', test_refTime, ierr_local)
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_print_alarm(test_clock, 'foobar', ierr_local))
+      if (mpas_is_alarm_ringing(test_clock, 'foobar', ierr = ierr_local)) then
+         MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('-> Alarm is RINGING'))
+         test_mesg = trim(test_mesg) // ' SUCCESS'
+      else
+         MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('-> Alarm is NOT ringing'))
+         test_mesg = trim(test_mesg) // ' FAILURE'
+         ierr = ierr + 1
+      end if
+      call mpas_log_write(trim(test_mesg))
+      call mpas_reset_clock_alarm(test_clock, 'foobar', ierr = ierr_local)
+
+      !
+      ! Set clock to run backwards in time
+      !
+      call mpas_set_clock_direction(test_clock, MPAS_BACKWARD, ierr_local)
+
+      write(test_mesg, '(a)') '  backward clock, ref_time < now, now is on new alarm time grid: '
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('================================='))
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('Setting ref time to 1999-06-15_00'))
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('---------------------------------'))
+      call mpas_set_time(test_refTime, YYYY = 1999, MM = 6, DD = 15, H = 0, M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr_local)
+      call mpas_adjust_alarm_to_reference_time(test_clock, 'foobar', test_refTime, ierr_local)
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_print_alarm(test_clock, 'foobar', ierr_local))
+      if (mpas_is_alarm_ringing(test_clock, 'foobar', ierr = ierr_local)) then
+         MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('-> Alarm is RINGING'))
+         test_mesg = trim(test_mesg) // ' SUCCESS'
+      else
+         MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('-> Alarm is NOT ringing'))
+         test_mesg = trim(test_mesg) // ' FAILURE'
+         ierr = ierr + 1
+      end if
+      call mpas_log_write(trim(test_mesg))
+      call mpas_reset_clock_alarm(test_clock, 'foobar', ierr = ierr_local)
+
+      write(test_mesg, '(a)') '  backward clock, ref_time > now, now is on new alarm time grid: '
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('================================='))
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('Setting ref time to 2010-02-01_00'))
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('---------------------------------'))
+      call mpas_set_time(test_refTime, YYYY = 2010, MM = 2, DD = 1, H = 0, M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr_local)
+      call mpas_adjust_alarm_to_reference_time(test_clock, 'foobar', test_refTime, ierr_local)
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_print_alarm(test_clock, 'foobar', ierr_local))
+      if (mpas_is_alarm_ringing(test_clock, 'foobar', ierr = ierr_local)) then
+         MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('-> Alarm is RINGING'))
+         test_mesg = trim(test_mesg) // ' SUCCESS'
+      else
+         MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('-> Alarm is NOT ringing'))
+         test_mesg = trim(test_mesg) // ' FAILURE'
+         ierr = ierr + 1
+      end if
+      call mpas_log_write(trim(test_mesg))
+      call mpas_reset_clock_alarm(test_clock, 'foobar', ierr = ierr_local)
+
+      write(test_mesg, '(a)') '  backward clock, ref_time = now, now is on new alarm time grid: '
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('================================='))
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('Setting ref time to 2000-01-01_00'))
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('---------------------------------'))
+      call mpas_set_time(test_refTime, YYYY = 2000, MM = 1, DD = 1, H = 0, M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr_local)
+      call mpas_adjust_alarm_to_reference_time(test_clock, 'foobar', test_refTime, ierr_local)
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_print_alarm(test_clock, 'foobar', ierr_local))
+      if (mpas_is_alarm_ringing(test_clock, 'foobar', ierr = ierr_local)) then
+         MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('-> Alarm is RINGING'))
+         test_mesg = trim(test_mesg) // ' SUCCESS'
+      else
+         MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('-> Alarm is NOT ringing'))
+         test_mesg = trim(test_mesg) // ' FAILURE'
+         ierr = ierr + 1
+      end if
+      call mpas_log_write(trim(test_mesg))
+      call mpas_reset_clock_alarm(test_clock, 'foobar', ierr = ierr_local)
+
+      write(test_mesg, '(a)') '  backward clock, ref_time < now, now is NOT on new alarm time grid: '
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('================================='))
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('Setting ref time to 1999-06-15_08'))
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('---------------------------------'))
+      call mpas_set_time(test_refTime, YYYY = 1999, MM = 6, DD = 15, H = 8, M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr_local)
+      call mpas_adjust_alarm_to_reference_time(test_clock, 'foobar', test_refTime, ierr_local)
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_print_alarm(test_clock, 'foobar', ierr_local))
+      if (mpas_is_alarm_ringing(test_clock, 'foobar', ierr = ierr_local)) then
+         MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('-> Alarm is RINGING'))
+         test_mesg = trim(test_mesg) // ' SUCCESS'
+      else
+         MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('-> Alarm is NOT ringing'))
+         test_mesg = trim(test_mesg) // ' FAILURE'
+         ierr = ierr + 1
+      end if
+      call mpas_log_write(trim(test_mesg))
+      call mpas_reset_clock_alarm(test_clock, 'foobar', ierr = ierr_local)
+
+      write(test_mesg, '(a)') '  backward clock, ref_time > now, now is NOT on new alarm time grid: '
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('================================='))
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('Setting ref time to 2010-02-01_18'))
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('---------------------------------'))
+      call mpas_set_time(test_refTime, YYYY = 2010, MM = 2, DD = 1, H = 18, M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr_local)
+      call mpas_adjust_alarm_to_reference_time(test_clock, 'foobar', test_refTime, ierr_local)
+      MPAS_ADJUST_ALARM_VERBOSE(call mpas_print_alarm(test_clock, 'foobar', ierr_local))
+      if (mpas_is_alarm_ringing(test_clock, 'foobar', ierr = ierr_local)) then
+         MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('-> Alarm is RINGING'))
+         test_mesg = trim(test_mesg) // ' SUCCESS'
+      else
+         MPAS_ADJUST_ALARM_VERBOSE(call mpas_log_write('-> Alarm is NOT ringing'))
+         test_mesg = trim(test_mesg) // ' FAILURE'
+         ierr = ierr + 1
+      end if
+      call mpas_log_write(trim(test_mesg))
+      call mpas_reset_clock_alarm(test_clock, 'foobar', ierr = ierr_local)
+
+   end subroutine mpas_adjust_alarm_tests
+
+   subroutine mpas_alarm_ringing_tests(domain, ierr)
+      implicit none
+
+      type (domain_type), intent(inout) :: domain
+      integer, intent(out) :: ierr
+
+      integer :: ierr_local
+      type (MPAS_Time_type) :: clockStartTime
+      type (MPAS_Time_type) :: clockStopTime
+      type (MPAS_Time_type) :: alarmStartTime
+      type (MPAS_TimeInterval_type) :: clockTimeStep
+      type (MPAS_TimeInterval_type) :: alarm1TimeInterval
+      type (MPAS_TimeInterval_type) :: alarm2TimeInterval
+      type (MPAS_Clock_type) :: clock
+      character(len = :), allocatable :: alarm1Id, alarm2Id
+      character(len= StrKIND) :: currentTimeString, previousRingTimeString
+      type (MPAS_Alarm_type), pointer :: alarm2
+      integer :: hour, numHours
+
+      ierr = 0
+      alarm1Id = 'alarm1'
+      alarm2Id = 'alarm2'
+      numHours = 240
+
+      call mpas_set_time(clockStartTime, YYYY = 2000, MM = 01, DD = 01, H = 0, &
+            M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr_local)
+      call mpas_set_time(clockStopTime, YYYY = 2100, MM = 01, DD = 11, H = 0, &
+            M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr_local)
+      call mpas_set_timeInterval(clockTimeStep, dt = 3600.0_RKIND, ierr = ierr_local)
+      call mpas_create_clock(clock, clockStartTime, clockTimeStep, clockStopTime, ierr = ierr_local)
+
+      call mpas_set_time(alarmStartTime, YYYY = 2000, MM = 01, DD = 01, H = 0, &
+            M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr_local)
+      call mpas_set_timeInterval(alarm1TimeInterval, dt = 3600.0_RKIND, ierr = ierr_local)
+      call mpas_set_timeInterval(alarm2TimeInterval, dt = 14400.0_RKIND, ierr = ierr_local)
+      call mpas_add_clock_alarm(clock, 'alarm1', alarmStartTime, &
+            alarmTimeInterval = alarm1TimeInterval, ierr = ierr_local)
+      call mpas_add_clock_alarm(clock, 'alarm2', alarmStartTime, &
+            alarmTimeInterval = alarm2TimeInterval, ierr = ierr_local)
+      do hour = 0, numHours
+         ! Alarm1 should always ring
+         if (.not. mpas_is_alarm_ringing(clock, 'alarm1', ierr = ierr_local)) then
+            ierr = ierr + 1
+         end if
+
+         ! Alarm2 should ring only every 4 hours
+         if (mod(hour, 4) == 0) then
+            if (.not. mpas_is_alarm_ringing(clock, 'alarm2', ierr = ierr_local)) then
+               ierr = ierr + 1
+            end if
+         else
+            if (mpas_is_alarm_ringing(clock, 'alarm2', ierr = ierr_local)) then
+               ierr = ierr + 1
+            end if
+         end if
+
+         call mpas_reset_clock_alarm(clock, 'alarm1', ierr = ierr_local)
+         call mpas_reset_clock_alarm(clock, 'alarm2', ierr = ierr_local)
+         call mpas_advance_clock(clock, ierr = ierr_local)
+      end do
+   end subroutine mpas_alarm_ringing_tests
+
+   subroutine mpas_alarm_stop_time_tests(domain, ierr)
+      implicit none
+
+      type (domain_type), intent(inout) :: domain
+      integer, intent(out) :: ierr
+
+      integer :: ierr_local
+      type (MPAS_Time_type) :: clockStartTime
+      type (MPAS_Time_type) :: clockStopTime
+      type (MPAS_Time_type) :: alarmTime
+      type (MPAS_Time_type) :: alarmStopTime
+      type (MPAS_Time_type) :: currentTime
+      type (MPAS_TimeInterval_type) :: clockTimeStep
+      type (MPAS_TimeInterval_type) :: alarmStopTimeInterval
+      type (MPAS_Clock_type) :: clock
+      type (MPAS_Alarm_type), pointer :: alarmStop
+      character(len = :), allocatable :: alarmStopID
+      character(len= StrKIND) :: currentTimeString, alarmStopTimeString
+      integer :: hour, numHours
+
+      ierr = 0
+      alarmStopID = 'alarm_stop'
+      numHours = 240
+
+      call mpas_set_time(clockStartTime, YYYY = 2000, MM = 01, DD = 01, H = 0, &
+            M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr_local)
+      call mpas_set_time(clockStopTime, YYYY = 2100, MM = 01, DD = 01, H = 0, &
+            M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr_local)
+      call mpas_set_timeInterval(clockTimeStep, dt = 3600.0_RKIND, ierr = ierr_local)
+      call mpas_create_clock(clock, clockStartTime, clockTimeStep, clockStopTime, ierr = ierr_local)
+
+      call mpas_set_time(alarmTime, YYYY = 2000, MM = 01, DD = 01, H = 0, &
+            M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr_local)
+      call mpas_set_time(alarmStopTime, YYYY = 2000, MM = 01, DD = 11, H = 0, &
+            M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr_local)
+      call mpas_set_timeInterval(alarmStopTimeInterval, dt = 3600.0_RKIND, ierr = ierr_local)
+      call mpas_add_clock_alarm(clock, alarmStopID, alarmTime, &
+            alarmTimeInterval = alarmStopTimeInterval, alarmStopTime=alarmStopTime, ierr = ierr_local)
+      alarmStop => clock % alarmListHead
+      if (alarmStop % hasStopTime .eqv. .false.) then
+         print *, 'Alarm stop time not set correctly'
+         ierr = ierr + 1
+      end if
+      do hour = 1, numHours
+         if (.not. mpas_is_alarm_ringing(clock, alarmStopID, ierr = ierr_local)) then
+            print * , 'Alarm should be ringing at hour ', hour
+            ierr = ierr + 1
+         end if
+         call mpas_reset_clock_alarm(clock, alarmStopID, ierr = ierr_local)
+         call mpas_advance_clock(clock, ierr = ierr_local)
+      end do
+      currentTime = mpas_get_clock_time(clock, MPAS_NOW, ierr = ierr_local)
+      if (.not. eq_t_t(currentTime, alarmStopTime)) then
+         call mpas_get_time(currentTime, dateTimeString = currentTimeString)
+         call mpas_get_time(alarmStopTime, dateTimeString = alarmStopTimeString)
+         print *, 'Current time does not match alarm stop time:'
+         print *, '  Current time: ', trim(currentTimeString)
+         print *, '  Alarm stop time: ', trim(alarmStopTimeString)
+         ierr = ierr + 1
+      end if
+      call mpas_advance_clock(clock, ierr = ierr_local)
+      call mpas_reset_clock_alarm(clock, alarmStopID, ierr = ierr_local)
+      do hour = numHours, 2*numHours
+         if (mpas_is_alarm_ringing(clock, alarmStopID, ierr = ierr_local)) then
+            print *, 'Alarm should not be ringing after stop time'
+            ierr = ierr + 1
+         end if
+         call mpas_reset_clock_alarm(clock, alarmStopID, ierr = ierr_local)
+         call mpas_advance_clock(clock, ierr = ierr_local)
+      end do
+
+      ! Remove alarm and clock
+      call mpas_remove_clock_alarm(clock, alarmStopID, ierr = ierr_local)
+      call mpas_destroy_clock(clock, ierr = ierr_local)
+   end subroutine
+
+   subroutine mpas_alarm_stop_time_no_reset_tests(domain, ierr)
+      implicit none
+
+      type (domain_type), intent(inout) :: domain
+      integer, intent(out) :: ierr
+
+      integer :: ierr_local
+      type (MPAS_Time_type) :: clockStartTime
+      type (MPAS_Time_type) :: clockStopTime
+      type (MPAS_Time_type) :: alarmTime
+      type (MPAS_Time_type) :: alarmStopTime
+      type (MPAS_Time_type) :: currentTime
+      type (MPAS_TimeInterval_type) :: clockTimeStep
+      type (MPAS_TimeInterval_type) :: alarmStopTimeInterval
+      type (MPAS_Clock_type) :: clock
+      type (MPAS_Alarm_type), pointer :: alarmStop
+      character(len = :), allocatable :: alarmStopID
+      character(len= StrKIND) :: currentTimeString, alarmStopTimeString
+      integer :: hour, numHours
+
+      ierr = 0
+      alarmStopID = 'alarm_stop'
+      numHours = 240
+
+      call mpas_set_time(clockStartTime, YYYY = 2000, MM = 01, DD = 01, H = 0, &
+            M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr_local)
+      call mpas_set_time(clockStopTime, YYYY = 2100, MM = 01, DD = 01, H = 0, &
+            M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr_local)
+      call mpas_set_timeInterval(clockTimeStep, dt = 3600.0_RKIND, ierr = ierr_local)
+      call mpas_create_clock(clock, clockStartTime, clockTimeStep, clockStopTime, ierr = ierr_local)
+
+      call mpas_set_time(alarmTime, YYYY = 2000, MM = 01, DD = 01, H = 0, &
+            M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr_local)
+      call mpas_set_time(alarmStopTime, YYYY = 2000, MM = 01, DD = 11, H = 0, &
+            M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr_local)
+      call mpas_set_timeInterval(alarmStopTimeInterval, dt = 3600.0_RKIND, ierr = ierr_local)
+      call mpas_add_clock_alarm(clock, alarmStopID, alarmTime, &
+            alarmTimeInterval = alarmStopTimeInterval, alarmStopTime=alarmStopTime, ierr = ierr_local)
+      alarmStop => clock % alarmListHead
+      if (alarmStop % hasStopTime .eqv. .false.) then
+         print *, 'Alarm stop time not set correctly'
+         ierr = ierr + 1
+      end if
+      do hour = 1, numHours
+         if (.not. mpas_is_alarm_ringing(clock, alarmStopID, ierr = ierr_local)) then
+            print * , 'Alarm should be ringing at hour ', hour
+            ierr = ierr + 1
+         end if
+         call mpas_advance_clock(clock, ierr = ierr_local)
+      end do
+      currentTime = mpas_get_clock_time(clock, MPAS_NOW, ierr = ierr_local)
+      if (.not. eq_t_t(currentTime, alarmStopTime)) then
+         call mpas_get_time(currentTime, dateTimeString = currentTimeString)
+         call mpas_get_time(alarmStopTime, dateTimeString = alarmStopTimeString)
+         print *, 'Current time does not match alarm stop time:'
+         print *, '  Current time: ', trim(currentTimeString)
+         print *, '  Alarm stop time: ', trim(alarmStopTimeString)
+         ierr = ierr + 1
+      end if
+      do hour = numHours, 2*numHours
+         if (.not. mpas_is_alarm_ringing(clock, alarmStopID, ierr = ierr_local)) then
+            print *, 'Alarm should be ringing after stop time when not reset.'
+            ierr = ierr + 1
+         end if
+         call mpas_advance_clock(clock, ierr = ierr_local)
+      end do
+
+      ! Remove alarm and clock
+      call mpas_remove_clock_alarm(clock, alarmStopID, ierr = ierr_local)
+      call mpas_destroy_clock(clock, ierr = ierr_local)
+   end subroutine mpas_alarm_stop_time_no_reset_tests
+
+   subroutine mpas_alarm_start_time_tests(domain, ierr)
+      implicit none
+
+      type (domain_type), intent(inout) :: domain
+      integer, intent(out) :: ierr
+
+      integer :: ierr_local
+      type (MPAS_Time_type) :: clockStartTime
+      type (MPAS_Time_type) :: clockStopTime
+      type (MPAS_Time_type) :: alarmTime
+      type (MPAS_Time_type) :: alarmStartTime
+      type (MPAS_Time_type) :: currentTime
+      type (MPAS_TimeInterval_type) :: clockTimeStep
+      type (MPAS_TimeInterval_type) :: alarmStartTimeInterval
+      type (MPAS_Clock_type) :: clock
+      type (MPAS_Alarm_type), pointer :: alarmStart
+      character(len = :), allocatable :: alarmStartID
+      character(len= StrKIND) :: currentTimeString, alarmStartTimeString
+      integer :: hour, numHours
+
+      ierr = 0
+      alarmStartID = 'alarm_start'
+      numHours = 240
+
+      call mpas_set_time(clockStartTime, YYYY = 2000, MM = 01, DD = 01, H = 0, &
+            M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr_local)
+      call mpas_set_time(clockStopTime, YYYY = 2100, MM = 01, DD = 01, H = 0, &
+            M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr_local)
+      call mpas_set_timeInterval(clockTimeStep, dt = 3600.0_RKIND, ierr = ierr_local)
+      call mpas_create_clock(clock, clockStartTime, clockTimeStep, clockStopTime, ierr = ierr_local)
+
+      call mpas_set_time(alarmTime, YYYY = 2000, MM = 01, DD = 01, H = 0, &
+            M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr_local)
+      call mpas_set_time(alarmStartTime, YYYY = 2000, MM = 01, DD = 11, H = 0, &
+            M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr_local)
+      call mpas_set_timeInterval(alarmStartTimeInterval, dt = 3600.0_RKIND, ierr = ierr_local)
+      call mpas_add_clock_alarm(clock, alarmStartID, alarmTime, &
+            alarmTimeInterval = alarmStartTimeInterval, alarmStartTime=alarmStartTime, ierr = ierr_local)
+      alarmStart => clock % alarmListHead
+      if (alarmStart % hasStartTime .eqv. .false.) then
+         print *, 'Alarm start time not set correctly'
+         ierr = ierr + 1
+      end if
+      do hour = 1, numHours
+         if (mpas_is_alarm_ringing(clock, alarmStartID, ierr = ierr_local)) then
+            ierr = ierr + 1
+            print *, 'Alarm should not be ringing before start time'
+         end if
+         call mpas_advance_clock(clock, ierr = ierr_local)
+      end do
+      currentTime = mpas_get_clock_time(clock, MPAS_NOW, ierr = ierr_local)
+      if (.not. eq_t_t(currentTime, alarmStartTime)) then
+         call mpas_get_time(currentTime, dateTimeString = currentTimeString)
+         call mpas_get_time(alarmStartTime, dateTimeString = alarmStartTimeString)
+         print *, 'Current time does not match alarm start time:'
+         print *, '  Current time: ', trim(currentTimeString)
+         print *, '  Alarm start time: ', trim(alarmStartTimeString)
+         ierr = ierr + 1
+      end if
+
+      ! Remove alarm and clock
+      call mpas_remove_clock_alarm(clock, alarmStartID, ierr = ierr_local)
+      call mpas_destroy_clock(clock, ierr = ierr_local)
+   end subroutine
+
+   subroutine mpas_alarm_start_stop_time_tests(domain, ierr)
+      implicit none
+
+      type (domain_type), intent(inout) :: domain
+      integer, intent(out) :: ierr
+
+      integer :: ierr_local
+      type (MPAS_Time_type) :: clockStartTime
+      type (MPAS_Time_type) :: clockStopTime
+      type (MPAS_Time_type) :: alarmTime
+      type (MPAS_Time_type) :: alarmStartTime
+      type (MPAS_Time_type) :: alarmStopTime
+      type (MPAS_Time_type) :: currentTime
+      type (MPAS_TimeInterval_type) :: clockTimeStep
+      type (MPAS_TimeInterval_type) :: alarmStartTimeInterval
+      type (MPAS_Clock_type) :: clock
+      type (MPAS_Alarm_type), pointer :: alarmStartStop
+      character(len = :), allocatable :: alarmStartStopID
+      character(len= StrKIND) :: currentTimeString, alarmStartTimeString, alarmStopTimeString
+      integer :: hour, numHours
+
+      ierr = 0
+      alarmStartStopID = 'alarm_start_stop'
+      numHours = 240
+
+      call mpas_set_time(clockStartTime, YYYY = 2000, MM = 01, DD = 01, H = 0, &
+            M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr_local)
+      call mpas_set_time(clockStopTime, YYYY = 2100, MM = 01, DD = 01, H = 0, &
+            M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr_local)
+      call mpas_set_timeInterval(clockTimeStep, dt = 3600.0_RKIND, ierr = ierr_local)
+      call mpas_create_clock(clock, clockStartTime, clockTimeStep, clockStopTime, ierr = ierr_local)
+
+      call mpas_set_time(alarmTime, YYYY = 2000, MM = 01, DD = 01, H = 0, &
+            M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr_local)
+      call mpas_set_time(alarmStartTime, YYYY = 2000, MM = 01, DD = 11, H = 0, &
+            M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr_local)
+      call mpas_set_time(alarmStopTime, YYYY = 2000, MM = 01, DD = 21, H = 0, &
+            M = 0, S = 0, S_n = 0, S_d = 0, ierr = ierr_local)
+      call mpas_set_timeInterval(alarmStartTimeInterval, dt = 3600.0_RKIND, ierr = ierr_local)
+      call mpas_add_clock_alarm(clock, alarmStartStopID, alarmTime, &
+            alarmTimeInterval = alarmStartTimeInterval, alarmStartTime=alarmStartTime, &
+            alarmStopTime=alarmStopTime, ierr = ierr_local)
+      alarmStartStop => clock % alarmListHead
+      if (alarmStartStop % hasStartTime .eqv. .false.) then
+         print *, 'Alarm start time not set correctly'
+         ierr = ierr + 1
+      end if
+      if (alarmStartStop % hasStopTime .eqv. .false.) then
+         print *, 'Alarm stop time not set correctly'
+         ierr = ierr + 1
+      end if
+      do hour = 1, numHours
+         if (mpas_is_alarm_ringing(clock, alarmStartStopID, ierr = ierr_local)) then
+            ierr = ierr + 1
+            print *, 'Alarm should not be ringing before start time'
+         end if
+         call mpas_reset_clock_alarm(clock, alarmStartStopID, ierr = ierr_local)
+         call mpas_advance_clock(clock, ierr = ierr_local)
+      end do
+      currentTime = mpas_get_clock_time(clock, MPAS_NOW, ierr = ierr_local)
+      if (.not. eq_t_t(currentTime, alarmStartTime)) then
+         call mpas_get_time(currentTime, dateTimeString = currentTimeString)
+         call mpas_get_time(alarmStartTime, dateTimeString = alarmStartTimeString)
+         print *, 'Current time does not match alarm start time:'
+         print *, '  Current time: ', trim(currentTimeString)
+         print *, '  Alarm start time: ', trim(alarmStartTimeString)
+         ierr = ierr + 1
+      end if
+      do hour = 1, numHours
+         if (.not. mpas_is_alarm_ringing(clock, alarmStartStopID, ierr = ierr_local)) then
+            ierr = ierr + 1
+            print *, 'Alarm should be ringing after start time and before stop time.'
+         end if
+         call mpas_reset_clock_alarm(clock, alarmStartStopID, ierr = ierr_local)
+         call mpas_advance_clock(clock, ierr = ierr_local)
+      end do
+      currentTime = mpas_get_clock_time(clock, MPAS_NOW, ierr = ierr_local)
+      if (.not. eq_t_t(currentTime, alarmStopTime)) then
+         call mpas_get_time(currentTime, dateTimeString = currentTimeString)
+         call mpas_get_time(alarmStartTime, dateTimeString = alarmStopTimeString)
+         print *, 'Current time does not match alarm stop time:'
+         print *, '  Current time: ', trim(currentTimeString)
+         print *, '  Alarm stop time: ', trim(alarmStopTimeString)
+         ierr = ierr + 1
+      end if
+      call mpas_reset_clock_alarm(clock, alarmStartStopID, ierr = ierr_local)
+      call mpas_advance_clock(clock, ierr = ierr_local)
+      do hour = 1, numHours
+         if (mpas_is_alarm_ringing(clock, alarmStartStopID, ierr = ierr_local)) then
+            ierr = ierr + 1
+            print *, 'Alarm should not be ringing after stop time.'
+         end if
+         call mpas_reset_clock_alarm(clock, alarmStartStopID, ierr = ierr_local)
+         call mpas_advance_clock(clock, ierr = ierr_local)
+      end do
+      ! Remove alarm and clock
+      call mpas_remove_clock_alarm(clock, alarmStartStopID, ierr = ierr_local)
+      call mpas_destroy_clock(clock, ierr = ierr_local)
+   end subroutine
 
 end module test_core_timekeeping_tests

--- a/src/framework/mpas_timekeeping.F
+++ b/src/framework/mpas_timekeeping.F
@@ -486,8 +486,8 @@ module mpas_timekeeping
    end function mpas_get_clock_time
 
 
-   subroutine mpas_add_clock_alarm(clock, alarmID, alarmTime, alarmTimeInterval, ierr)
-! TODO: possibly add a stop time for recurring alarms
+   subroutine mpas_add_clock_alarm(clock, alarmID, alarmTime, alarmTimeInterval, &
+         alarmStartTime, alarmStopTime, ierr)
 
       implicit none
 
@@ -495,6 +495,8 @@ module mpas_timekeeping
       character (len=*), intent(in) :: alarmID
       type (MPAS_Time_type), intent(in) :: alarmTime
       type (MPAS_TimeInterval_type), intent(in), optional :: alarmTimeInterval
+      type (MPAS_Time_type), intent(in), optional :: alarmStartTime
+      type (MPAS_Time_type), intent(in), optional :: alarmStopTime
       integer, intent(out), optional :: ierr
 
       type (MPAS_Alarm_type), pointer :: alarmPtr
@@ -554,6 +556,18 @@ module mpas_timekeeping
          else
             alarmPtr % isRecurring = .false.
             alarmPtr % prevRingTime = alarmTime
+         end if
+         if (present(alarmStartTime)) then
+            alarmPtr % startTime = alarmStartTime
+            alarmPtr % hasStartTime = .true.
+         else
+            alarmPtr % hasStartTime = .false.
+         end if
+         if (present(alarmStopTime)) then
+            alarmPtr % stopTime = alarmStopTime
+            alarmPtr % hasStopTime = .true.
+         else
+            alarmPtr % hasStopTime = .false.
          end if
          if (present(ierr)) then
             if (ierr == ESMF_SUCCESS) ierr = 0
@@ -887,8 +901,20 @@ module mpas_timekeeping
       alarmNow = mpas_get_clock_time(clock, MPAS_NOW, ierr)
       alarmThreshold = alarmPtr % ringTime 
       
-      mpas_in_ringing_envelope = .false.      
-               
+      mpas_in_ringing_envelope = .false.
+
+      if (alarmPtr % hasStartTime) then
+         if (alarmNow < alarmPtr % startTime) then
+            return
+         end if
+      end if
+
+      if (alarmPtr % hasStopTime) then
+         if (alarmNow > alarmPtr % stopTime .and. .not. alarmPtr % isSet) then
+            return
+         end if
+      end if
+
       if(clock % direction == MPAS_FORWARD) then
 
          if (present(interval)) then
@@ -971,6 +997,11 @@ module mpas_timekeeping
                         call mpas_interval_division(alarmPtr % prevRingTime, nowInterval, alarmPtr % ringTimeInterval, nDivs, nowRemainder)
                         alarmPtr % prevRingTime = alarmNow + nowRemainder
                      end if
+                  end if
+               end if
+               if (alarmPtr % hasStopTime) then
+                  if (alarmNow >= alarmPtr % stopTime) then
+                     alarmPtr % isSet = .false.   ! permanently disable
                   end if
                end if
                exit

--- a/src/framework/mpas_timekeeping.F
+++ b/src/framework/mpas_timekeeping.F
@@ -19,7 +19,7 @@ module mpas_timekeeping
    private :: mpas_calibrate_alarms
    private :: mpas_in_ringing_envelope
 
-   integer :: TheCalendar 
+   integer :: TheCalendar
    integer :: yearWidth
 
    integer, dimension(12), parameter :: daysInMonth     = (/31,28,31,30,31,30,31,31,30,31,30,31/)
@@ -88,7 +88,7 @@ module mpas_timekeeping
 
       implicit none
 
-      character (len=*), intent(in) :: calendar 
+      character (len=*), intent(in) :: calendar
 
       if (trim(calendar) == 'gregorian') then
          TheCalendar = MPAS_GREGORIAN
@@ -198,7 +198,7 @@ module mpas_timekeeping
                   return
                end if
             end if
-         else if (present(stopTime)) then 
+         else if (present(stopTime)) then
             stop_time = stopTime
          else
             if (present(ierr)) ierr = 1   ! neither stopTime nor runDuration are specified
@@ -543,7 +543,7 @@ module mpas_timekeeping
 
          alarmPtr % isSet = .true.
          alarmPtr % ringTime = alarmTime
-         
+
 
          if (present(alarmTimeInterval)) then
             alarmPtr % isRecurring = .true.
@@ -551,7 +551,7 @@ module mpas_timekeeping
             if(clock % direction == MPAS_FORWARD) then
                alarmPtr % prevRingTime = alarmTime - alarmTimeInterval
             else
-               alarmPtr % prevRingTime = alarmTime + alarmTimeInterval         
+               alarmPtr % prevRingTime = alarmTime + alarmTimeInterval
             end if
          else
             alarmPtr % isRecurring = .false.
@@ -648,7 +648,7 @@ module mpas_timekeeping
             mpas_is_alarm_defined = .true.
             return
          end if
-         alarmPtr => alarmPtr % next 
+         alarmPtr => alarmPtr % next
       end do
 
    end function mpas_is_alarm_defined
@@ -687,7 +687,7 @@ module mpas_timekeeping
             end if
             return
          end if
-         alarmPtr => alarmPtr % next 
+         alarmPtr => alarmPtr % next
       end do
 
    end function mpas_alarm_interval
@@ -838,7 +838,7 @@ module mpas_timekeeping
       if (present(ierr)) ierr = 0
 
       mpas_is_alarm_ringing = .false.
-      
+
       alarmPtr => clock % alarmListHead
       do while (associated(alarmPtr))
          if (trim(alarmPtr % alarmID) == trim(alarmID)) then
@@ -889,18 +889,18 @@ module mpas_timekeeping
    logical function mpas_in_ringing_envelope(clock, alarmPtr, interval, ierr)
 
       implicit none
-      
+
       type (MPAS_Clock_type), intent(in) :: clock
       type (MPAS_Alarm_type), pointer :: alarmPtr
       type (MPAS_TimeInterval_type), intent(in), optional :: interval
       integer, intent(out), optional :: ierr
-      
+
       type (MPAS_Time_type) :: alarmNow
       type (MPAS_Time_type) :: alarmThreshold
 
       alarmNow = mpas_get_clock_time(clock, MPAS_NOW, ierr)
-      alarmThreshold = alarmPtr % ringTime 
-      
+      alarmThreshold = alarmPtr % ringTime
+
       mpas_in_ringing_envelope = .false.
 
       if (alarmPtr % hasStartTime) then
@@ -918,7 +918,7 @@ module mpas_timekeeping
       if(clock % direction == MPAS_FORWARD) then
 
          if (present(interval)) then
-            alarmNow = alarmNow + interval; 
+            alarmNow = alarmNow + interval;
          end if
 
          if (alarmPtr % isRecurring) then
@@ -931,13 +931,13 @@ module mpas_timekeeping
       else
 
          if (present(interval)) then
-            alarmNow = alarmNow - interval; 
+            alarmNow = alarmNow - interval;
          end if
 
          if (alarmPtr % isRecurring) then
             alarmThreshold = alarmPtr % prevRingTime - alarmPtr % ringTimeInterval
          end if
-            
+
          if (alarmThreshold >= alarmNow) then
             mpas_in_ringing_envelope = .true.
          end if
@@ -945,9 +945,41 @@ module mpas_timekeeping
 
    end function mpas_in_ringing_envelope
 
+      !-----------------------------------------------------------------------
+      !  routine mpas_update_alarm_stop_status
+      !
+      !> \brief Update an alarm's active status based on its stop time.
+      !> \author Andy Stokely
+      !> \date   09/19/2025
+      !> \details This routine checks whether an alarm has reached or passed
+      !>   its configured stop time, and updates its status accordingly:
+      !>   * If the clock is running forward and the current time is at or
+      !>     beyond the stop time, the alarm is permanently disabled.
+      !>   * If the clock is running backward and the current time is at or
+      !>     beyond the stop time, the alarm is re-enabled.
+      !>
+      !>   This logic is applied to alarms that have the `hasStopTime` flag set.
+      !-----------------------------------------------------------------------
+      subroutine mpas_update_alarm_stop_status(clock, alarm_ptr, alarm_now)
+         implicit none
+
+         type(MPAS_Clock_type), intent(in) :: clock
+         type(MPAS_Alarm_type), pointer, intent(inout) :: alarm_ptr
+         type(MPAS_Time_type), intent(in) :: alarm_now
+
+         if (alarm_ptr%hasStopTime) then
+            if (alarm_now >= alarm_ptr%stopTime) then
+               if (clock%direction == MPAS_FORWARD) then
+                  alarm_ptr%isSet = .false. ! disable alarm unless clock direction changes
+               else
+                  alarm_ptr%isSet = .true. ! re-enable alarm if clock is running backward
+               end if
+            end if
+         end if
+      end subroutine mpas_update_alarm_stop_status
 
 
-   subroutine mpas_reset_clock_alarm(clock, alarmID, interval, ierr)
+      subroutine mpas_reset_clock_alarm(clock, alarmID, interval, ierr)
 
       implicit none
 
@@ -970,13 +1002,13 @@ module mpas_timekeeping
       if ( threadNum == 0 ) then
          alarmPtr => clock % alarmListHead
          do while (associated(alarmPtr))
-         
+
             if (trim(alarmPtr % alarmID) == trim(alarmID)) then
 
                if (mpas_in_ringing_envelope(clock, alarmPtr, interval, ierr)) then
 
                   if (.not. alarmPtr % isRecurring) then
-                     alarmPtr % isSet = .false. 
+                     alarmPtr % isSet = .false.
                   else
                      alarmNow = mpas_get_clock_time(clock, MPAS_NOW, ierr)
 
@@ -999,12 +1031,7 @@ module mpas_timekeeping
                      end if
                   end if
                end if
-               if (alarmPtr % hasStopTime) then
-                  if (alarmNow >= alarmPtr % stopTime) then
-                     alarmPtr % isSet = .false.   ! permanently disable
-                  end if
-               end if
-               exit
+               call mpas_update_alarm_stop_status(clock, alarmPtr, alarmNow)
             end if
             alarmPtr => alarmPtr % next
          end do
@@ -1032,12 +1059,16 @@ module mpas_timekeeping
       ! Local variables
       type (MPAS_Alarm_type), pointer :: alarmPtr
       type (MPAS_TimeInterval_type) :: searchInterval, searchRemainder
+      type (MPAS_TimeInterval_type) :: zeroInterval
       integer (kind=I8KIND) :: nDivs
       integer :: threadNum
       integer :: ierr_tmp
 
+
       ierr = 0
       ierr_tmp = 0
+
+      call mpas_set_timeInterval(zeroInterval, S=0)
 
       threadNum = mpas_threading_get_thread_num()
 
@@ -1055,22 +1086,26 @@ module mpas_timekeeping
                      if (now > referenceTime) then
                         searchInterval = now - referenceTime
                         call mpas_interval_division(referenceTime, searchInterval, alarmPtr % ringTimeInterval, nDivs, searchRemainder)
-                        alarmPtr % prevRingTime = now - searchRemainder
                      else
                         searchInterval = referenceTime - now
                         call mpas_interval_division(referenceTime, searchInterval, alarmPtr % ringTimeInterval, nDivs, searchRemainder)
-                        alarmPtr % prevRingTime = now - (alarmPtr % ringTimeInterval - searchRemainder)
+                        if (searchRemainder /= zeroInterval) then
+                            searchRemainder = alarmPtr % ringTimeInterval - searchRemainder
+                        end if
                      endif
-                  else ! MPAS_REVERSE
+                     alarmPtr % prevRingTime = now - alarmPtr % ringTimeInterval - searchRemainder
+                  else ! MPAS_BACKWARD
                      if (now < referenceTime) then
+                        searchInterval = referenceTime - now
+                        call mpas_interval_division(referenceTime, searchInterval, alarmPtr % ringTimeInterval, nDivs, searchRemainder)
+                     else
                         searchInterval = now - referenceTime
                         call mpas_interval_division(referenceTime, searchInterval, alarmPtr % ringTimeInterval, nDivs, searchRemainder)
-                        alarmPtr % prevRingTime = now - searchRemainder
-                     else
-                        searchInterval = referenceTime - now
-                        call mpas_interval_division(referenceTime, searchInterval, alarmPtr % ringTimeInterval, nDivs, searchRemainder)
-                        alarmPtr % prevRingTime = now - (alarmPtr % ringTimeInterval - searchRemainder)
+                        if (searchRemainder /= zeroInterval) then
+                            searchRemainder = alarmPtr % ringTimeInterval - searchRemainder
+                        end if
                      endif
+                     alarmPtr % prevRingTime = now + alarmPtr % ringTimeInterval + searchRemainder
                   end if  ! forward direction
                   !call mpas_print_alarm(clock, alarmID, ierr_tmp)
                end if  ! isRecurring
@@ -1103,29 +1138,29 @@ module mpas_timekeeping
       threadNum = mpas_threading_get_thread_num()
 
       now = mpas_get_clock_time(clock, MPAS_NOW, ierr)
-      
+
       if ( threadNum == 0 ) then
          alarmPtr => clock % alarmListHead
          do while (associated(alarmPtr))
-            
+
             if (.not. alarmPtr % isRecurring) then
-               alarmPtr % isSet = .true.            
+               alarmPtr % isSet = .true.
             else
-            
+
                previousRingTime = alarmPtr % prevRingTime
 
                if (previousRingTime <= now) then
-               
+
                   do while(previousRingTime <= now)
                      previousRingTime = previousRingTime + alarmPtr % ringTimeInterval
                   end do
                   positiveNeighborRingTime = previousRingTime
-               
+
                   do while(previousRingTime >= now)
                      previousRingTime = previousRingTime - alarmPtr % ringTimeInterval
                   end do
                   negativeNeighborRingTime = previousRingTime
-               
+
                else
 
                   do while(previousRingTime >= now)
@@ -1137,7 +1172,7 @@ module mpas_timekeeping
                      previousRingTime = previousRingTime + alarmPtr % ringTimeInterval
                   end do
                   positiveNeighborRingTime = previousRingTime
-            
+
                end if
 
                if (clock % direction == MPAS_FORWARD) then
@@ -1147,18 +1182,18 @@ module mpas_timekeeping
                end if
 
             end if
-   
+
             alarmPtr => alarmPtr % next
-            
+
          end do
-   
+
          if (present(ierr)) then
             if (ierr == ESMF_SUCCESS) ierr = 0
          end if
       end if
 
       !$omp barrier
-   
+
    end subroutine mpas_calibrate_alarms
 
 
@@ -1202,7 +1237,7 @@ module mpas_timekeeping
             deallocate(subStrings)
             denominatorPower = len_trim(secDecSubString)
             if(denominatorPower > 0) then
-               read(secDecSubString,*) numerator 
+               read(secDecSubString,*) numerator
                if(numerator > 0) then
                   denominator = 10**denominatorPower
                end if
@@ -1222,13 +1257,13 @@ module mpas_timekeeping
             dateSubString = subStrings(1)
             timeSubString = subStrings(2)
             deallocate(subStrings)
-            
+
             call mpas_split_string(timeSubString, ":", subStrings)
-            
+
             if (size(subStrings) == 3) then
-               read(subStrings(1),*) hour 
-               read(subStrings(2),*) min 
-               read(subStrings(3),*) sec 
+               read(subStrings(1),*) hour
+               read(subStrings(2),*) min
+               read(subStrings(3),*) sec
                deallocate(subStrings)
             else
                deallocate(subStrings)
@@ -1237,14 +1272,14 @@ module mpas_timekeeping
                return
             end if
 
-         else if(size(subStrings) == 1) then   ! contains only a date- assume all time values are 0 
+         else if(size(subStrings) == 1) then   ! contains only a date- assume all time values are 0
             dateSubString = subStrings(1)
             deallocate(subStrings)
-           
+
             hour = 0
             min = 0
             sec = 0
-         
+
          else
             deallocate(subStrings)
             if (present(ierr)) ierr = 1
@@ -1253,9 +1288,9 @@ module mpas_timekeeping
          end if
 
          call mpas_split_string(dateSubString, "-", subStrings)
-            
+
          if (size(subStrings) == 3) then
-            read(subStrings(1),*) year 
+            read(subStrings(1),*) year
             read(subStrings(2),*) month
             read(subStrings(3),*) day
             deallocate(subStrings)
@@ -1269,10 +1304,10 @@ module mpas_timekeeping
          call ESMF_TimeSet(curr_time % t, YY=year, MM=month, DD=day, H=hour, M=min, S=sec, Sn=numerator, Sd=denominator, rc=ierr)
 
       else
-      
+
          if (present(DoY)) then
             call mpas_get_month_day(YYYY, DoY, month, day)
-         
+
             ! consistency check
             if (present(MM)) then
                if (MM /= month) then
@@ -1310,9 +1345,9 @@ module mpas_timekeeping
          end if
 
          call ESMF_TimeSet(curr_time % t, YY=YYYY, MM=month, DD=day, H=H, M=M, S=S, Sn=S_n, Sd=S_d, rc=ierr)
-      
+
       end if
-      
+
       if (present(ierr)) then
          if (ierr == ESMF_SUCCESS) ierr = 0
       end if
@@ -1502,7 +1537,7 @@ module mpas_timekeeping
          denominator = 1
 
          call mpas_split_string(timeString_, ".", subStrings)
-         
+
          if (size(subStrings) == 2) then ! contains second decimals
             timeString_ = subStrings(1)
             secDecSubString = subStrings(2)(:integerMaxDigits)
@@ -1510,7 +1545,7 @@ module mpas_timekeeping
 
             denominatorPower = len_trim(secDecSubString)
             if(denominatorPower > 0) then
-               read(secDecSubString,*) numerator 
+               read(secDecSubString,*) numerator
                if(numerator > 0) then
                   denominator = 10**denominatorPower
                end if
@@ -1567,21 +1602,21 @@ module mpas_timekeeping
          end if
 
          call mpas_split_string(timeSubString, ":", subStrings)
-            
+
          if (size(subStrings) == 3) then
-            read(subStrings(1),*) hour 
-            read(subStrings(2),*) min 
-            read(subStrings(3),*) sec 
+            read(subStrings(1),*) hour
+            read(subStrings(2),*) min
+            read(subStrings(3),*) sec
             deallocate(subStrings)
          else if (size(subStrings) == 2) then
             hour = 0
-            read(subStrings(1),*) min 
-            read(subStrings(2),*) sec 
+            read(subStrings(1),*) min
+            read(subStrings(2),*) sec
             deallocate(subStrings)
          else if (size(subStrings) == 1) then
             hour = 0
             min = 0
-            read(subStrings(1),*) sec 
+            read(subStrings(1),*) sec
             deallocate(subStrings)
          else
             deallocate(subStrings)
@@ -1595,7 +1630,7 @@ module mpas_timekeeping
       else
 
          call ESMF_TimeIntervalSet(interval % ti, YY=YY, MM=MM, D=DD, H=H, M=M, S_i8=S_i8, S=S, Sn=S_n, Sd=S_d, rc=ierr)
-      
+
       end if
 
 !     ! verify that time interval is positive
@@ -1606,10 +1641,10 @@ module mpas_timekeeping
 !     end if
 
 !     if (interval <= zeroInterval) then
-!        if (present(ierr)) ierr = 1   
+!        if (present(ierr)) ierr = 1
 !        call mpas_log_write('TimeInterval must be greater than zero: '// trim(timeString), MPAS_LOG_ERR) !'ERROR: TimeInterval cannot be negative'
 !     end if
-      
+
    end subroutine mpas_set_timeInterval
 
 
@@ -1859,7 +1894,7 @@ module mpas_timekeeping
    !> \brief This routine computes the number intervals that fit into another interval.
    !> \author Michael Duda, Doug Jacobsen, Daniel Henderson
    !> \date   4 October 2016
-   !> \details 
+   !> \details
    !> This routine performs time-interval division on any intervals with cost
    !> that is proportional to the log of the result, n.
    !> It works by first performing a forward search, doubling intervals, until
@@ -2096,8 +2131,8 @@ module mpas_timekeeping
       integer :: D, S, Sn, Sd
 
       call ESMF_TimeIntervalGet(ti % ti, D=D, S=S, Sn=Sn, Sd=Sd, rc=rc)
-      D    = -D 
-      S    = -S 
+      D    = -D
+      S    = -S
       Sn   = -Sn
       call ESMF_TimeIntervalSet(neg_ti % ti, D=D, S=S, Sn=Sn, Sd=Sd, rc=rc)
 
@@ -2118,8 +2153,8 @@ module mpas_timekeeping
 
       if(ti < zeroInterval) then
          call ESMF_TimeIntervalGet(ti % ti, D=D, S=S, Sn=Sn, Sd=Sd, rc=rc)
-         D    = -D 
-         S    = -S 
+         D    = -D
+         S    = -S
          Sn   = -Sn
          call ESMF_TimeIntervalSet(abs_ti % ti, D=D, S=S, Sn=Sn, Sd=Sd, rc=rc)
       else
@@ -2141,14 +2176,14 @@ module mpas_timekeeping
 !   end function mod
 
     subroutine mpas_get_month_day(YYYY, DoY, month, day)
-       
+
        implicit none
 
        integer, intent(in) :: YYYY, DoY
        integer, intent(out) :: month, day
 
        integer, dimension(12) :: dpm
-       
+
        if (isLeapYear(YYYY)) then
           dpm(:) = daysInMonthLeap
        else
@@ -2159,20 +2194,20 @@ module mpas_timekeeping
        day = DoY
        do while (day > dpm(month))
           day = day -  dpm(month)
-          month = month + 1       
+          month = month + 1
        end do
 
     end subroutine mpas_get_month_day
 
 
    logical function isValidDate(YYYY, MM, DD)
-   
+
       integer, intent(in) :: YYYY, MM, DD
       integer :: daysInMM
-      
+
       isValidDate = .true.
 
-      ! TODO: ???? Gregorian calendar has no year zero, but perhaps 0 = 1 BC ??? 
+      ! TODO: ???? Gregorian calendar has no year zero, but perhaps 0 = 1 BC ???
       !if (YYYY == 0) then
       !   isValidDate = .false.
       !   return
@@ -2194,10 +2229,10 @@ module mpas_timekeeping
          if (TheCalendar == MPAS_GREGORIAN .and. isLeapYear(YYYY)) then
             daysInMM = daysInMonthLeap(MM)
          else
-            daysInMM = daysInMonth(MM)        
+            daysInMM = daysInMonth(MM)
          end if
       end if
-     
+
       if (DD > daysInMM) then
          isValidDate = .false.
          return
@@ -2205,7 +2240,7 @@ module mpas_timekeeping
 
    end function
 
-    
+
     logical function isLeapYear(year)
 
        implicit none
@@ -2213,7 +2248,7 @@ module mpas_timekeeping
        integer, intent(in) :: year
 
        isLeapYear = .false.
-       
+
        if (mod(year,4) == 0) then
           if (mod(year,100) == 0) then
              if (mod(year,400) == 0) then
@@ -2344,6 +2379,6 @@ module mpas_timekeeping
         end do
 
     end subroutine mpas_expand_string!}}}
- 
+
 
 end module mpas_timekeeping

--- a/src/framework/mpas_timekeeping.F
+++ b/src/framework/mpas_timekeeping.F
@@ -945,38 +945,52 @@ module mpas_timekeeping
 
    end function mpas_in_ringing_envelope
 
+
       !-----------------------------------------------------------------------
-      !  routine mpas_update_alarm_stop_status
+      !  routine mpas_update_alarm_active_state
       !
-      !> \brief Update an alarm's active status based on its stop time.
+      !> \brief Update whether an alarm is active, based on its stop time.
+      !>
       !> \author Andy Stokely
       !> \date   09/19/2025
-      !> \details This routine checks whether an alarm has reached or passed
-      !>   its configured stop time, and updates its status accordingly:
-      !>   * If the clock is running forward and the current time is at or
-      !>     beyond the stop time, the alarm is permanently disabled.
-      !>   * If the clock is running backward and the current time is at or
-      !>     beyond the stop time, the alarm is re-enabled.
       !>
-      !>   This logic is applied to alarms that have the `hasStopTime` flag set.
+      !> \details
+      !>   This routine determines whether an alarm should remain active
+      !>   given the clock direction and the alarm's configured stop time:
+      !>
+      !>   * If the alarm has no stop time, nothing is changed.
+      !>   * If the clock is running forward:
+      !>       - When the current time reaches or exceeds the stop time,
+      !>         the alarm is permanently disabled (`isSet = .false.`).
+      !>   * If the clock is running backward:
+      !>       - When the current time is at or beyond the stop time,
+      !>         the alarm is re-enabled (`isSet = .true.`), allowing
+      !>         it to become active again as the clock re-enters its window.
+      !>
+      !>   This routine is typically called inside alarm management logic
+      !>   such as `mpas_reset_clock_alarm` to ensure alarms obey their
+      !>   stop-time rules consistently.
       !-----------------------------------------------------------------------
-      subroutine mpas_update_alarm_stop_status(clock, alarm_ptr, alarm_now)
+      subroutine mpas_update_alarm_active_state(clock, alarm_ptr, alarm_now)
          implicit none
 
-         type(MPAS_Clock_type), intent(in) :: clock
+         type(MPAS_Clock_type), intent(in)    :: clock
          type(MPAS_Alarm_type), pointer, intent(inout) :: alarm_ptr
-         type(MPAS_Time_type), intent(in) :: alarm_now
+         type(MPAS_Time_type), intent(in)     :: alarm_now
 
-         if (alarm_ptr%hasStopTime) then
-            if (alarm_now >= alarm_ptr%stopTime) then
-               if (clock%direction == MPAS_FORWARD) then
-                  alarm_ptr%isSet = .false. ! disable alarm unless clock direction changes
-               else
-                  alarm_ptr%isSet = .true. ! re-enable alarm if clock is running backward
-               end if
-            end if
+         ! If no stop time is defined, the alarm remains unchanged.
+         if (.not. alarm_ptr%hasStopTime) return
+
+         ! Only act if we've crossed the stop time.
+         if (alarm_now >= alarm_ptr%stopTime) then
+            select case (clock%direction)
+            case (MPAS_FORWARD)
+               alarm_ptr%isSet = .false.  ! Disable permanently while forward
+            case (MPAS_BACKWARD)
+               alarm_ptr%isSet = .true.   ! Re-enable when running backward
+            end select
          end if
-      end subroutine mpas_update_alarm_stop_status
+      end subroutine mpas_update_alarm_active_state
 
 
       subroutine mpas_reset_clock_alarm(clock, alarmID, interval, ierr)
@@ -1031,7 +1045,7 @@ module mpas_timekeeping
                      end if
                   end if
                end if
-               call mpas_update_alarm_stop_status(clock, alarmPtr, alarmNow)
+               call mpas_update_alarm_active_state(clock, alarmPtr, alarmNow)
             end if
             alarmPtr => alarmPtr % next
          end do

--- a/src/framework/mpas_timekeeping_types.inc
+++ b/src/framework/mpas_timekeeping_types.inc
@@ -23,9 +23,13 @@
       character (len=ShortStrKIND) :: alarmID
       logical :: isRecurring
       logical :: isSet
+      logical :: hasStopTime
+      logical :: hasStartTime
       type (MPAS_Time_type) :: ringTime
       type (MPAS_Time_type) :: prevRingTime
       type (MPAS_TimeInterval_type) :: ringTimeInterval
+      type (MPAS_Time_type) :: startTime
+      type (MPAS_Time_type) :: stopTime
       type (MPAS_Alarm_type), pointer :: next => null()
    end type
    


### PR DESCRIPTION
This PR adds **start and stop times** to `MPAS_Alarm` with activation logic. The `startTime` and `stopTime` fields were introduced in `mpas_timekeeping_types.inc`, and the logic in `mpas_add_clock_alarm`, `mpas_in_ringing_envelope`, and `mpas_reset_clock_alarm` was updated to ensure alarms are only active when the current clock time falls within the defined open interval. At this stage, the feature is only supported for forward clocks.
