### PR TITLE
Update the core_atmosphere cmake file to include src/framework

### DIFF
--- a/src/framework/CMakeLists.txt
+++ b/src/framework/CMakeLists.txt
@@ -69,6 +69,9 @@ if (MPAS_PROFILE)
     list(APPEND FRAMEWORK_LINK_LIBRARIES GPTL::GPTL)
 endif ()
 target_link_libraries(framework PUBLIC ${FRAMEWORK_LINK_LIBRARIES})
+target_include_directories(framework INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:include/framework>)
 
 install(TARGETS framework EXPORT ${PROJECT_NAME}Exports
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}


### PR DESCRIPTION
This change adds an include of the src /framework directory when building core-atmosphere.

This is required due to a dependency added in https://github.com/MPAS-Dev/MPAS-Model/pull/1359.

This fix was tested by building MPAS-Model core_atmosphere via cmake, using the gnu compiler.
This was also tested by building the mpas-bundle suite via cmake using the gnu compiler.