### PR TITLE
add a new stream property 'gattr_update' to control whether to update global attributes 

### DIFF
--- a/src/framework/mpas_stream_list_types.inc
+++ b/src/framework/mpas_stream_list_types.inc
@@ -22,6 +22,7 @@
         integer :: nRecords
         integer :: precision = MPAS_IO_NATIVE_PRECISION
         integer :: clobber_mode
+        integer :: gattr_update = 1
         integer :: io_type
         type (MPAS_TimeInterval_type), pointer :: recordInterval => null()
         type (MPAS_stream_list_type), pointer :: alarmList_in => null()

--- a/src/framework/mpas_stream_manager.F
+++ b/src/framework/mpas_stream_manager.F
@@ -315,7 +315,7 @@ module mpas_stream_manager
     !-----------------------------------------------------------------------
     subroutine MPAS_stream_mgr_create_stream(manager, streamID, direction, filename, &
                                              filenameInterval, referenceTime, recordInterval, &
-                                             realPrecision, clobberMode, ioType, ierr) !{{{
+                                             realPrecision, clobberMode, gattrUpdate, ioType, ierr) !{{{
 
         use mpas_io, only : MPAS_IO_PNETCDF
 
@@ -332,6 +332,7 @@ module mpas_stream_manager
         type (MPAS_TimeInterval_type), intent(in), optional :: recordInterval
         integer, intent(in), optional :: realPrecision
         integer, intent(in), optional :: clobberMode
+        integer, intent(in), optional :: gattrUpdate
         integer, intent(in), optional :: ioType
         integer, intent(out), optional :: ierr
 
@@ -378,6 +379,11 @@ module mpas_stream_manager
                new_stream % clobber_mode = clobberMode
            else
                new_stream % clobber_mode = MPAS_STREAM_CLOBBER_NEVER
+           end if
+           if (present(gattrUpdate)) then
+               new_stream % gattr_update = gattrUpdate
+           else
+               new_stream % gattr_update = MPAS_STREAM_GATTR_UPDATE_YES
            end if
            if (present(ioType)) then
                new_stream % io_type = ioType
@@ -1482,7 +1488,7 @@ module mpas_stream_manager
         logical :: resetAlarms
 
         threadNum = mpas_threading_get_thread_num()
-        
+
         if (present(streamID)) then
             STREAM_DEBUG_WRITE('-- Called MPAS_stream_mgr_reset_alarms() for stream ' // trim(streamID))
         else
@@ -1797,6 +1803,9 @@ module mpas_stream_manager
                   case (MPAS_STREAM_PROPERTY_CLOBBER)
                       stream_cursor % clobber_mode = propertyValue
 
+                  case (MPAS_STREAM_PROPERTY_GATTR_UPDATE)
+                      stream_cursor % gattr_update = propertyValue
+
                   case (MPAS_STREAM_PROPERTY_IOTYPE)
                       stream_cursor % io_type = propertyValue
 
@@ -2029,6 +2038,9 @@ module mpas_stream_manager
 
             case (MPAS_STREAM_PROPERTY_CLOBBER)
                 propertyValue = stream_cursor % clobber_mode
+
+            case (MPAS_STREAM_PROPERTY_GATTR_UPDATE)
+                propertyValue = stream_cursor % gattr_update
 
             case (MPAS_STREAM_PROPERTY_IOTYPE)
                 propertyValue = stream_cursor % io_type
@@ -4267,7 +4279,7 @@ module mpas_stream_manager
         integer :: err_level
 
 
-        if (direction == MPAS_STREAM_OUTPUT) then
+        if (direction == MPAS_STREAM_OUTPUT .and. stream % gattr_update == MPAS_STREAM_GATTR_UPDATE_YES) then
 
             !
             ! Write attributes to stream
@@ -5722,7 +5734,7 @@ module mpas_stream_manager
     logical function MPAS_stream_mgr_get_next_stream(manager, streamID, directionProperty, activeProperty, & !{{{
                                                      immutableProperty, filenameTemplateProperty, &
                                                      referenceTimeProperty, recordIntervalProperty, precisionProperty, &
-                                                     filenameIntervalProperty, clobberProperty) result(validStream)
+                                                     filenameIntervalProperty, clobberProperty, gattrUpdateProperty) result(validStream)
 
         implicit none
 
@@ -5737,6 +5749,7 @@ module mpas_stream_manager
         integer, intent(out), optional :: precisionProperty                        !< Output: Integer describing the precision of the stream
         character (len=StrKIND), intent(out), optional :: filenameIntervalProperty !< Output: String containing the filename interval for the stream
         integer, intent(out), optional :: clobberProperty                          !< Output: Interger describing the clobber mode of the stream
+        integer, intent(out), optional :: gattrUpdateProperty                      !< Output: Interger describing whether to update global attributes
 
         integer :: threadNum
 
@@ -5802,6 +5815,10 @@ module mpas_stream_manager
 
         if ( present(clobberProperty) ) then
             clobberProperty = manager % currentStream % clobber_mode
+        end if
+
+        if ( present(gattrUpdateProperty) ) then
+            gattrUpdateProperty = manager % currentStream % gattr_update
         end if
 
     end function MPAS_stream_mgr_get_next_stream !}}}
@@ -5926,7 +5943,7 @@ end module mpas_stream_manager
 
 
 subroutine stream_mgr_create_stream_c(manager_c, streamID_c, direction_c, filename_c, filename_intv_c, ref_time_c, rec_intv_c, &
-                                      immutable_c, precision_c, clobber_c, iotype_c, ierr_c) bind(c) !{{{
+                                      immutable_c, precision_c, clobber_c, gattr_update_c, iotype_c, ierr_c) bind(c) !{{{
 
     use mpas_c_interfacing, only : mpas_c_to_f_string
     use iso_c_binding, only : c_char, c_int, c_ptr, c_f_pointer
@@ -5935,7 +5952,8 @@ subroutine stream_mgr_create_stream_c(manager_c, streamID_c, direction_c, filena
                                         MPAS_STREAM_PROPERTY_FILENAME_INTV, MPAS_STREAM_PROPERTY_REF_TIME, &
                                         MPAS_STREAM_PROPERTY_RECORD_INTV, MPAS_STREAM_PROPERTY_PRECISION, &
                                         MPAS_STREAM_PROPERTY_CLOBBER, MPAS_STREAM_CLOBBER_NEVER, MPAS_STREAM_CLOBBER_APPEND, &
-                                        MPAS_STREAM_CLOBBER_TRUNCATE, MPAS_STREAM_CLOBBER_OVERWRITE, MPAS_STREAM_PROPERTY_IOTYPE
+                                        MPAS_STREAM_CLOBBER_TRUNCATE, MPAS_STREAM_CLOBBER_OVERWRITE, MPAS_STREAM_PROPERTY_IOTYPE, &
+                                        MPAS_STREAM_PROPERTY_GATTR_UPDATE, MPAS_STREAM_GATTR_UPDATE_YES, MPAS_STREAM_GATTR_UPDATE_NO
     use mpas_stream_manager, only : MPAS_stream_mgr_create_stream, MPAS_stream_mgr_set_property
     use mpas_kind_types, only : StrKIND
     use mpas_derived_types, only : MPAS_LOG_ERR
@@ -5955,13 +5973,14 @@ subroutine stream_mgr_create_stream_c(manager_c, streamID_c, direction_c, filena
     integer(kind=c_int) :: immutable_c
     integer(kind=c_int) :: precision_c
     integer(kind=c_int) :: clobber_c
+    integer(kind=c_int) :: gattr_update_c
     integer(kind=c_int) :: iotype_c
     integer(kind=c_int) :: ierr_c
 
     type (MPAS_streamManager_type), pointer :: manager
     character(len=StrKIND) :: streamID, filename, filename_interval, reference_time, record_interval
     integer :: direction, immutable, prec, ierr
-    integer :: clobber_mode, iotype
+    integer :: clobber_mode, iotype, gattr_update
 
     call c_f_pointer(manager_c, manager)
     call mpas_c_to_f_string(streamID_c, streamID)
@@ -5990,6 +6009,12 @@ subroutine stream_mgr_create_stream_c(manager_c, streamID_c, direction_c, filena
        clobber_mode = MPAS_STREAM_CLOBBER_OVERWRITE
     else
        clobber_mode = MPAS_STREAM_CLOBBER_NEVER
+    end if
+
+    if (gattr_update_c == 0) then
+       gattr_update = MPAS_STREAM_GATTR_UPDATE_NO
+    else
+       gattr_update = MPAS_STREAM_GATTR_UPDATE_YES
     end if
 
     if (iotype_c == 0) then
@@ -6027,10 +6052,11 @@ subroutine stream_mgr_create_stream_c(manager_c, streamID_c, direction_c, filena
         end if
         call MPAS_stream_mgr_set_property(manager, streamID, MPAS_STREAM_PROPERTY_PRECISION, prec, ierr=ierr)
         call MPAS_stream_mgr_set_property(manager, streamID, MPAS_STREAM_PROPERTY_CLOBBER, clobber_mode, ierr=ierr)
+        call MPAS_stream_mgr_set_property(manager, streamID, MPAS_STREAM_PROPERTY_GATTR_UPDATE, gattr_update, ierr=ierr)
         call MPAS_stream_mgr_set_property(manager, streamID, MPAS_STREAM_PROPERTY_IOTYPE, iotype, ierr=ierr)
     else
         call MPAS_stream_mgr_create_stream(manager, streamID, direction, filename, realPrecision=prec, &
-                                           clobberMode=clobber_mode, ioType=iotype, ierr=ierr)
+                                           clobberMode=clobber_mode, gattrUpdate=gattr_update, ioType=iotype, ierr=ierr)
     end if
 
     if (reference_time /= 'initial_time') then

--- a/src/framework/mpas_stream_manager_types.inc
+++ b/src/framework/mpas_stream_manager_types.inc
@@ -20,12 +20,16 @@
                                   MPAS_STREAM_PROPERTY_PRECISION     = 10, &
                                   MPAS_STREAM_PROPERTY_FILENAME_INTV = 11, &
                                   MPAS_STREAM_PROPERTY_CLOBBER       = 12, &
-                                  MPAS_STREAM_PROPERTY_IOTYPE        = 13
+                                  MPAS_STREAM_PROPERTY_IOTYPE        = 13, &
+                                  MPAS_STREAM_PROPERTY_GATTR_UPDATE  = 14
 
     integer, public, parameter :: MPAS_STREAM_CLOBBER_NEVER     = 100, &
                                   MPAS_STREAM_CLOBBER_APPEND    = 101, &
                                   MPAS_STREAM_CLOBBER_TRUNCATE  = 102, &
                                   MPAS_STREAM_CLOBBER_OVERWRITE = 103
+
+    integer, public, parameter :: MPAS_STREAM_GATTR_UPDATE_YES  = 201, &
+                                  MPAS_STREAM_GATTR_UPDATE_NO   = 200
 
     type MPAS_streamManager_type
 

--- a/src/framework/xml_stream_parser.c
+++ b/src/framework/xml_stream_parser.c
@@ -25,7 +25,7 @@
 /*
  *  Interface routines for building streams at run-time; defined in mpas_stream_manager.F
  */
-void stream_mgr_create_stream_c(void *, const char *, int *, const char *, const char *, const char *, const char *, int *, int *, int *, int *, int *);
+void stream_mgr_create_stream_c(void *, const char *, int *, const char *, const char *, const char *, const char *, int *, int *, int *, int *, int *, int *);
 void stream_mgr_add_field_c(void *, const char *, const char *, const char *, int *);
 void stream_mgr_add_immutable_stream_fields_c(void *, const char *, const char *, const char *, int *);
 void stream_mgr_add_pool_c(void *, const char *, const char *, const char *, int *);
@@ -1053,6 +1053,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 	const char *streamID, *filename_template, *filename_interval, *direction, *varfile, *fieldname_const, *reference_time, *record_interval, *streamname_const, *precision;
 	const char *interval_in, *interval_out, *packagelist;
 	const char *clobber;
+	const char *gattr_update;
 	const char *iotype;
 	const char *streamID2, *interval_in2, *interval_out2;
 	char interval_name[256];
@@ -1068,6 +1069,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 	char msgbuf[MSGSIZE];
 	int itype;
 	int iclobber;
+	int igattr_update;
 	int i_iotype;
 	int iprec;
 	int immutable;
@@ -1114,6 +1116,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 		precision = ezxml_attr(stream_xml, "precision");
 		packagelist = ezxml_attr(stream_xml, "packages");
 		clobber = ezxml_attr(stream_xml, "clobber_mode");
+		gattr_update = ezxml_attr(stream_xml, "gattr_update");
 		iotype = ezxml_attr(stream_xml, "io_type");
 
 		/* Extract the input interval, if it refer to other streams */
@@ -1236,6 +1239,26 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 			}
 		}
 
+		/* NB: These gattr_update constants must match those in the mpas_stream_manager module! */
+		igattr_update = 1;
+		if (gattr_update != NULL) {
+			if (strstr(gattr_update, "yes") != NULL) {
+				igattr_update = 1;
+				snprintf(msgbuf, MSGSIZE, "        %-20s%s", "gattr_update:", "yes");
+				mpas_log_write_c(msgbuf, "MPAS_LOG_OUT");
+			}
+			else if (strstr(gattr_update, "no") != NULL) {
+				igattr_update = 0;
+				snprintf(msgbuf, MSGSIZE, "        %-20s%s", "gattr_update:", "no");
+				mpas_log_write_c(msgbuf, "MPAS_LOG_OUT");
+			}
+			else {
+				igattr_update = 1;
+				snprintf(msgbuf, MSGSIZE, "        *** unrecognized gattr_update specification; global attributes will be updated by default");
+				mpas_log_write_c(msgbuf, "MPAS_LOG_OUT");
+			}
+		}
+
 		/* NB: These io_type constants must match those in the mpas_stream_manager module! */
 		i_iotype = 0;
 		if (iotype != NULL) {
@@ -1337,7 +1360,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 		}
 
 		stream_mgr_create_stream_c(manager, streamID, &itype, filename_template, filename_interval_string, ref_time_local, rec_intv_local,
-					&immutable, &iprec, &iclobber, &i_iotype, &err);
+					&immutable, &iprec, &iclobber, &igattr_update, &i_iotype, &err);
 		if (err != 0) {
 			*status = 1;
 			return;
@@ -1423,6 +1446,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 		precision = ezxml_attr(stream_xml, "precision");
 		packagelist = ezxml_attr(stream_xml, "packages");
 		clobber = ezxml_attr(stream_xml, "clobber_mode");
+		gattr_update = ezxml_attr(stream_xml, "gattr_update");
 		iotype = ezxml_attr(stream_xml, "io_type");
 
 		/* Extract the input interval, if it refer to other streams */
@@ -1545,6 +1569,26 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 			}
 		}
 
+		/* NB: These gattr_update constants must match those in the mpas_stream_manager module! */
+		igattr_update = 1;
+		if (gattr_update != NULL) {
+			if (strstr(gattr_update, "yes") != NULL) {
+				igattr_update = 1;
+				snprintf(msgbuf, MSGSIZE, "        %-20s%s", "gattr_update:", "yes");
+				mpas_log_write_c(msgbuf, "MPAS_LOG_OUT");
+			}
+			else if (strstr(gattr_update, "no") != NULL) {
+				igattr_update = 0;
+				snprintf(msgbuf, MSGSIZE, "        %-20s%s", "gattr_update:", "no");
+				mpas_log_write_c(msgbuf, "MPAS_LOG_OUT");
+			}
+			else {
+				igattr_update = 1;
+				snprintf(msgbuf, MSGSIZE, "        *** unrecognized gattr_update specification; global attributes will be updated by default");
+				mpas_log_write_c(msgbuf, "MPAS_LOG_OUT");
+			}
+		}
+
 		/* NB: These io_type constants must match those in the mpas_stream_manager module! */
 		i_iotype = 0;
 		if (iotype != NULL) {
@@ -1646,7 +1690,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 		}
 
 		stream_mgr_create_stream_c(manager, streamID, &itype, filename_template, filename_interval_string, ref_time_local, rec_intv_local,
-					&immutable, &iprec, &iclobber, &i_iotype, &err);
+					&immutable, &iprec, &iclobber, &igattr_update, &i_iotype, &err);
 		if (err != 0) {
 			*status = 1;
 			return;


### PR DESCRIPTION
When we do coldstart data assimilation on `init.nc` using JEDI, we will get a crash in MPAS IO with the following error:
```
ERROR: MPAS IO Error: PIO error -38: NetCDF: Operation not allowed in data mode
```
Per discussions with NOAA @samuelTrahanNOAA and NCAR Tao Sun, we identified that the problem came from `src/framework/mpas_stream_manager.F` where `mpas_writeStreamAtt` tries to write not-defined global attributes to `init.nc`. Since we don't expect JEDI to update any global attributes (at least for `init.nc`), we can skip the relevant `mpas_writeStreamAtt` part when doing JEDI data assimilation.

This PR is to address this issue by adding a new stream property `gattr_update`. It takes values of `yes` or `no` and defaults to `yes`. So it does not affect any existing MPAS-Model capabilities but allow coldstart JEDI DA to skip the relevant `mpas_writeStreamAtt` part to avoid crash, by setting `gattr_update=no` in the `analysis` stream. 


