### PR TITLE
Nullify `subPool` pointer in `mpas_pool_get_subpool` to allow safe associated checks

### DIFF
--- a/src/framework/mpas_pool_routines.F
+++ b/src/framework/mpas_pool_routines.F
@@ -5149,6 +5149,7 @@ module mpas_pool_routines
 
       type (mpas_pool_data_type), pointer :: mem
 
+      nullify(subPool)
 
       mem => pool_get_member(inPool, key, MPAS_POOL_SUBPOOL)
 


### PR DESCRIPTION
This PR adds a `nullify(subPool)` call at the start of the `mpas_pool_get_subpool` subroutine. Previously, the `subPool` pointer argument was not initialized before being assigned within the routine. This could lead to undefined behavior if a caller used `associated(subPool)` to check whether a subpool with the given name existed in the pool, since `subPool` could contain an undefined address prior to assignment. By explicitly nullifying `subPool`, the pointer is guaranteed to be in a defined state, allowing safe and predictable use of `associated(subPool)` in calling code. No other behavior or logic in the subroutine has been changed.

