### PR TITLE
MPAS MUSICA namelist option for MICM configuration

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -394,6 +394,15 @@
                      possible_values="`mpas_dmpar', `mpas_halo'"/>
         </nml_record>
 
+#ifdef MPAS_USE_MUSICA
+        <nml_record name="musica" in_defaults="true">
+                <nml_option name="config_micm_file" type="character" default_value=""
+                     units="-"
+                     description="MICM configuration file name"
+                     possible_values="Any valid filename"/>
+        </nml_record>
+#endif
+
 <!-- **************************************************************************************** -->
 <!-- **************************************  Packages  ************************************** -->
 <!-- **************************************************************************************** -->

--- a/src/core_atmosphere/chemistry/mpas_atm_chemistry.F
+++ b/src/core_atmosphere/chemistry/mpas_atm_chemistry.F
@@ -43,7 +43,7 @@ module mpas_atm_chemistry
         use mpas_musica, only: musica_init
 #endif
         use mpas_log, only : mpas_log_write
-        use mpas_derived_types, only: mpas_pool_type
+        use mpas_derived_types, only: mpas_pool_type, MPAS_LOG_CRIT
         use mpas_kind_types, only: StrKIND
         use mpas_pool_routines, only: mpas_pool_get_config, mpas_pool_get_dimension 
 
@@ -51,13 +51,11 @@ module mpas_atm_chemistry
         type (mpas_pool_type), intent(in) :: dimensions
 
 #ifdef MPAS_USE_MUSICA
-        integer                       :: error_code
-        character(len=:), allocatable :: error_message
-        integer                       :: nVertLevels
-        integer, pointer              :: nVertLevels_ptr
-        ! MUSICA will get the MICM JSON config from a namelist
-        ! hardcode filepath for now
-        character(len=StrKIND) :: filepath = 'chapman.json'
+        character(len=StrKIND), pointer :: filepath_ptr
+        integer                         :: error_code
+        character(len=:), allocatable   :: error_message
+        integer                         :: nVertLevels
+        integer, pointer                :: nVertLevels_ptr
 #endif
 
         call mpas_log_write('Initializing chemistry packages...')
@@ -66,9 +64,13 @@ module mpas_atm_chemistry
         call mpas_pool_get_dimension(dimensions, 'nVertLevels', nVertLevels_ptr)
         nVertLevels = nVertLevels_ptr
 
-        call musica_init(filepath, nVertLevels, error_code, error_message)
+        call mpas_pool_get_config(configs, 'config_micm_file', filepath_ptr)
 
-        ! TODO check error_code and generate MPAS error log message
+        call musica_init(filepath_ptr, nVertLevels, error_code, error_message)
+
+        if (error_code /= 0) then
+            call mpas_log_write(error_message, messageType=MPAS_LOG_CRIT)
+        end if
 #endif
 
     end subroutine chemistry_init

--- a/src/core_atmosphere/chemistry/musica/mpas_musica.F
+++ b/src/core_atmosphere/chemistry/musica/mpas_musica.F
@@ -29,6 +29,7 @@ module mpas_musica
 
     type(micm_t),  pointer :: micm  => null ( )  ! Pointer to the MICM ODE solver instance
     type(state_t), pointer :: state => null ( )  ! Pointer to the state of the MICM solver
+    logical :: musica_is_initialized = .false.   ! Flag to track if MUSICA was successfully initialized
 
     contains
 
@@ -61,13 +62,22 @@ module mpas_musica
 
         type(error_t)  :: error
         type(string_t) :: micm_version
-
         ! TEMPORARY: Hard-coded options for the MICM solver
         integer :: solver_type = RosenbrockStandardOrder
+        integer :: i_species
+
+        ! Skip MUSICA initialization if no configuration file is provided
+        if (len_trim(filename_of_micm_configuration) == 0) then
+            call mpas_log_write('MUSICA chemistry disabled: no MICM configuration file specified')
+            error_code = 0
+            error_message = ''
+            return
+        end if
 
         micm_version = get_micm_version()
 
         call mpas_log_write('Initializing MUSICA chemistry package...')
+        call mpas_log_write('MICM configuration file: ' // trim(filename_of_micm_configuration))
         call mpas_log_write('MICM version: ' // micm_version%value_)
         call mpas_log_write('MICM number of grid cells: $i', intArgs=[number_of_grid_cells])
 
@@ -76,6 +86,12 @@ module mpas_musica
 
         state => micm%get_state(number_of_grid_cells, error)
         if (has_error_occurred(error, error_message, error_code)) return
+
+        do i_species = 1, state%species_ordering%size()
+            call mpas_log_write('MICM species: ' // state%species_ordering%name(i_species))
+        end do
+
+        musica_is_initialized = .true.
 
     end subroutine musica_init
 
@@ -95,6 +111,8 @@ module mpas_musica
     subroutine musica_step()
 
         use mpas_log, only : mpas_log_write
+
+        if (.not. musica_is_initialized) return
 
         call mpas_log_write('Stepping MUSICA chemistry package...')
 
@@ -116,6 +134,8 @@ module mpas_musica
     subroutine musica_finalize()
 
         use mpas_log, only : mpas_log_write
+
+        if (.not. musica_is_initialized) return
 
         call mpas_log_write('Finalizing MUSICA chemistry package...')
 


### PR DESCRIPTION
**MICM configuration is now driven by a MUSICA namelist option with added logging.**

Registry.xml: Added a MUSICA namelist record gated by MPAS_USE_MUSICA with the `config_micm_file` option so the MICM JSON path can be provided through the standard configuration system.
mpas_atm_chemistry.F: Removed the hardcoded `chapman.json`, pull the MICM file path from the configs pool, then propagate errors from `musica_init` via `mpas_log_write` to fail when initialization breaks. mpas_musica.F: Track the species description pointer and log each MICM species name from `state%species_ordering` so users can verify the runtime mapping.


