### PR TITLE
Explicitly declare ierr as an integer variable in the noahmp_init routine

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_lsm_noahmpinit.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_lsm_noahmpinit.F
@@ -258,7 +258,7 @@
  logical,pointer:: do_restart
  logical,parameter:: fndsnowh = .true.
 
- integer:: i,its,ite,n,ns,nsoil,nsnow,nzsnow
+ integer:: i,its,ite,n,ns,nsoil,nsnow,nzsnow,ierr
 
  real(kind=RKIND),parameter:: hlice = 3.335E5
  real(kind=RKIND):: bexp,fk,smcmax,psisat


### PR DESCRIPTION
This PR modifies the `noahmp_init` subroutine in the `mpas_atmphys_lsm_noahmpinit` module so that the `ierr` variable is explicitly declared as an integer variable.

Because the name of the `ierr` variable begins with the letter `i`, it was implicitly defined as an integer variable, and its use within the `noahmp_init` routine was consistent with that of an integer variable.