### PR TITLE
mpas_init_atmosphere mesh connectivity out-of-bounds bug

### DIFF
--- a/src/core_init_atmosphere/mpas_atm_advection.F
+++ b/src/core_init_atmosphere/mpas_atm_advection.F
@@ -51,6 +51,7 @@ module atm_advection
       real (kind=RKIND) :: thetae_tmp
       real (kind=RKIND) :: xv1, xv2, yv1, yv2, zv1, zv2
       integer :: i, j, k, ip1, ip2, n
+      integer :: iv1, iv2
       integer :: iCell, iEdge
       real (kind=RKIND) :: pii
       real (kind=RKIND), dimension(25) :: xp, yp
@@ -292,12 +293,26 @@ module atm_advection
             if (ip1 > n-1) ip1 = 1
   
             iEdge = edgesOnCell(i,iCell)
-            xv1 = xVertex(verticesOnEdge(1,iedge))/sphere_radius
-            yv1 = yVertex(verticesOnEdge(1,iedge))/sphere_radius
-            zv1 = zVertex(verticesOnEdge(1,iedge))/sphere_radius
-            xv2 = xVertex(verticesOnEdge(2,iedge))/sphere_radius
-            yv2 = yVertex(verticesOnEdge(2,iedge))/sphere_radius
-            zv2 = zVertex(verticesOnEdge(2,iedge))/sphere_radius
+
+            ! Defensive: halos may have incomplete connectivity
+            if (iEdge < 1 .or. iEdge > nEdges) then
+               do_the_cell = .false.
+               exit
+            end if
+
+            iv1 = verticesOnEdge(1,iEdge)
+            iv2 = verticesOnEdge(2,iEdge)
+            if (iv1 < 1 .or. iv1 > size(xVertex) .or. iv2 < 1 .or. iv2 > size(xVertex)) then
+               do_the_cell = .false.
+               exit
+            end if
+
+            xv1 = xVertex(iv1)/sphere_radius
+            yv1 = yVertex(iv1)/sphere_radius
+            zv1 = zVertex(iv1)/sphere_radius
+            xv2 = xVertex(iv2)/sphere_radius
+            yv2 = yVertex(iv2)/sphere_radius
+            zv2 = zVertex(iv2)/sphere_radius
   
             if ( on_a_sphere ) then
                call arc_bisect( xv1, yv1, zv1,  &
@@ -322,10 +337,14 @@ module atm_advection
   
          end do
 
+         if ( .not. do_the_cell ) cycle
+
 !  fill second derivative stencil for rk advection 
 
          do i=1, nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i,iCell)
+
+            if (iEdge < 1 .or. iEdge > nEdges) cycle
   
   
             if ( on_a_sphere ) then
@@ -769,6 +788,7 @@ module atm_advection
       real (kind=RKIND), dimension(25) :: thetav, thetat, dl_sphere
       real (kind=RKIND) :: dl
       integer :: i, ip1, ip2, n
+      integer :: iEdge
       integer :: iCell
       real (kind=RKIND) :: pii
       real (kind=RKIND), dimension(25) :: xp, yp
@@ -820,6 +840,17 @@ module atm_advection
             if (cell_list(i) > nCells) do_the_cell = .false.
          end do
 
+
+         if (.not. do_the_cell) cycle
+
+         ! Defensive: ensure edge indices used below are valid
+         do i=1,n-1
+            iEdge = edgesOnCell(i,iCell)
+            if (iEdge < 1 .or. iEdge > size(cellsOnEdge,2)) then
+               do_the_cell = .false.
+               exit
+            end if
+         end do
 
          if (.not. do_the_cell) cycle
 
@@ -927,7 +958,8 @@ module atm_advection
             defc_b(i,iCell) = dl*2.*sint_cost/area_cell
             cell_gradient_coef_x(i,iCell) = dl*cos(thetat(i))/area_cell
             cell_gradient_coef_y(i,iCell) = dl*sin(thetat(i))/area_cell
-            if (cellsOnEdge(1,EdgesOnCell(i,iCell)) /= iCell) then
+            iEdge = edgesOnCell(i,iCell)
+            if (cellsOnEdge(1,iEdge) /= iCell) then
                defc_a(i,iCell) = - defc_a(i,iCell)
                defc_b(i,iCell) = - defc_b(i,iCell)
             end if


### PR DESCRIPTION
Found an issue when running ./mpas_init_atmosphere, getting a SIGSEGV when processing the x1.40962 mesh, I'd previously been using x1.2562 mesh for development and it was fine. This is using the official meshes provided https://www2.mmm.ucar.edu/projects/mpas/site/downloads/meshes.html. 

Narrowed it down to the subroutine atm_initialize_advection_rk / deformation-weight initialization). The mesh itself is valid, but some connectivity arrays (e.g., edgesOnCell/cellsOnCell) are padded with sentinel zeros by design, and under some MPI decompositions/halo configurations a halo cell can present incomplete connectivity where the code path assumes valid edge/vertex IDs. When a 0 or out-of-range ID is used as a 1-based Fortran index (e.g., indexing cellsOnEdge(:,iEdge), verticesOnEdge(:,iEdge), or xVertex(iv)), the model can dereference out of bounds and crash.

As this is using the official mesh provided, it's probably a unique compiler/machine issue which must not be triggering on other machines, which would explain why this hasn't been picked up on before. Thought it was simply a memory issue initially, but logs I added during testing are consistent with out-of-bounds access.

The fix does the following: 
- add bounds checks immediately before dereferencing edge and vertex connectivity in src/core_init_atmosphere/mpas_atm_advection.F 
  - Eseentially a check which validates iEdge = edgesOnCell(i,iCell) is within [1,nEdges] and that verticesOnEdge(:,iEdge) yields vertex IDs within [1,nVertices] before indexing xVertex/yVertex/zVertex or cellsOnEdge. If any required connectivity is invalid for a cell, we skip computing that cell’s stencil/weights. This matches the existing intent of these initialization routines (already avoiding forming polynomial fits when stencil reaches outside of the available halo via do_the_cell gating). 

After re-compiling, segfault no longer occurs and I'm able to run ./mpas_init_atmosphere successfully with sensible results.