### PR TITLE
Enable custom stream updates in mpas_init via callback config

### DIFF
--- a/src/driver/mpas_subdriver.F
+++ b/src/driver/mpas_subdriver.F
@@ -35,78 +35,53 @@ module mpas_subdriver
    use test_core_interface
 #endif
 
-   private :: make_stream_update_config
-
-   interface stream_update_config_t
-      module procedure make_stream_update_config
-   end interface stream_update_config_t
-
-
-   type stream_update_config_t
-      !> Stream manager to be modified.
-      type(MPAS_streamManager_Type) :: manager
-
-      !> Configuration filename associated with the update operation.
-      character(len = :), allocatable :: filename
-
-      !> Procedure pointer implementing the update behavior.
-      procedure(apply_stream_update_i), pointer :: apply
-   end type stream_update_config_t
-
-
-   !-----------------------------------------------------------------------
-   !  abstract interface apply_stream_update_i
+   !***********************************************************************
    !
-   !> \brief Interface for user-defined stream update routines.
-   !>
+   !  type stream_update_callback_type
+   !
+   !> \brief   Abstract base class for stream update callbacks.
+   !> \author  Andy Stokely
+   !> \date    11/11/2025
    !> \details
-   !>  Any procedure assigned to `stream_update_config_t%apply` must
-   !>  match this interface.
+   !>   Users extend this type to define custom behavior for updating
+   !>   MPAS stream configurations. The deferred procedure "apply" is
+   !>   implemented by the child derived type.
+   !
+   !-----------------------------------------------------------------------
+   type, abstract :: stream_update_callback_type
+   contains
+      procedure(stream_update_callback), private, deferred :: apply
+      procedure :: update
+   end type stream_update_callback_type
+
+   !***********************************************************************
+   !
+   !  interface stream_update_callback
+   !
+   !> \brief   Interface for the deferred callback procedure.
+   !> \author  Andy Stokely
+   !> \date    11/11/2025
+   !> \details
+   !>   Implementations of this routine modify stream metadata within
+   !>   the MPAS_streamManager_type. Errors should be signaled by setting
+   !>   ierr to a non-zero value when present.
+   !
    !-----------------------------------------------------------------------
    abstract interface
-      subroutine apply_stream_update_i(this, ierr)
-         import :: stream_update_config_t
-         class(stream_update_config_t), intent(inout) :: this
-         integer, intent(out), optional :: ierr
-      end subroutine apply_stream_update_i
-   end interface
+      subroutine stream_update_callback(self, manager, ierr)
+         import :: MPAS_streamManager_type
+         import :: stream_update_callback_type
 
+         implicit none
+         class(stream_update_callback_type), intent(inout) :: self
+         type(MPAS_streamManager_type), intent(inout) :: manager
+         integer, optional, intent(out) :: ierr
+      end subroutine stream_update_callback
+   end interface
 
    contains
 
-
-   !-----------------------------------------------------------------------
-   !  function make_stream_update_config
-   !
-   !> \brief Construct and initialize a `stream_update_config_t` object.
-   !> \author Andy Stokely
-   !> \date   11/05/2025
-   !>
-   !> \details
-   !>  Returns a `stream_update_config_t` instance initialized using the
-   !>  provided manager, filename, and update procedure pointer.
-   !-----------------------------------------------------------------------
-   type(stream_update_config_t) function make_stream_update_config( &
-         manager, filename, apply) result(stream_update_config)
-      implicit none
-      type(MPAS_streamManager_Type), intent(in) :: manager
-      character(len = *), intent(in), optional :: filename
-      procedure(apply_stream_update_i), pointer, intent(in) :: apply
-
-      nullify(stream_update_config % apply)
-      stream_update_config % manager = manager
-      if (present(filename)) then
-         stream_update_config % filename = filename
-      else
-         stream_update_config % filename = ''
-      end if
-      stream_update_config % filename = filename
-      stream_update_config % apply => apply
-   end function make_stream_update_config
-
-
-
-   subroutine mpas_init(corelist, domain_ptr, external_comm, namelistFileParam, streamsFileParam, stream_update_config)
+   subroutine mpas_init(corelist, domain_ptr, external_comm, namelistFileParam, streamsFileParam, streamUpdateCallback)
 
 #ifdef MPAS_USE_MPI_F08
       use mpi_f08, only : MPI_Comm
@@ -118,6 +93,7 @@ module mpas_subdriver
       use mpas_bootstrapping, only : mpas_bootstrap_framework_phase1, mpas_bootstrap_framework_phase2
       use mpas_log
       use mpas_stream_inquiry, only : MPAS_stream_inquiry_new_streaminfo
+      use mpas_callback, only : stream_update_callback_type
  
       implicit none
 
@@ -130,7 +106,7 @@ module mpas_subdriver
 #endif
       character(len=*), intent(in), optional :: namelistFileParam
       character(len=*), intent(in), optional :: streamsFileParam
-      type(stream_update_config_t), intent(inout), optional :: stream_update_config
+      class(stream_update_callback_type), intent(inout), optional :: streamUpdateCallback
 
       integer :: iArg, nArgs
       logical :: readNamelistArg, readStreamsArg
@@ -442,17 +418,13 @@ module mpas_subdriver
          call mpas_log_write('xml stream parser failed: '//trim(domain_ptr % streams_filename), messageType=MPAS_LOG_CRIT)
       end if
 
-         if (present(stream_update_config)) then
-            if (associated(stream_update_config % apply)) then
-               call stream_update_config % apply(ierr)
-               if (ierr /= 0) then
-                  call mpas_log_write('Stream update procedure failed for core '//trim(domain_ptr % core % coreName), &
-                        messageType=MPAS_LOG_CRIT)
-               end if
-            end if
-
+      if ( present(streamUpdateCallback) ) then
+         call streamUpdateCallback%update(domain_ptr % streamManager, ierr)
+         if ( ierr /= 0 ) then
+            call mpas_log_write('Stream update callback failed for core '//trim(domain_ptr % core % coreName), messageType=MPAS_LOG_CRIT)
          end if
-         !
+      end if
+
       ! Validate streams after set-up
       !
       call mpas_log_write(' ** Validating streams')

--- a/src/driver/mpas_subdriver.F
+++ b/src/driver/mpas_subdriver.F
@@ -50,8 +50,7 @@ module mpas_subdriver
    !-----------------------------------------------------------------------
    type, abstract :: stream_update_callback_type
    contains
-      procedure(stream_update_callback), private, deferred :: apply
-      procedure :: update
+      procedure(stream_update_callback), deferred :: apply
    end type stream_update_callback_type
 
    !***********************************************************************

--- a/src/driver/mpas_subdriver.F
+++ b/src/driver/mpas_subdriver.F
@@ -35,11 +35,78 @@ module mpas_subdriver
    use test_core_interface
 #endif
 
+   private :: make_stream_update_config
+
+   interface stream_update_config_t
+      module procedure make_stream_update_config
+   end interface stream_update_config_t
+
+
+   type stream_update_config_t
+      !> Stream manager to be modified.
+      type(MPAS_streamManager_Type) :: manager
+
+      !> Configuration filename associated with the update operation.
+      character(len = :), allocatable :: filename
+
+      !> Procedure pointer implementing the update behavior.
+      procedure(apply_stream_update_i), pointer :: apply
+   end type stream_update_config_t
+
+
+   !-----------------------------------------------------------------------
+   !  abstract interface apply_stream_update_i
+   !
+   !> \brief Interface for user-defined stream update routines.
+   !>
+   !> \details
+   !>  Any procedure assigned to `stream_update_config_t%apply` must
+   !>  match this interface.
+   !-----------------------------------------------------------------------
+   abstract interface
+      subroutine apply_stream_update_i(this, ierr)
+         import :: stream_update_config_t
+         class(stream_update_config_t), intent(inout) :: this
+         integer, intent(out), optional :: ierr
+      end subroutine apply_stream_update_i
+   end interface
+
 
    contains
 
 
-   subroutine mpas_init(corelist, domain_ptr, external_comm, namelistFileParam, streamsFileParam)
+   !-----------------------------------------------------------------------
+   !  function make_stream_update_config
+   !
+   !> \brief Construct and initialize a `stream_update_config_t` object.
+   !> \author Andy Stokely
+   !> \date   11/05/2025
+   !>
+   !> \details
+   !>  Returns a `stream_update_config_t` instance initialized using the
+   !>  provided manager, filename, and update procedure pointer.
+   !-----------------------------------------------------------------------
+   type(stream_update_config_t) function make_stream_update_config( &
+         manager, filename, apply) result(stream_update_config)
+      implicit none
+      type(MPAS_streamManager_Type), intent(in) :: manager
+      character(len = *), intent(in), optional :: filename
+      procedure(apply_stream_update_i), pointer, intent(in) :: apply
+
+      nullify(stream_update_config % apply)
+      stream_update_config % manager = manager
+      if (present(filename)) then
+         stream_update_config % filename = filename
+      else
+         stream_update_config % filename = ''
+      end if
+      stream_update_config % filename = filename
+      stream_update_config % apply => apply
+   end function make_stream_update_config
+
+
+
+   subroutine mpas_init(corelist, domain_ptr, external_comm, namelistFileParam, streamsFileParam, stream_update_config)
 
 #ifdef MPAS_USE_MPI_F08
       use mpi_f08, only : MPI_Comm
@@ -63,6 +130,7 @@ module mpas_subdriver
 #endif
       character(len=*), intent(in), optional :: namelistFileParam
       character(len=*), intent(in), optional :: streamsFileParam
+      type(stream_update_config_t), intent(inout), optional :: stream_update_config
 
       integer :: iArg, nArgs
       logical :: readNamelistArg, readStreamsArg
@@ -374,7 +442,17 @@ module mpas_subdriver
          call mpas_log_write('xml stream parser failed: '//trim(domain_ptr % streams_filename), messageType=MPAS_LOG_CRIT)
       end if
 
-      !
+         if (present(stream_update_config)) then
+            if (associated(stream_update_config % apply)) then
+               call stream_update_config % apply(ierr)
+               if (ierr /= 0) then
+                  call mpas_log_write('Stream update procedure failed for core '//trim(domain_ptr % core % coreName), &
+                        messageType=MPAS_LOG_CRIT)
+               end if
+            end if
+
+         end if
+         !
       ! Validate streams after set-up
       !
       call mpas_log_write(' ** Validating streams')


### PR DESCRIPTION
This PR adds an optional argument to `mpas_init` for supplying a user-defined callback that executes after stream manager initialization. The user provides an instance of a derived type that extends the abstract base type `stream_update_callback_type`. To satisfy the interface, the derived type must implement a procedure with the signature:

```fortran
subroutine stream_update_callback(self, manager, ierr)
   class(stream_update_callback_type), intent(inout) :: self
   type(MPAS_streamManager_type), intent(inout) :: manager
   integer, optional, intent(out) :: ierr
end subroutine stream_update_callback
```
This mechanism allows users to inject custom stream modification or update logic during initialization without altering the core stream-processing code. These are the MPAS-specific changes needed to resolve issue #1373.

