### PR TITLE
Nullify value pointers in mpas_pool_get_config_* routines to ensure safe associated checks

### DIFF
--- a/src/framework/mpas_pool_routines.F
+++ b/src/framework/mpas_pool_routines.F
@@ -4770,6 +4770,8 @@ module mpas_pool_routines
 
       type (mpas_pool_data_type), pointer :: mem
 
+      nullify(value)
+
       if ( present(record) ) then
          call mpas_pool_get_subpool(inPool, record, recordPool)
          mem => pool_get_member(recordPool, key, MPAS_POOL_CONFIG)
@@ -4811,6 +4813,8 @@ module mpas_pool_routines
       type (mpas_pool_type), pointer :: recordPool
 
       type (mpas_pool_data_type), pointer :: mem
+
+      nullify(value)
 
       if ( present(record) ) then
          call mpas_pool_get_subpool(inPool, record, recordPool)
@@ -4854,6 +4858,8 @@ module mpas_pool_routines
 
       type (mpas_pool_data_type), pointer :: mem
 
+      nullify(value)
+
       if ( present(record) ) then
          call mpas_pool_get_subpool(inPool, record, recordPool)
          mem => pool_get_member(recordPool, key, MPAS_POOL_CONFIG)
@@ -4896,6 +4902,8 @@ module mpas_pool_routines
       type (mpas_pool_type), pointer :: recordPool
 
       type (mpas_pool_data_type), pointer :: mem
+
+      nullify(value)
 
       if ( present(record) ) then
          call mpas_pool_get_subpool(inPool, record, recordPool)


### PR DESCRIPTION
This PR updates the `mpas_pool_get_config_*` subroutines (`real`, `int`, `char`, and `logical`) to nullify the `value` pointer argument at the start of each routine. Previously, the `value` pointer was not initialized before being potentially assigned within the subroutine. As a result, if a caller later used `associated(value)` to check whether a config key existed in the pool, the behavior was undefined because the pointer could contain a garbage address. By adding `nullify(value)` at the beginning of each subroutine, this change ensures that the pointer is always in a defined state, allowing safe use of `associated(value)` by callers. No other logic or behavior was modified, and this change has no impact on valid configurations or model results.
