### PR TITLE
Fix evapprod indexing typo

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_interface.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_interface.F
@@ -573,7 +573,7 @@
           qg_p(i,k,j) = qg(k,i)
 
           rainprod_p(i,k,j) = rainprod(k,i)
-          evapprod_p(i,k,j) = evapprod(k,k)
+          evapprod_p(i,k,j) = evapprod(k,i)
           recloud_p(i,k,j)  = re_cloud(k,i)
           reice_p(i,k,j)    = re_ice(k,i)
           resnow_p(i,k,j)   = re_snow(k,i)


### PR DESCRIPTION
This PR fixes a typo in src/core_atmosphere/physics/mpas_atmphys_interface.F where evapprod(k,k) was used instead of evapprod(k,i) (introduced in [8e0057689d](https://github.com/MPAS-Dev/MPAS-Model/commit/8e0057689d)). 
This issue was reported in [Issue #1395](https://github.com/MPAS-Dev/MPAS-Model/issues/1395).

This corrects the diagnostic output and should not affect model results. 

I based the fix on the commit where the typo was introduced, so it can be applied to older MPAS versions without bringing in unrelated changes. 


