### PR TITLE
Online distributed graph partitioning using PT-Scotch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -759,6 +759,15 @@ endif
 	LIBS += $(NCLIB)
 endif
 
+ifneq "$(SCOTCH)" ""
+	SCOTCH_INCLUDES += -I$(SCOTCH)/include
+	SCOTCH_LIBS += -L$(SCOTCH)/lib64 -lptscotch -lscotch  -lptscotcherr -lm
+	SCOTCH_FLAGS = -DMPAS_SCOTCH
+
+	CPPINCLUDES += $(SCOTCH_INCLUDES)
+	LIBS += $(SCOTCH_LIBS)
+	override CPPFLAGS += $(SCOTCH_FLAGS)
+endif
 
 ifneq "$(PNETCDF)" ""
 ifneq ($(wildcard $(PNETCDF)/lib/libpnetcdf.*), )
@@ -1415,6 +1424,37 @@ musica_fortran_test:
 	$(eval MUSICA_FORTRAN_VERSION := $(shell pkg-config --modversion musica-fortran))
 	$(if $(findstring 1,$(MUSICA_FORTRAN_TEST)), $(info Built a simple test program with MUSICA-Fortran version $(MUSICA_FORTRAN_VERSION)), )
 
+scotch_c_test:
+	@#
+	@# Create a C test program and try to build against the PT-SCOTCH library
+	@#
+	$(info Checking for a working Scotch library...)
+	$(eval SCOTCH_C_TEST := $(shell $\
+	    printf "#include <stdio.h>\n\
+			&#include \"mpi.h\"\n\
+			&#include \"ptscotch.h\"\n\
+			&int main(){\n\
+			&    int err;\n\
+			&    SCOTCH_Dgraph *dgraph;\n\
+			&    err = SCOTCH_dgraphInit(dgraph, MPI_COMM_WORLD);\n\
+			&    SCOTCH_dgraphExit(dgraph);\n\
+			&    return err;\n\
+			&}\n" | sed 's/&/ /' > ptscotch_c_test.c; $\
+		$\
+		$(CC) $(CPPINCLUDES) $(CFLAGS) $(LDFLAGS) ptscotch_c_test.c -o ptscotch_c_test.x $(SCOTCH_LIBS) > ptscotch_c_test.log 2>&1; $\
+		scotch_c_status=$$?; $\
+		if [ $$scotch_c_status -eq 0 ]; then $\
+			printf "1"; $\
+			rm -f ptscotch_c_test.c ptscotch_c_test.x ptscotch_c_test.log; $\
+		else $\
+			printf "0"; $\
+		fi $\
+	))
+	$(if $(findstring 0,$(SCOTCH_C_TEST)), $(error Could not build a simple C program with Scotch. $\
+		Test program ptscotch_c_test.c and output ptscotch_c_test.log have been left $\
+	    in the top-level MPAS directory for further debugging ))
+	$(if $(findstring 1,$(SCOTCH_C_TEST)), $(info Built a simple C program with Scotch ))
+
 pnetcdf_test:
 	@#
 	@# Create test C programs that look for PNetCDF header file and some symbols in it
@@ -1471,6 +1511,13 @@ else
 MUSICA_MESSAGE = "MPAS was not linked with the MUSICA-Fortran library."
 endif
 
+ifneq "$(SCOTCH)" ""
+MAIN_DEPS += scotch_c_test
+SCOTCH_MESSAGE = "MPAS has been linked with the Scotch graph partitioning library."
+else
+SCOTCH_MESSAGE = "MPAS was NOT linked with the Scotch graph partitioning library."
+endif
+
 mpas_main: $(MAIN_DEPS)
 	cd src; $(MAKE) FC="$(FC)" \
                  CC="$(CC)" \
@@ -1508,6 +1555,7 @@ mpas_main: $(MAIN_DEPS)
 	@echo $(OPENMP_OFFLOAD_MESSAGE)
 	@echo $(OPENACC_MESSAGE)
 	@echo $(MUSICA_MESSAGE)
+	@echo $(SCOTCH_MESSAGE)
 	@echo $(SHAREDLIB_MESSAGE)
 ifeq "$(AUTOCLEAN)" "true"
 	@echo $(AUTOCLEAN_MESSAGE)

--- a/src/framework/Makefile
+++ b/src/framework/Makefile
@@ -87,7 +87,7 @@ mpas_timekeeping.o: mpas_string_utils.o mpas_kind_types.o mpas_derived_types.o m
 
 mpas_timer.o: mpas_kind_types.o mpas_dmpar.o mpas_threading.o mpas_log.o
 
-mpas_block_decomp.o: mpas_derived_types.o mpas_hash.o mpas_io_units.o mpas_dmpar.o mpas_ptscotch_interface.o
+mpas_block_decomp.o: mpas_derived_types.o mpas_hash.o mpas_io_units.o mpas_dmpar.o mpas_timer.o mpas_ptscotch_interface.o
 
 mpas_block_creator.o: mpas_dmpar.o mpas_hash.o mpas_sort.o mpas_io_units.o mpas_block_decomp.o mpas_stream_manager.o mpas_decomp.o mpas_abort.o $(DEPS)
 

--- a/src/framework/Makefile
+++ b/src/framework/Makefile
@@ -36,6 +36,8 @@ OBJS = mpas_kind_types.o \
        mpas_log.o \
        mpas_halo.o \
        mpas_string_utils.o \
+       mpas_ptscotch_interface.o \
+       ptscotch_interface.o \
        mpas_stream_inquiry.o \
        stream_inquiry.o
 
@@ -111,6 +113,8 @@ xml_stream_parser.o: xml_stream_parser.c
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(CPPINCLUDES) -I../external/ezxml -c xml_stream_parser.c
 
 mpas_halo.o: mpas_derived_types.o mpas_pool_routines.o mpas_log.o
+
+mpas_ptscotch_interface.o : mpas_derived_types.o mpas_log.o
 
 mpas_stream_inquiry.o : mpas_derived_types.o mpas_log.o mpas_c_interfacing.o
 

--- a/src/framework/Makefile
+++ b/src/framework/Makefile
@@ -87,7 +87,7 @@ mpas_timekeeping.o: mpas_string_utils.o mpas_kind_types.o mpas_derived_types.o m
 
 mpas_timer.o: mpas_kind_types.o mpas_dmpar.o mpas_threading.o mpas_log.o
 
-mpas_block_decomp.o: mpas_derived_types.o mpas_hash.o mpas_io_units.o mpas_dmpar.o
+mpas_block_decomp.o: mpas_derived_types.o mpas_hash.o mpas_io_units.o mpas_dmpar.o mpas_ptscotch_interface.o
 
 mpas_block_creator.o: mpas_dmpar.o mpas_hash.o mpas_sort.o mpas_io_units.o mpas_block_decomp.o mpas_stream_manager.o mpas_decomp.o mpas_abort.o $(DEPS)
 

--- a/src/framework/mpas_block_decomp.F
+++ b/src/framework/mpas_block_decomp.F
@@ -80,6 +80,7 @@ module mpas_block_decomp
       character (len=StrKIND) :: filename
 
       logical :: no_blocks
+      logical :: useScotch
 
       no_blocks = .false.
 
@@ -98,53 +99,85 @@ module mpas_block_decomp
         allocate(local_nvertices(dminfo % nprocs))
         allocate(global_start(dminfo % nprocs))
         allocate(global_list(partial_global_graph_info % nVerticesTotal))
+ 
+         if (dminfo % my_proc_id == IO_NODE) then
 
-        if (dminfo % my_proc_id == IO_NODE) then
+            if (dminfo % total_blocks < 10) then
+               write(filename,'(a,i1)') trim(blockFilePrefix), dminfo % total_blocks
+            else if (dminfo % total_blocks < 100) then
+               write(filename,'(a,i2)') trim(blockFilePrefix), dminfo % total_blocks
+            else if (dminfo % total_blocks < 1000) then
+               write(filename,'(a,i3)') trim(blockFilePrefix), dminfo % total_blocks
+            else if (dminfo % total_blocks < 10000) then
+               write(filename,'(a,i4)') trim(blockFilePrefix), dminfo % total_blocks
+            else if (dminfo % total_blocks < 100000) then
+               write(filename,'(a,i5)') trim(blockFilePrefix), dminfo % total_blocks
+            else if (dminfo % total_blocks < 1000000) then
+               write(filename,'(a,i6)') trim(blockFilePrefix), dminfo % total_blocks
+            else if (dminfo % total_blocks < 10000000) then
+               write(filename,'(a,i7)') trim(blockFilePrefix), dminfo % total_blocks
+            else if (dminfo % total_blocks < 100000000) then
+               write(filename,'(a,i8)') trim(blockFilePrefix), dminfo % total_blocks
+            end if
 
-           if (dminfo % total_blocks < 10) then
-              write(filename,'(a,i1)') trim(blockFilePrefix), dminfo % total_blocks
-           else if (dminfo % total_blocks < 100) then
-              write(filename,'(a,i2)') trim(blockFilePrefix), dminfo % total_blocks
-           else if (dminfo % total_blocks < 1000) then
-              write(filename,'(a,i3)') trim(blockFilePrefix), dminfo % total_blocks
-           else if (dminfo % total_blocks < 10000) then
-              write(filename,'(a,i4)') trim(blockFilePrefix), dminfo % total_blocks
-           else if (dminfo % total_blocks < 100000) then
-              write(filename,'(a,i5)') trim(blockFilePrefix), dminfo % total_blocks
-           else if (dminfo % total_blocks < 1000000) then
-              write(filename,'(a,i6)') trim(blockFilePrefix), dminfo % total_blocks
-           else if (dminfo % total_blocks < 10000000) then
-              write(filename,'(a,i7)') trim(blockFilePrefix), dminfo % total_blocks
-           else if (dminfo % total_blocks < 100000000) then
-              write(filename,'(a,i8)') trim(blockFilePrefix), dminfo % total_blocks
-           end if
+            call mpas_new_unit(iunit)
+            open(unit=iunit, file=trim(filename), form='formatted', status='old', iostat=istatus)
+            
+            if (istatus /= 0) then
+#ifdef MPAS_SCOTCH
+               useScotch = .true.
+#else
+               call mpas_log_write('Could not open block decomposition file for $i blocks.', MPAS_LOG_ERR, intArgs=(/dminfo % total_blocks/) )
+               call mpas_log_write('Filename: '//trim(filename), MPAS_LOG_CRIT)
+#endif
+            else
+               useScotch = .false.
+            end if
+         end if
 
-           call mpas_new_unit(iunit)
-           open(unit=iunit, file=trim(filename), form='formatted', status='old', iostat=istatus)
+#ifdef MPAS_SCOTCH
+         call mpas_dmpar_bcast_logical(dminfo, useScotch)
 
-           if (istatus /= 0) then
-              call mpas_log_write('Could not open block decomposition file for $i blocks.', MPAS_LOG_ERR, intArgs=(/dminfo % total_blocks/) )
-              call mpas_log_write('Filename: '//trim(filename), MPAS_LOG_CRIT)
-           end if
+         if (useScotch) then ! Using PT-Scotch across all MPI ranks
 
-           local_nvertices(:) = 0
-           do i=1,partial_global_graph_info % nVerticesTotal
-              read(unit=iunit, fmt=*, iostat=err) global_block_id
+            ! Pre-emptively blocking this untested code path. 
+            if (numBlocks /= 0) then
+               call mpas_log_write('Scotch partitioning not available when config_number_of_blocks != 0 ', MPAS_LOG_CRIT)
+            end if
 
-              if ( err .ne. 0 ) then
-                 call mpas_log_write('Decomoposition file: ' // trim(filename) // ' contains less than $i cells', &
-                                      MPAS_LOG_CRIT, intArgs=(/partial_global_graph_info % nVerticesTotal/) )
-              end if
-              call mpas_get_owning_proc(dminfo, global_block_id, owning_proc)
-              local_nvertices(owning_proc+1) = local_nvertices(owning_proc+1) + 1
-           end do
+            call mpas_log_write('No existing block decomposition file found, invoking Scotch.')
+            call mpas_block_decomp_scotch(dminfo, partial_global_graph_info, blockFilePrefix, filename)
 
-           read(unit=iunit, fmt=*, iostat=err)
+            if (dminfo % my_proc_id == IO_NODE) then
+               open(unit=iunit, file=trim(filename), form='formatted', status='old', iostat=istatus)
+               if (istatus /= 0) then
+                  call mpas_log_write('Could not open block decomposition file for $i blocks.', MPAS_LOG_ERR, intArgs=(/dminfo % total_blocks/) )
+                  call mpas_log_write('Filename: '//trim(filename), MPAS_LOG_CRIT)
+               end if
+            end if
+         end if
+#endif
 
-           if ( err == 0 ) then
-              call mpas_log_write('Decomposition file: ' // trim(filename) // ' contains more than $i cells', &
-                                   MPAS_LOG_CRIT, intArgs=(/partial_global_graph_info % nVerticesTotal/) )
-           end if
+         if (dminfo % my_proc_id == IO_NODE) then
+
+               local_nvertices(:) = 0
+               do i=1,partial_global_graph_info % nVerticesTotal
+                  read(unit=iunit, fmt=*, iostat=err) global_block_id
+
+                  if ( err .ne. 0 ) then
+                     call mpas_log_write('Decomoposition file: ' // trim(filename) // ' contains less than $i cells', &
+                                          MPAS_LOG_CRIT, intArgs=(/partial_global_graph_info % nVerticesTotal/) )
+                  end if
+                  call mpas_get_owning_proc(dminfo, global_block_id, owning_proc)
+                  local_nvertices(owning_proc+1) = local_nvertices(owning_proc+1) + 1
+               end do
+
+               read(unit=iunit, fmt=*, iostat=err)
+
+               if ( err == 0 ) then
+                  call mpas_log_write('Decomposition file: ' // trim(filename) // ' contains more than $i cells', &
+                                       MPAS_LOG_CRIT, intArgs=(/partial_global_graph_info % nVerticesTotal/) )    
+               end if
 
            global_start(1) = 1
            do i=2,dminfo % nprocs

--- a/src/framework/mpas_block_decomp.F
+++ b/src/framework/mpas_block_decomp.F
@@ -54,6 +54,8 @@ module mpas_block_decomp
    subroutine mpas_block_decomp_cells_for_proc(dminfo, partial_global_graph_info, local_cell_list, block_id, block_start, &
                                                block_count, numBlocks, explicitProcDecomp, blockFilePrefix, procFilePrefix)!{{{
 
+      use mpas_timer, only : mpas_timer_start, mpas_timer_stop
+
       implicit none
 
       type (dm_info), intent(inout) :: dminfo !< Input: domain information
@@ -83,6 +85,8 @@ module mpas_block_decomp
       logical :: useScotch
 
       no_blocks = .false.
+
+      call mpas_timer_start('mpas_block_decomp_cells_for_proc')
 
       if (numBlocks == 0) then
         dminfo % total_blocks = dminfo % nProcs
@@ -321,6 +325,8 @@ module mpas_block_decomp
         end if
       end if
 
+      call mpas_timer_stop('mpas_block_decomp_cells_for_proc')
+
    end subroutine mpas_block_decomp_cells_for_proc!}}}
 
 !***********************************************************************
@@ -341,6 +347,7 @@ module mpas_block_decomp
 #ifdef MPAS_SCOTCH
    subroutine mpas_block_decomp_scotch(dminfo, partial_global_graph_info, blockFilePrefix, blockFilename)!{{{
 
+      use mpas_timer, only : mpas_timer_start, mpas_timer_stop
 #ifdef MPAS_USE_MPI_F08
       use mpi_f08, only : MPI_Comm, MPI_INTEGER, MPI_Comm_dup, MPI_Comm_free, MPI_Gather, MPI_Gatherv
 #else
@@ -385,6 +392,8 @@ module mpas_block_decomp
       allocate(global_start(dminfo % nprocs))
       allocate(global_block_id_arr(partial_global_graph_info % nVerticesTotal))
       allocate(local_block_id_arr(partial_global_graph_info % nVertices))
+
+      call mpas_timer_start('scotch_total')
 
       ! Count the number of edges (including to ghost cells) in the portion of graph
       ! owned by the current rank. Each edge is counted twice, once for each vertex,
@@ -451,9 +460,12 @@ module mpas_block_decomp
       ! Initialize the strategy data structure
       call scotch_stratinit (stradat)
 
+      call mpas_timer_start('scotch_graph_partitioning')
       ! Partition the distributed graph and save the result in local_block_id_arr
       npart = dminfo % nProcs
       call scotch_dgraphpart (scotchdgraph, npart, stradat, local_block_id_arr)
+
+      call mpas_timer_stop('scotch_graph_partitioning')
 
       ! After the paritioning above, each processor would not necessarily have information about all of the
       ! vertices it owns. To obtain this information, Scotch provides a convenience function to redistribute the graph
@@ -532,6 +544,8 @@ module mpas_block_decomp
       deallocate(local_block_id_arr)
 
       call MPI_Comm_free(localcomm, mpi_ierr)
+
+      call mpas_timer_stop('scotch_total')
 
    end subroutine mpas_block_decomp_scotch
 #endif

--- a/src/framework/mpas_block_decomp.F
+++ b/src/framework/mpas_block_decomp.F
@@ -25,6 +25,9 @@ module mpas_block_decomp
    use mpas_derived_types
    use mpas_io_units
    use mpas_log
+#ifdef MPAS_SCOTCH
+   use mpas_ptscotch_interface
+#endif
 
    type graph
       integer :: nVerticesTotal
@@ -286,6 +289,219 @@ module mpas_block_decomp
       end if
 
    end subroutine mpas_block_decomp_cells_for_proc!}}}
+
+!***********************************************************************
+!
+!  routine mpas_block_decomp_scotch
+!
+!> \brief   Use PT-Scotch to generate the graph partitioning
+!> \author  Abishek Gopal
+!> \date    12/05/25
+!> \details
+!>  This routine invokes the PT-Scotch library to first construct a distributed graph from the
+!>  partial global graph information read by each processor, then partitions the graph into the
+!>  specified number of blocks, and after redistributing the graph, it finally gathers all the
+!>  local block ids (for each MPI rank) to the IO_NODE to write out to a partition file with the
+!>  specified prefix.
+!
+!-----------------------------------------------------------------------
+#ifdef MPAS_SCOTCH
+   subroutine mpas_block_decomp_scotch(dminfo, partial_global_graph_info, blockFilePrefix, blockFilename)!{{{
+
+#ifdef MPAS_USE_MPI_F08
+      use mpi_f08, only : MPI_Comm, MPI_INTEGER, MPI_Comm_dup, MPI_Comm_free, MPI_Gather, MPI_Gatherv
+#else
+      use mpi
+#endif
+
+      implicit none
+
+      type (dm_info), intent(inout) :: dminfo !< Input: domain information
+      type (graph), intent(in) :: partial_global_graph_info !< Input: Global graph information
+      character (len=*), intent(in) :: blockFilePrefix !< Input: File prefix for block decomposition
+      character (len=*), intent(out) :: blockFilename !< Output: Block decomposition file name
+
+      integer, dimension(:), pointer :: global_start
+      ! integer, dimension(:), allocatable :: local_cell_list ! May be needed later to avoid reading partition file from disk
+      integer, dimension(:), allocatable :: local_block_list
+
+      integer, dimension(:), allocatable ::global_block_id_arr, local_block_id_arr
+      integer :: i, ounit, ostatus, j, k
+      integer :: err, ierr
+      integer, dimension(:), pointer :: local_nvertices
+      integer :: num_local_vertices !< Number of local vertices for this processor
+
+      integer :: nLocEdgesGraph = 0, nLocVerticesGraph = 0, edgelocsiz = 0, npart = 1
+      character (len=StrKIND) :: partitionFilePrefix
+      integer, dimension(:), allocatable :: edgeloctab, vertloctab
+      type(scotchm_strat) :: stradat
+      type(scotchm_dgraph) :: scotchdgraph
+      type(scotchm_dgraph) :: scotchdgraph_redist
+      integer :: mpi_ierr
+#ifdef MPAS_USE_MPI_F08
+      type (MPI_Comm) :: localcomm
+#else
+      integer :: localcomm
+#endif
+
+      ! Check that Scotch has not been built with 64-bit integers
+      ! Exit otherwise
+      call scotch_checkintsize()
+
+      allocate(local_nvertices(dminfo % nprocs))
+      allocate(global_start(dminfo % nprocs))
+      allocate(global_block_id_arr(partial_global_graph_info % nVerticesTotal))
+      allocate(local_block_id_arr(partial_global_graph_info % nVertices))
+
+      ! Count the number of edges (including to ghost cells) in the portion of graph
+      ! owned by the current rank. Each edge is counted twice, once for each vertex,
+      ! with the exception of edges to ghost vertices, which are counted only once.
+      do i=1,partial_global_graph_info % nVertices
+         do j=1,partial_global_graph_info % nAdjacent(i)
+            if (partial_global_graph_info % adjacencyList(j,i) == 0) cycle
+            nLocEdgesGraph = nLocEdgesGraph + 1
+            ! call mpas_log_write('i=$i j=$i adj= $i', intArgs=(/i,j,partial_global_graph_info % adjacencyList(j,i)/) )
+         end do
+      end do
+
+      ! Holds the adjacency array for every local vertex
+      allocate(edgeloctab(nLocEdgesGraph))
+      ! Array of start indices in edgeloctab for each local vertex
+      allocate(vertloctab(partial_global_graph_info % nVertices + 1))
+
+      ! Fill up edgeloctab and vertloctab
+      k = 1
+      do i=1,partial_global_graph_info % nVertices
+         vertloctab(i) = k
+         do j=1,partial_global_graph_info % nAdjacent(i)
+            if (partial_global_graph_info % adjacencyList(j,i) == 0) cycle
+            edgeloctab(k) = partial_global_graph_info % adjacencyList(j,i)
+            k = k + 1
+         end do
+      end do
+      vertloctab(partial_global_graph_info % nVertices+1) = nLocEdgesGraph + 1
+
+      ! Duplicate the communicator to be used by Scotch
+      call MPI_Comm_dup(dminfo % comm, localcomm, mpi_ierr)
+      if (mpi_ierr /= 0) then
+         call mpas_log_write('Cannot duplicate communicator', MPAS_LOG_CRIT)
+      endif
+      ! Initialize the Scotch graph data structure, and an extra one to hold the re-distributed graph
+#ifdef MPAS_USE_MPI_F08
+      call scotch_dgraphinit(scotchdgraph, localcomm% mpi_val)
+      call scotch_dgraphinit(scotchdgraph_redist, localcomm% mpi_val)
+#else
+      call scotch_dgraphinit(scotchdgraph, localcomm)
+      call scotch_dgraphinit(scotchdgraph_redist, localcomm)
+#endif
+
+      ! From Scotch documentation: edgelocsiz is lower-bounded by the minimum size
+      ! of the edge array required to encompass all used adjacency values; it is
+      ! therefore at least equal to the maximum of the vendloctab entries, over all
+      ! local vertices, minus baseval; it can be set to edgelocnbr if the edge array is compact.
+      edgelocsiz = maxval(vertloctab) - 1
+
+      nLocVerticesGraph = partial_global_graph_info % nVertices
+
+      ! Build the distributed Scotch graph and save it in scotchdgraph
+      ! Note: Optional arguments veloloctab, vlblloctab, edgegsttab, and edloloctab are not needed here.
+      call scotch_dgraphbuild (scotchdgraph, &
+                        nLocVerticesGraph, & ! num of local vertices on the calling process
+                        vertloctab, & ! Array of start indices in edgeloctab for each local vertex
+                        nLocEdgesGraph, & ! Number of local edges, including to ghost vertices
+                        edgelocsiz, & ! Defined previously
+                        edgeloctab) ! Holds the adjacency array for every local vertex
+
+      ! Only needed during development/debugging. 
+      call scotch_dgraphcheck (scotchdgraph)
+
+      ! Initialize the strategy data structure
+      call scotch_stratinit (stradat)
+
+      ! Partition the distributed graph and save the result in local_block_id_arr
+      npart = dminfo % nProcs
+      call scotch_dgraphpart (scotchdgraph, npart, stradat, local_block_id_arr)
+
+      ! After the paritioning above, each processor would not necessarily have information about all of the
+      ! vertices it owns. To obtain this information, Scotch provides a convenience function to redistribute the graph
+      ! to all processors, so that each processor has information about all of the vertices it owns.
+      call scotch_dgraphredist(scotchdgraph, & ! Input: original distributed graph
+                                 local_block_id_arr, & ! Input: the partition array
+                                 scotchdgraph_redist, & ! Output: re-distributed graph
+                                 num_local_vertices) ! Output: number of local vertices
+
+      ! DO NOT REMOVE: This call is required if we want to read the local cell list directly after partitioning,
+      ! instead of reading it from the output partition file.
+      ! Extract the local cell list from the re-distributed graph.
+      ! allocate(local_cell_list(num_local_vertices))
+      ! call scotch_dgraphdata(scotchdgraph_redist, local_cell_list)
+      ! do i=1,num_local_vertices
+      !    call mpas_log_write('local_cell_list($i): $i',MPAS_LOG_ERR, intArgs=(/i,local_cell_list(i)/))
+      ! end do
+
+      allocate(local_block_list(num_local_vertices))
+
+      local_block_list(:)=dminfo % my_proc_id
+
+      ! Using the local_nvertices array to hold the original number of vertices in
+      ! the partial graph readb by each processor. Might need to use a different array
+      ! to clear up potential confusion.
+      local_nvertices(dminfo % my_proc_id + 1) = partial_global_graph_info % nVertices
+
+      ! call mpas_log_write('local_nvertices($i): $i', MPAS_LOG_ERR, intArgs=(/i,num_local_vertices/))
+
+      ! Gather all the partial_global_graph_info % nVertices to IO_NODE.
+      ! num_local_vertices is the number of vertices that this processor owns, determined by the
+      ! Scotch paritioning. Whereas artial_global_graph_info % nVertices is the number of vertices
+      ! resident in the partial graph read by this processor. The latter is the correct size of the
+      ! local_block_id_arr.
+      call MPI_Gather( partial_global_graph_info % nVertices, 1, MPI_INTEGER, local_nvertices, &
+                           1, MPI_INTEGER, 0, localcomm, ierr)
+
+      ! Compute the displacements for gathering all the local_block_id_arr to global_block_id_arr
+      global_start(1) = 0
+      do i=2,dminfo % nprocs
+         global_start(i) = global_start(i-1) + local_nvertices(i-1)
+      end do
+
+      ! Gather all the local block ids to global_block_id_arr so IO_NODE can write out the partitioning data
+      call MPI_Gatherv( local_block_id_arr, partial_global_graph_info % nVertices, MPI_INTEGER, global_block_id_arr, &
+                              local_nvertices, global_start, MPI_INTEGER, 0, localcomm, ierr)
+      ! Write out the paritioning data to a file from IO_NODE
+      if (dminfo % my_proc_id == IO_NODE) then
+         partitionFilePrefix=trim(blockFilePrefix)
+         if (trim(partitionFilePrefix) == '') then
+            write(partitionFilePrefix,'(i0,a)') partial_global_graph_info%nVerticesTotal,'.graph.info.part.'
+         end if
+         write(blockFilename,'(a,i0)') trim(partitionFilePrefix), dminfo % nProcs
+
+         call mpas_log_write('Writing out Scotch Graph partitioning data to '//trim(blockFilename))
+         call mpas_new_unit(ounit)
+         open(unit=ounit, file=trim(blockFilename), form='formatted', status='new', action="write", iostat=ostatus)
+         do i=1,partial_global_graph_info % nVerticesTotal
+            write(unit=ounit, fmt='(i0)', iostat=err) global_block_id_arr(i)
+         end do
+         close(unit=ounit)
+         call mpas_release_unit(ounit)
+      end if
+
+      ! Clean up
+      call scotch_dgraphexit (scotchdgraph)
+      call scotch_dgraphexit (scotchdgraph_redist)
+      call scotch_stratexit (stradat)
+
+      deallocate(edgeloctab)
+      deallocate(vertloctab)
+      deallocate(local_block_list)
+      deallocate(local_nvertices)
+      deallocate(global_start)
+      deallocate(global_block_id_arr)
+      deallocate(local_block_id_arr)
+
+      call MPI_Comm_free(localcomm, mpi_ierr)
+
+   end subroutine mpas_block_decomp_scotch
+#endif
 
 !***********************************************************************
 !

--- a/src/framework/mpas_framework.F
+++ b/src/framework/mpas_framework.F
@@ -263,6 +263,12 @@ module mpas_framework
 #else
                           'no')
 #endif
+      call mpas_log_write('  SCOTCH support: ' // &
+#ifdef MPAS_SCOTCH
+                              'yes')
+#else
+                              'no')
+#endif
       call mpas_log_write('')
 
       call mpas_log_write('Run-time settings:')

--- a/src/framework/mpas_ptscotch_interface.F
+++ b/src/framework/mpas_ptscotch_interface.F
@@ -1,0 +1,453 @@
+! Copyright (c) 2025 The University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at https://mpas-dev.github.io/license.html .
+!
+#ifdef MPAS_SCOTCH
+module mpas_ptscotch_interface
+    use iso_c_binding, only : c_ptr
+    public :: scotch_dgraphinit, scotch_dgraphbuild
+
+    ! Dummy type declaration for SCOTCH distributed graph
+    ! Member ptr is a pointer to the SCOTCH_Dgraph C structure
+    type :: scotchm_dgraph
+        type(c_ptr) :: ptr
+    end type scotchm_dgraph
+
+    ! Dummy type declaration for SCOTCH strategy
+    ! Member ptr is a pointer to the SCOTCH_Strat C structure
+    type :: scotchm_strat
+        type(c_ptr) :: ptr
+    end type scotchm_strat
+
+contains
+
+    !-----------------------------------------------------------------------
+    !  subroutine scotch_checkintsize
+    !
+    !> \brief Check that SCOTCH integer size matches MPAS integer size
+    !> \author Abishek Gopal
+    !> \date   21 Jan 2026
+    !> \details
+    !>  Compares the size of SCOTCH_Num type with the MPAS integer size.
+    !>  Logs an error message if there is a mismatch.
+    !-----------------------------------------------------------------------
+    subroutine scotch_checkintsize()
+        use iso_c_binding, only : c_int, c_size_t, c_sizeof
+        use mpas_log, only : mpas_log_write
+        use mpas_derived_types, only : MPAS_LOG_CRIT
+
+        implicit none
+
+        integer(c_int) :: dummy_int
+
+        interface
+            function scotchm_get_intsize() bind(C, name='scotchm_get_intsize') result(intsize)
+                use iso_c_binding, only : c_size_t
+                integer(c_size_t) :: intsize
+            end function scotchm_get_intsize
+        end interface
+
+        if (scotchm_get_intsize() /= c_sizeof(dummy_int)) then
+          call mpas_log_write("Error: Scotch SCOTCH_Num size does not match MPAS integer size \n" &
+                                // "Please build Scotch with 32-bit integers", MPAS_LOG_CRIT)
+        end if
+
+    end subroutine scotch_checkintsize
+
+    !-----------------------------------------------------------------------
+    !  subroutine scotch_dgraphinit
+    !
+    !> \brief Initialize a SCOTCH distributed graph object
+    !> \author Abishek Gopal
+    !> \date   8 Dec 2025
+    !> \details
+    !>  Initializes a SCOTCH_Dgraph structure using a Fortran MPI communicator.
+    !>  This subroutine wraps the C function scotchm_dgraphinit.
+    !> \arguments
+    !>   dgraph - scotchm_dgraph structure to be initialized
+    !>   comm   - Fortran MPI communicator integer
+    !
+    !-----------------------------------------------------------------------
+    subroutine scotch_dgraphinit(dgraph, comm)
+        use iso_c_binding, only : c_ptr
+        use mpas_log, only : mpas_log_write
+        use mpas_derived_types, only : MPAS_LOG_CRIT
+
+        implicit none
+        ! Arguments
+        type(scotchm_dgraph), intent(inout) :: dgraph
+        integer, intent(in) :: comm
+
+        ! Return value
+        integer :: ierr
+
+        interface
+            function scotchm_dgraphinit(dgraph_ptr, localcomm) bind(C, name='scotchm_dgraphinit') result(err)
+                use iso_c_binding, only : c_ptr, c_int
+                type(c_ptr) :: dgraph_ptr
+                integer(c_int), value :: localcomm
+                integer(c_int) :: err
+            end function scotchm_dgraphinit
+        end interface
+
+        ierr = scotchm_dgraphinit(dgraph % ptr, comm)
+
+        if (ierr /= 0) then
+            call mpas_log_write('Error initalizing distributed Scotch graph', MPAS_LOG_CRIT)
+        end if
+
+    end subroutine scotch_dgraphinit
+
+    !-----------------------------------------------------------------------
+    !  subroutine scotch_dgraphbuild
+    !
+    !> \brief Build a SCOTCH distributed graph from local vertex/edge arrays
+    !> \author Abishek Gopal
+    !> \date   8 Dec 2025
+    !> \details
+    !>  Constructs a SCOTCH_Dgraph from local vertex and edge connectivity data.
+    !>  This subroutine wraps the C function scotchm_dgraphbuild
+    !> \arguments
+    !>   dgraph         - scotchm_dgraph structure to be built
+    !>   nVertices      - Number of local vertices
+    !>   vertloctab     - Array of size (nVertices+1)
+    !>                     giving the start index of edges for each local vertex
+    !>   nLocEdgesGraph - Total number of local edges in the graph
+    !>   edgelocsiz     - Size of the adjncy array
+    !>   adjncy         - Array of size nLocEdgesGraph containing the  
+    !>                     adjacency list for local vertices
+    !
+    !-----------------------------------------------------------------------
+    subroutine scotch_dgraphbuild(dgraph, nVertices, vertloctab, nLocEdgesGraph, edgelocsiz, adjncy)
+        use iso_c_binding, only : c_ptr, c_int
+        use mpas_log, only : mpas_log_write
+        use mpas_derived_types, only : MPAS_LOG_CRIT
+
+        implicit none
+
+        type(scotchm_dgraph) :: dgraph
+        integer(c_int), intent(in) :: nVertices
+        integer(c_int), intent(in) :: vertloctab(nVertices+1)
+        integer(c_int), intent(in) :: nLocEdgesGraph
+        integer(c_int), intent(in) :: edgelocsiz
+        integer(c_int), intent(in) :: adjncy(nLocEdgesGraph)
+
+        ! Return value
+        integer :: ierr
+
+        interface
+            function scotchm_dgraphbuild(dgraph_ptr, nVertices, vertloctab, &
+                nLocEdgesGraph, edgelocsiz, adjncy) bind(C, name='scotchm_dgraphbuild') result(err)
+                use iso_c_binding, only : c_ptr, c_int
+                type(c_ptr), value :: dgraph_ptr
+                integer(c_int), value :: nVertices
+                integer(c_int) :: vertloctab(nVertices+1)
+                integer(c_int), value :: nLocEdgesGraph
+                integer(c_int), value :: edgelocsiz
+                integer(c_int) :: adjncy(nLocEdgesGraph)
+                integer(c_int) :: err
+            end function scotchm_dgraphbuild
+        end interface
+
+        ierr = 0
+
+        ierr = scotchm_dgraphbuild(dgraph % ptr, nVertices, vertloctab,  &
+                                   nLocEdgesGraph, edgelocsiz, adjncy)
+
+        if (ierr /= 0) then
+            call mpas_log_write('Error building distributed Scotch graph', MPAS_LOG_CRIT)
+        else
+            call mpas_log_write('Successfully built distributed Scotch graph')    
+        end if
+
+    end subroutine scotch_dgraphbuild
+
+    !-----------------------------------------------------------------------
+    !  subroutine scotch_dgraphcheck
+    !
+    !> \brief Perform consistency check on a SCOTCH distributed graph
+    !> \author Abishek Gopal
+    !> \date   8 Dec 2025
+    !> \details
+    !>  Validates the internal structure of a SCOTCH_Dgraph for consistency.
+    !>  This subroutine wraps the C function scotchm_dgraphcheck.
+    !> \arguments
+    !>   dgraph - scotchm_dgraph structure to be checked
+    !
+    !-----------------------------------------------------------------------
+    subroutine scotch_dgraphcheck(dgraph)    
+        use mpas_log, only : mpas_log_write
+        use mpas_derived_types, only : MPAS_LOG_CRIT
+        use iso_c_binding, only : c_ptr
+
+        implicit none
+
+        type(scotchm_dgraph) :: dgraph
+
+        ! Return value
+        integer :: ierr
+
+        interface
+            function scotchm_dgraphcheck(dgraph_ptr) bind(C, name='scotchm_dgraphcheck') result(err)
+                use iso_c_binding, only : c_int, c_ptr
+                type(c_ptr), value :: dgraph_ptr
+                integer(c_int) :: err
+            end function scotchm_dgraphcheck
+        end interface
+
+        ierr = scotchm_dgraphcheck(dgraph % ptr)
+
+        if (ierr /= 0) then
+            call mpas_log_write('Error during distributed Scotch graph check', MPAS_LOG_CRIT)
+        end if
+
+    end subroutine scotch_dgraphcheck
+
+    !-----------------------------------------------------------------------
+    !  subroutine scotch_dgraphexit
+    !
+    !> \brief Finalize/cleanup a SCOTCH distributed graph object
+    !> \author Abishek Gopal
+    !> \date   8 Dec 2025
+    !> \details
+    !>  Deallocates internal structures associated with a SCOTCH_Dgraph.
+    !>  This subroutine wraps the C function scotchm_dgraphexit.
+    !> \arguments
+    !>   dgraph - scotchm_dgraph structure to be finalized
+    !
+    !-----------------------------------------------------------------------
+    subroutine scotch_dgraphexit(dgraph)        
+        use mpas_log, only : mpas_log_write
+        use iso_c_binding, only : c_ptr
+
+        implicit none
+
+        type(scotchm_dgraph) :: dgraph
+
+        interface
+            subroutine scotchm_dgraphexit(dgraph_ptr) bind(C, name='scotchm_dgraphexit')
+                use iso_c_binding, only : c_int, c_ptr
+                type(c_ptr), value :: dgraph_ptr
+            end subroutine scotchm_dgraphexit
+        end interface
+
+        call scotchm_dgraphexit(dgraph % ptr)
+
+    end subroutine scotch_dgraphexit
+
+    !-----------------------------------------------------------------------
+    !  subroutine scotch_stratinit
+    !
+    !> \brief Initialize a SCOTCH strategy object
+    !> \author Abishek Gopal
+    !> \date   8 Dec 2025
+    !> \details
+    !>  Initializes a SCOTCH_Strat structure and builds a default strategy
+    !>  for distributed graph mapping. This subroutine wraps the C function
+    !>  scotchm_stratinit.
+    !> \arguments
+    !>   stradat - scotchm_strat structure to be initialized
+    !
+    !-----------------------------------------------------------------------
+    subroutine scotch_stratinit(stradat)
+        use mpas_log, only : mpas_log_write
+        use mpas_derived_types, only : MPAS_LOG_CRIT
+        use iso_c_binding, only : c_ptr
+
+        implicit none
+
+        type(scotchm_strat), intent(inout) :: stradat
+        
+        integer :: ierr
+
+        interface
+            function scotchm_stratinit(strat_ptr) bind(C, name='scotchm_stratinit') result(err)
+                use iso_c_binding, only : c_int, c_ptr
+                type(c_ptr) :: strat_ptr
+                integer(c_int) :: err
+            end function scotchm_stratinit
+        end interface
+
+        ierr = scotchm_stratinit(stradat % ptr)
+
+        if (ierr /= 0) then
+            call mpas_log_write('Error during Scotch strategy initialization', MPAS_LOG_CRIT)
+        end if
+
+    end subroutine scotch_stratinit
+
+    !-----------------------------------------------------------------------
+    !  subroutine scotch_stratexit
+    !
+    !> \brief Finalize/cleanup a SCOTCH strategy object
+    !> \author Abishek Gopal
+    !> \date   8 Dec 2025
+    !> \details
+    !>  Deallocates internal structures associated with a SCOTCH_Strat.
+    !>  This subroutine wraps the C function scotchm_stratexit.
+    !> \arguments
+    !>   stradat - scotchm_strat structure to be finalized
+    !
+    !-----------------------------------------------------------------------
+    subroutine scotch_stratexit(stradat)        
+        use mpas_log, only : mpas_log_write
+        use iso_c_binding, only : c_ptr
+
+        implicit none
+
+        type(scotchm_strat), intent(in) :: stradat
+        
+        interface
+            subroutine scotchm_stratexit(strat_ptr) bind(C, name='scotchm_stratexit')
+                use iso_c_binding, only : c_ptr
+                type(c_ptr), value :: strat_ptr
+            end subroutine scotchm_stratexit
+        end interface
+
+        call scotchm_stratexit(stradat % ptr)
+
+    end subroutine scotch_stratexit
+
+    !-----------------------------------------------------------------------
+    !  subroutine scotch_dgraphpart
+    !
+    !> \brief Partition a SCOTCH distributed graph
+    !> \author Abishek Gopal
+    !> \date   8 Dec 2025
+    !> \details
+    !>  Partitions the distributed graph into num_part parts using the
+    !>  provided SCOTCH strategy object. This subroutine wraps the C function
+    !>  scotchm_dgraphpart.
+    !> \arguments
+    !>   dgraph  - scotchm_dgraph structure to be partitioned
+    !>   num_part - Number of partitions
+    !>   stradat - scotchm_strat structure containing partitioning strategy
+    !>   parttab - Output array of size equal to number of local vertices,
+    !
+    !-----------------------------------------------------------------------
+    subroutine scotch_dgraphpart(dgraph, num_part, stradat, parttab)
+        use mpas_log, only : mpas_log_write
+        use mpas_derived_types, only : MPAS_LOG_CRIT
+        use iso_c_binding, only : c_ptr, c_int
+
+        implicit none
+
+        type(scotchm_dgraph), intent(in) :: dgraph
+        integer(c_int), intent(in) :: num_part
+        type(scotchm_strat), intent(in) :: stradat
+        integer(c_int), intent(out) :: parttab(*)
+        
+        ! Return value
+        integer :: ierr
+
+        interface
+            function scotchm_dgraphpart(dgraph_ptr, num_part_loc, strat_ptr, parttab_loc ) bind(C, name='scotchm_dgraphpart') result(err)
+                use iso_c_binding, only : c_int, c_ptr
+                type(c_ptr), value :: dgraph_ptr
+                integer(c_int), value :: num_part_loc
+                type(c_ptr), value :: strat_ptr
+                integer(c_int) :: parttab_loc(*)
+                integer(c_int) :: err
+            end function scotchm_dgraphpart
+        end interface
+
+        ierr = scotchm_dgraphpart(dgraph % ptr, num_part, stradat % ptr, parttab)
+
+        if (ierr /= 0) then
+            call mpas_log_write('Error during Scotch graph partition', MPAS_LOG_CRIT)
+        else 
+            call mpas_log_write('Successfully partitioned distributed Scotch graph')
+        end if
+
+    end subroutine scotch_dgraphpart
+
+    !-----------------------------------------------------------------------
+    !  subroutine scotch_dgraphredist
+    !
+    !> \brief Redistribute a SCOTCH distributed graph according to partitions
+    !> \author Abishek Gopal
+    !> \date   8 Dec 2025
+    !> \details
+    !>  Redistributes the distributed graph structure based on a partition
+    !>  table. This subroutine wraps the C function scotchm_dgraphredist.
+    !> \arguments
+    !>   dgraph  - scotchm_dgraph structure to be redistributed
+    !>   parttab - Input array of size equal to number of local vertices,
+    !>             containing partition assignments
+    !>   dgraph_out - scotchm_dgraph structure to hold redistributed graph
+    !>   num_local_vertices - Number of local vertices in the redistributed graph
+    !
+    !-----------------------------------------------------------------------
+    subroutine scotch_dgraphredist(dgraph, parttab, dgraph_out, num_local_vertices)
+        use mpas_log, only : mpas_log_write
+        use mpas_derived_types, only : MPAS_LOG_CRIT
+        use iso_c_binding, only : c_ptr, c_int
+
+        implicit none
+
+        type(scotchm_dgraph) :: dgraph
+        integer(c_int), intent(in) :: parttab(*)
+        type(scotchm_dgraph) :: dgraph_out
+        integer(c_int) :: num_local_vertices
+           
+        ! Return value
+        integer :: ierr
+
+        interface
+            function scotchm_dgraphredist(dgraph_ptr, parttab_loc, dgraph_out_ptr, vertlocnbr ) bind(C, name='scotchm_dgraphredist') result(err)
+                use iso_c_binding, only : c_int, c_ptr
+                type(c_ptr), value :: dgraph_ptr
+                integer(c_int) :: parttab_loc(*)
+                type(c_ptr), value :: dgraph_out_ptr
+                integer(c_int) :: vertlocnbr
+                integer(c_int) :: err
+            end function scotchm_dgraphredist
+        end interface
+
+        ierr = scotchm_dgraphredist(dgraph % ptr, parttab, dgraph_out % ptr, num_local_vertices)
+
+        if (ierr /= 0) then
+            call mpas_log_write('Error during Scotch graph redistribution', MPAS_LOG_CRIT)
+        end if
+
+    end subroutine scotch_dgraphredist
+
+    !-----------------------------------------------------------------------
+    !  subroutine scotch_dgraphdata
+    !
+    !> \brief Extract vertex labels from a SCOTCH distributed graph
+    !> \author Abishek Gopal
+    !> \date   8 Dec 2025
+    !> \details
+    !>  Extracts vertex labels or stored IDs for local vertices into the
+    !>  output array. This subroutine wraps the C function scotchm_dgraphdata.
+    !> \arguments
+    !>   dgraph  - scotchm_dgraph structure to extract from
+    !>   local_cell_list - Output array to hold vertex labels for local vertices
+    !
+    !-----------------------------------------------------------------------
+     subroutine scotch_dgraphdata(dgraph, local_cell_list)        
+        use mpas_log, only : mpas_log_write
+        use iso_c_binding, only : c_ptr, c_int
+
+        implicit none
+
+        type(scotchm_dgraph) :: dgraph
+        integer(c_int), intent(out) :: local_cell_list(*)
+
+        interface
+            subroutine scotchm_dgraphdata(dgraph_ptr, cell_list) bind(C, name='scotchm_dgraphdata')
+                use iso_c_binding, only : c_int, c_ptr
+                type(c_ptr), value :: dgraph_ptr
+                integer(c_int) :: cell_list(*)
+            end subroutine scotchm_dgraphdata
+        end interface
+
+        call scotchm_dgraphdata(dgraph % ptr, local_cell_list)
+
+    end subroutine scotch_dgraphdata
+
+end module mpas_ptscotch_interface
+#endif

--- a/src/framework/ptscotch_interface.c
+++ b/src/framework/ptscotch_interface.c
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2025, The University Corporation for Atmospheric Research (UCAR).
+ *
+ * Unless noted otherwise source code is licensed under the BSD license.
+ * Additional copyright and license information can be found in the LICENSE file
+ * distributed with this code, or at http://mpas-dev.github.com/license.html
+ */
+#ifdef MPAS_SCOTCH
+#include <stdlib.h>
+#include <stdio.h>
+#include "mpi.h"
+#include "ptscotch.h"
+
+
+/*********************************************************************************
+ *
+ * scotchm_get_intsize
+ *
+ * Get the size of SCOTCH_Num in bytes.
+ *
+ * Returns:
+ *   size of SCOTCH_Num in bytes.
+ *
+ ********************************************************************************/
+size_t scotchm_get_intsize()
+{
+	return sizeof(SCOTCH_Num);
+
+}
+
+
+/********************************************************************************
+ *
+ * scotchm_dgraphinit
+ *
+ * Initialize a SCOTCH distributed graph object using a Fortran MPI communicator.
+ *
+ * Parameters:
+ *   dgraph_ptr - pointer to a `SCOTCH_Dgraph` structure
+ *   localcomm  - Fortran MPI communicator handle (`MPI_Fint`) passed as `int`
+ *
+ * Returns:
+ *   integer error code returned by `SCOTCH_dgraphInit` (0 on success).
+ *
+ ********************************************************************************/
+int scotchm_dgraphinit(SCOTCH_Dgraph **dgraph_ptr, int localcomm)
+{
+	MPI_Comm comm;
+
+	comm = MPI_Comm_f2c((MPI_Fint)localcomm);
+
+	*dgraph_ptr = (SCOTCH_Dgraph *) malloc(sizeof (SCOTCH_Dgraph));
+
+	return SCOTCH_dgraphInit(*dgraph_ptr, comm);
+
+}
+
+
+/********************************************************************************
+ *
+ * scotchm_dgraphbuild
+ *
+ * Build a SCOTCH distributed graph from local vertex/edge arrays.
+ *
+ * Parameters:
+ *   ptr               - pointer to a `SCOTCH_Dgraph` structure
+ *   nVertices         - number of local vertices
+ *   vertloctab_1      - pointer to Fortran-style vertex index array (based)
+ *   nLocEdgesGraph    - number of local edges in the distributed graph
+ *   edgelocsiz_1      - size of the local edge array
+ *   adjncy            - adjacency list array (edge destinations)
+ *
+ * Returns:
+ *   integer error code returned by `SCOTCH_dgraphBuild` (0 on success).
+ *
+ ********************************************************************************/
+int scotchm_dgraphbuild(SCOTCH_Dgraph *dgraph_ptr, SCOTCH_Num nVertices, 
+                        SCOTCH_Num *vertloctab_1, SCOTCH_Num nLocEdgesGraph,
+                        SCOTCH_Num edgelocsiz_1, SCOTCH_Num *adjncy)
+{
+	SCOTCH_Num baseval = 1; /* Fortran-style 1-based indexing */
+	SCOTCH_Num vertlocnbr = nVertices;
+	SCOTCH_Num *veloloctab = NULL; /* vertex weights not used */
+	SCOTCH_Num *vlblloctab = NULL; /* vertex labels not used */
+	SCOTCH_Num edgelocnbr = nLocEdgesGraph;
+	SCOTCH_Num edgelocsiz = edgelocsiz_1;
+	SCOTCH_Num *edgegsttab = NULL; /* Optional array holding the local and ghost indices */
+	SCOTCH_Num *edloloctab = NULL; /* Optional array of integer loads for each local edge */
+
+	SCOTCH_Num *vertloctab = (SCOTCH_Num *)vertloctab_1;
+	SCOTCH_Num *vendloctab = vertloctab_1 + 1;
+	SCOTCH_Num *edgeloctab = (SCOTCH_Num *)adjncy;
+
+	return SCOTCH_dgraphBuild(dgraph_ptr, baseval, vertlocnbr, vertlocnbr,
+	                          vertloctab, vendloctab, veloloctab, vlblloctab,
+	                          edgelocnbr, edgelocsiz, edgeloctab, edgegsttab,
+	                          edloloctab);
+
+}
+
+
+/********************************************************************************
+ *
+ * scotchm_dgraphcheck
+ *
+ * Perform an internal consistency check of a SCOTCH distributed graph.
+ *
+ * Parameters:
+ *   ptr - pointer to a `SCOTCH_Dgraph` structure
+ *
+ * Returns:
+ *   integer error code returned by `SCOTCH_dgraphCheck` (0 on success).
+ *
+ ********************************************************************************/
+int scotchm_dgraphcheck(SCOTCH_Dgraph *dgraph_ptr)
+{
+	return SCOTCH_dgraphCheck(dgraph_ptr);
+
+}
+
+
+/********************************************************************************
+ *
+ * scotchm_dgraphpart
+ *
+ * Partition the distributed graph into `num_part` parts using the provided
+ * SCOTCH strategy object.
+ *
+ * Parameters:
+ *   ptr       - pointer to a `SCOTCH_Dgraph` structure
+ *   num_part  - number of partitions
+ *   ptr_strat - pointer to a `SCOTCH_Strat` structure
+ *   parttab   - output array receiving part numbers for local vertices
+ *
+ * Returns:
+ *   integer error code returned by `SCOTCH_dgraphPart` (0 on success).
+ *
+ ********************************************************************************/
+int scotchm_dgraphpart(SCOTCH_Dgraph *dgraph_ptr, SCOTCH_Num num_part, SCOTCH_Strat *strat_ptr, SCOTCH_Num *parttab)
+{
+	return SCOTCH_dgraphPart(dgraph_ptr, num_part, strat_ptr, parttab);
+
+}
+
+
+/********************************************************************************
+ *
+ * scotchm_dgraphredist
+ *
+ * Redistribute a distributed SCOTCH graph given the partition table.
+ *
+ * Parameters:
+ *   ptr         - pointer to input `SCOTCH_Dgraph` structure
+ *   partloctab  - partition table for local vertices
+ *   ptr_out     - pointer to output `SCOTCH_Dgraph` structure
+ *   vertlocnbr  - pointer to return the number of local vertices in output
+ *
+ * Returns:
+ *   integer error code returned by `SCOTCH_dgraphRedist` (0 on success).
+ *
+ ********************************************************************************/
+int scotchm_dgraphredist(SCOTCH_Dgraph *dgraph_in, SCOTCH_Num *partloctab, SCOTCH_Dgraph *dgraph_out, SCOTCH_Num *vertlocnbr)
+{
+	SCOTCH_Num *permgsttab = NULL; /* Redistribution permutation array */
+	SCOTCH_Num vertlocdlt = 0;     /* Extra size of local vertex array */
+	SCOTCH_Num edgelocdlt = 0;     /* Extra size of local edge array */
+	int err;
+
+	err = SCOTCH_dgraphRedist(dgraph_in, partloctab, permgsttab, vertlocdlt, edgelocdlt, dgraph_out);
+
+	// Call SCOTCH_dgraphSize to obtain the number of local vertices in the redistributed graph
+	SCOTCH_dgraphSize(dgraph_out, NULL, vertlocnbr, NULL, NULL);
+
+	return err;
+
+}
+
+
+/********************************************************************************
+ *
+ * scotchm_dgraphdata
+ *
+ * Extract vertex labels (or stored IDs) for local vertices into `cell_list`.
+ *
+ * Parameters:
+ *   ptr        - pointer to a `SCOTCH_Dgraph` structure
+ *   cell_list  - output array to receive vertex labels for local vertices
+ *
+ * Returns:
+ *   nothing
+ *
+ ********************************************************************************/
+void scotchm_dgraphdata(SCOTCH_Dgraph *dgraph_ptr, SCOTCH_Num *cell_list)
+{
+
+	SCOTCH_Num vertlocnbr;
+	SCOTCH_Num *vlblloctab; /* vertex labels */
+
+	SCOTCH_dgraphData(dgraph_ptr, NULL, NULL, &vertlocnbr, NULL, NULL,
+	                  NULL, NULL, NULL, &vlblloctab, NULL, NULL, NULL,
+	                  NULL, NULL, NULL, NULL);
+
+	// Copy vertex labels to output array
+	for (SCOTCH_Num i = 0; i < vertlocnbr; i++) {
+		cell_list[i] = vlblloctab[i];
+	}
+
+}
+
+
+/********************************************************************************
+ *
+ * scotchm_dgraphexit
+ *
+ * Finalize/cleanup a `SCOTCH_Dgraph` object.
+ *
+ * Parameters:
+ *   ptr - pointer to a `SCOTCH_Dgraph` structure
+ *
+ * Returns:
+ *   nothing (wraps `SCOTCH_dgraphExit`).
+ *
+ ********************************************************************************/
+void scotchm_dgraphexit(SCOTCH_Dgraph *dgraph_ptr)
+{
+	SCOTCH_dgraphExit(dgraph_ptr);
+	free(dgraph_ptr);
+
+}
+
+
+/********************************************************************************
+ *
+ * scotchm_stratinit
+ *
+ * Initialize a SCOTCH strategy object and build a default strategy for
+ * distributed graph mapping.
+ *
+ * Parameters:
+ *   strat_ptr - pointer to a `SCOTCH_Strat` structure
+ *
+ * Returns:
+ *   integer (0 on success).
+ *
+ ********************************************************************************/
+int scotchm_stratinit(SCOTCH_Strat **strat_ptr)
+{
+
+	*strat_ptr = (SCOTCH_Strat *) malloc (sizeof (SCOTCH_Strat));
+
+	SCOTCH_stratInit(*strat_ptr);
+
+	// This was required to avoid crashes when scaling up to large core counts
+	SCOTCH_stratDgraphMapBuild(*strat_ptr, SCOTCH_STRATSCALABILITY, 1, 0, 0.05);
+
+	return 0;
+
+}
+
+
+/* ********************************************************************************
+ *
+ * scotchm_stratexit
+ *
+ * Finalize/cleanup a `SCOTCH_Strat` strategy object.
+ *
+ * Parameters:
+ *   strat_ptr - pointer to a `SCOTCH_Strat` structure
+ *
+ * Returns:
+ *   nothing
+ *
+ ********************************************************************************/
+void scotchm_stratexit(SCOTCH_Strat *strat_ptr)
+{
+	SCOTCH_stratExit(strat_ptr);
+	free(strat_ptr);
+
+}
+#endif


### PR DESCRIPTION
This PR enables the use of MPAS atmosphere core without requiring any graph decomposition files specified as input, if the atmosphere core has been built with the Scotch graph partitioning library (built separately). 

This PR supersedes https://github.com/MPAS-Dev/MPAS-Model/pull/1348 to implement a Fortran interface to the PT-Scotch C library within MPAS. 

### Building MPAS with Scotch

Instructions to build Scotch are provided later in the description. The Scotch version must be at least v7.0.8. Once Scotch has been installed, the MPAS atmosphere core can be leveraged to use online graph partitioning by setting the path to Scotch prior to building MPAS.

```
export SCOTCH=/path/to/scotch/installation
make nvhpc CORE=atmosphere
```

If MPAS is built/linked with Scotch successfully, you should see a message stating that at the end of the build output. 

### Usage and run-time behavior

After building MPAS with Scotch, you can still choose whether or not to use online graph partitioning by setting appropriate values for the `config_block_decomp_file_prefix` namelist option.  

- If `config_block_decomp_file_prefix`+`mpi_tasks` points to a valid graph decomp file that already exists in the run directory, then it is used to proceed with the model run without invoking Scotch. 

- If `config_block_decomp_file_prefix==''` or `config_block_decomp_file_prefix`+`mpi_tasks` does not match any valid graph decomp file in the run directory, then Scotch graph partitioning is invoked. During this process, the generated partition is saved as a graph decomp file to the run directory so that it may be reused in the following runs without needing to invoke Scotch again. 

If MPAS has not been built with scotch, any code paths relating to Scotch will not be taken. And an incorrect specification of `config_block_decomp_file_prefix`+`mpi_tasks` should lead to the model halting.

### Downloading and building Scotch

Scotch may be obtained from its gitlab repository or as tarballs from this [link](https://gitlab.inria.fr/scotch/scotch/-/releases). The minimum Scotch version must be at least v7.0.8. 
```
git clone https://gitlab.inria.fr/scotch/scotch.git && cd scotch 
git checkout v7.0.8
```

Build instructions are on this [page](https://gitlab.inria.fr/scotch/scotch#installation)

It can be as simple as 
```
mkdir build && cd build
cmake -DCMAKE_INSTALL_PREFIX=prefix/scotch/install -DMPI_HOME=/your/mpi/path  ..
make -j5
make install
```

To be able to use the distributed graph partitioning provided by PT-Scotch, you will need to pass an appropriate MPI installation path during the Scotch build. 

Other system pre-requisites are Bison and Flex. I have observed that an older Flex version (v2.6.1) on Eris caused the Scotch build to fail. After pulling in a more recent version of Flex [v2.6.4](https://github.com/westes/flex/releases) it seemed to build fine.  Scotch documentation also references the requirement for a Bison version > 3.4. 