### PR TITLE
Bugfix/intel fpp fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -663,11 +663,11 @@ intel:   # BUILDTARGET Intel oneAPI Fortran, C, and C++ compiler suite
 	"CC_SERIAL = icx" \
 	"CXX_SERIAL = icpx" \
 	"FFLAGS_PROMOTION = -real-size 64" \
-	"FFLAGS_OPT = -O3 -convert big_endian -free -align array64byte" \
+	"FFLAGS_OPT = -O3 -convert big_endian -free -align array64byte -Qoption,fpp,-macro_expand=vc" \
 	"CFLAGS_OPT = -O3" \
 	"CXXFLAGS_OPT = -O3" \
 	"LDFLAGS_OPT = -O3" \
-	"FFLAGS_DEBUG = -g -convert big_endian -free -check bounds,pointers,arg_temp_created,format,shape,contiguous -fpe0 -traceback" \
+	"FFLAGS_DEBUG = -g -convert big_endian -free -check bounds,pointers,arg_temp_created,format,shape,contiguous -fpe0 -traceback -Qoption,fpp,-macro_expand=vc" \
 	"CFLAGS_DEBUG = -g -traceback" \
 	"CXXFLAGS_DEBUG = -g -traceback" \
 	"LDFLAGS_DEBUG = -g -traceback" \

--- a/cmake/Functions/MPAS_Functions.cmake
+++ b/cmake/Functions/MPAS_Functions.cmake
@@ -121,6 +121,7 @@ function(mpas_fortran_target target)
         list(APPEND MPAS_FORTRAN_TARGET_COMPILE_OPTIONS_PUBLIC
                 $<$<COMPILE_LANGUAGE:Fortran>:-align array64byte>
                 $<$<COMPILE_LANGUAGE:Fortran>:-convert big_endian>
+                $<$<COMPILE_LANGUAGE:Fortran>:-Qoption,fpp,-macro_expand=vc>
         )
         if(MPAS_DOUBLE_PRECISION)
             list(APPEND MPAS_FORTRAN_TARGET_COMPILE_OPTIONS_PRIVATE


### PR DESCRIPTION
This PR addresses a problem with the intel fortran preprocessor (fpp).

In particular, the default preprocessor ordering results in a failure to expand a macro properly when it is used as an argument to another macro.
Given the following definitions:
```
#define COMMA ,
#define STREAM_DEBUG_WRITE(M) call mpas_log_write(M)
```
followed by the following invocation:
```
STREAM_DEBUG_WRITE(' -- Setting record to: $i' COMMA intArgs=(/stream % nRecords/))
```
results in the COMMA and everything after it being eliminated from the final expansion:
```
call mpas_log_write(' -- Setting record to: $i')
```

There is a switch you can provide to fpp (via the compiler) which changes the order of nexted macro expansion and gives the desire result.

I tested this by running test_model and verifying correct printouts, using both an intel make build and an intl cmake build.