### PR TITLE
Variable-resolution gravity-wave absorbing layer formulation change

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -152,8 +152,8 @@
                      possible_values="Positive real values. A zero value implies that the length scale is prescribed by the nominalMinDc value in the input file."/>
 
                 <nml_option name="config_visc4_2dsmag" type="real" default_value="0.05"
-                     units="-"
-                     description="Scaling coefficient of $\delta x^3$ to obtain $\nabla^4$ diffusion coefficient"
+                     units="m s^{-1}"
+                     description="Coefficient multiplied by $\delta x^3$ to obtain $\nabla^4$ physical hyperviscosity"
                      possible_values="Non-negative real values"/>
 
                 <nml_option name="config_del4u_div_factor" type="real" default_value="10.0" in_defaults="false"
@@ -264,7 +264,7 @@
                      possible_values="Positive real values"/>
 
                 <nml_option name="config_xnutr" type="real" default_value="0.2"
-                     units="-"
+                     units="s^{-1}"
                      description="Maximum w-damping coefficient at model top"
                      possible_values="0 $\leq$ config_xnutr $\leq$ 1"/>
 

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -1250,8 +1250,6 @@ module atm_core
       real (kind=RKIND), pointer :: config_xnutr, config_zd
       real (kind=RKIND) :: z, zt, m1, pii
       real (kind=RKIND), dimension(:,:), pointer :: dss, zgrid
-      real (kind=RKIND), dimension(:), pointer :: meshDensity
-      real (kind=RKIND) :: dx_scale_power
 
       m1 = -1.0
       pii = acos(m1)
@@ -1259,14 +1257,12 @@ module atm_core
       call mpas_pool_get_dimension(mesh, 'nCells', nCells)
       call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
 
-      call mpas_pool_get_array(mesh, 'meshDensity', meshDensity)
       call mpas_pool_get_array(mesh, 'dss', dss)
       call mpas_pool_get_array(mesh, 'zgrid', zgrid)
 
       call mpas_pool_get_config(configs, 'config_zd', config_zd)
       call mpas_pool_get_config(configs, 'config_xnutr', config_xnutr)
 
-      dx_scale_power = 1.0
       dss(:,:) = 0.0
       do iCell=1,nCells
          zt = zgrid(nVertLevels+1,iCell)
@@ -1274,7 +1270,6 @@ module atm_core
             z = 0.5*(zgrid(k,iCell) + zgrid(k+1,iCell))
             if (z > config_zd) then
                dss(k,iCell) = config_xnutr*sin(0.5*pii*(z-config_zd)/(zt-config_zd))**2.0
-               dss(k,iCell) = dss(k,iCell) / meshDensity(iCell)**(0.25*dx_scale_power)
             end if
          end do
       end do


### PR DESCRIPTION
This PR removes the scaling of the gravity-wave absorbing layer coefficient by the local mesh size.  Previously, the absorbing layer coefficient was scaled by dx/dx_fine.  For large values of dx/dx_fine instabilities have been ancountered associated with this scaling of the absorbing layer coefficient.

Units have been added to the configuration variable config_xnutr (1/s) in the Registry - it is used in calculating the absorbing layer coefficient.  Units have also been added to config_visc4_2dsmag (m/s) in the Registry - it is used in the calculation of the hyperviscosity.