### PR TITLE
Nullify pointer arguments in all pool accessor routines for consistency

### DIFF
--- a/src/framework/mpas_pool_routines.F
+++ b/src/framework/mpas_pool_routines.F
@@ -4770,6 +4770,8 @@ module mpas_pool_routines
 
       type (mpas_pool_data_type), pointer :: mem
 
+      nullify(value)
+
       if ( present(record) ) then
          call mpas_pool_get_subpool(inPool, record, recordPool)
          mem => pool_get_member(recordPool, key, MPAS_POOL_CONFIG)
@@ -4811,6 +4813,8 @@ module mpas_pool_routines
       type (mpas_pool_type), pointer :: recordPool
 
       type (mpas_pool_data_type), pointer :: mem
+
+      nullify(value)
 
       if ( present(record) ) then
          call mpas_pool_get_subpool(inPool, record, recordPool)
@@ -4854,6 +4858,8 @@ module mpas_pool_routines
 
       type (mpas_pool_data_type), pointer :: mem
 
+      nullify(value)
+
       if ( present(record) ) then
          call mpas_pool_get_subpool(inPool, record, recordPool)
          mem => pool_get_member(recordPool, key, MPAS_POOL_CONFIG)
@@ -4896,6 +4902,8 @@ module mpas_pool_routines
       type (mpas_pool_type), pointer :: recordPool
 
       type (mpas_pool_data_type), pointer :: mem
+
+      nullify(value)
 
       if ( present(record) ) then
          call mpas_pool_get_subpool(inPool, record, recordPool)
@@ -5149,6 +5157,7 @@ module mpas_pool_routines
 
       type (mpas_pool_data_type), pointer :: mem
 
+      nullify(subPool)
 
       mem => pool_get_member(inPool, key, MPAS_POOL_SUBPOOL)
 
@@ -5228,6 +5237,7 @@ module mpas_pool_routines
 
       type (mpas_pool_data_type), pointer :: mem
 
+      nullify(package)
 
       mem => pool_get_member(inPool, key, MPAS_POOL_PACKAGE)
 


### PR DESCRIPTION
This PR updates all pool accessor routines to nullify their pointer arguments at the start of each subroutine. The affected routines are:

* `mpas_pool_get_config_real`
* `mpas_pool_get_config_int`
* `mpas_pool_get_config_char`
* `mpas_pool_get_config_logical`
* `mpas_pool_get_subpool`
* `mpas_pool_get_package`

Previously, these pointer arguments (`value`, `subPool`, and `package`) were not initialized before assignment. This could lead to undefined behavior if callers used `associated()` to check whether a config key, subpool, or package existed in the pool.

By explicitly nullifying these pointers, they are guaranteed to be in a defined state before assignment, allowing callers to safely perform `associated()` checks. This change also makes the behavior of these accessor routines consistent with the existing behavior of `mpas_pool_get_field_*`, `mpas_pool_get_array_*`, and `mpas_pool_get_dimension_*`.