### PR TITLE
Shpbl2026 : The revised SHINHONG PBL

### DIFF
--- a/src/core_atmosphere/Externals.cfg
+++ b/src/core_atmosphere/Externals.cfg
@@ -2,6 +2,7 @@
 local_path = ./physics_mmm
 protocol = git
 repo_url = https://github.com/Sonyou184/MMM-physics.git
+branch = MMM2026-SHPBL
 required = True
 
 [GSL_UGWP]

--- a/src/core_atmosphere/Externals.cfg
+++ b/src/core_atmosphere/Externals.cfg
@@ -1,8 +1,7 @@
 [MMM-physics]
 local_path = ./physics_mmm
 protocol = git
-repo_url = https://github.com/NCAR/MMM-physics.git
-tag = 20250616-MPASv8.3
+repo_url = https://github.com/Sonyou184/MMM-physics.git
 required = True
 
 [GSL_UGWP]

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -406,6 +406,7 @@
                 <package name="cu_grell_freitas_in" description="parameterization of Grell-Freitas convection."/>
                 <package name="cu_kain_fritsch_in" description="parameterization of Kain-Fritsch convection."/>
                 <package name="cu_ntiedtke_in" description="parameterization of Tiedtke convection."/>
+                <package name="bl_shinhong_in" description="parameterization of SHINHONG Planetary Boundary Layer."/>
                 <package name="bl_ysu_in" description="parameterization of YSU Planetary Boundary Layer."/>
                 <package name="bl_mynn_in" description="parameterization of MYNN Planetary Boundary Layer."/>
                 <package name="sf_noahmp_in" description="parameterization of NOAH-MP land surface scheme."/>
@@ -471,6 +472,7 @@
 			<var name="cellsOnVertex"/>
 			<var name="kiteAreasOnVertex"/>
 			<var name="fEdge"/>
+			<var name="fCell"/>
 			<var name="fVertex"/>
 			<var name="meshDensity"/>
 			<var name="nominalMinDc"/>
@@ -1434,10 +1436,13 @@
                 <var name="kiteAreasOnVertex" type="real" dimensions="vertexDegree nVertices" units="m^2"
                      description="Intersection areas between primal (Voronoi) and dual (triangular) mesh cells"/>
 
-                <var name="fEdge" type="real" dimensions="nEdges" units="unitless"
+                <var name="fEdge" type="real" dimensions="nEdges" units="s-1"
                      description="Coriolis parameter at an edge"/>
 
-                <var name="fVertex" type="real" dimensions="nVertices" units="unitless"
+                <var name="fCell" type="real" dimensions="nCells" units="s-1"
+                     description="Coriolis parameter at an cell"/>
+
+                <var name="fVertex" type="real" dimensions="nVertices" units="s-1"
                      description="Coriolis parameter at a vertex"/>
 
                 <var name="meshDensity" type="real" dimensions="nCells" units="unitless"
@@ -1636,7 +1641,7 @@
 
                         <var name="qc" array_group="moist" units="kg kg^{-1}"
                              description="Cloud water mixing ratio"
-                             packages="bl_mynn_in;bl_ysu_in;cu_ntiedtke_in;mp_kessler_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
+                             packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in;cu_ntiedtke_in;mp_kessler_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
 
                         <var name="qr" array_group="moist" units="kg kg^{-1}"
                              description="Rain water mixing ratio"
@@ -1644,7 +1649,7 @@
 
                         <var name="qi" array_group="moist" units="kg kg^{-1}"
                              description="Ice mixing ratio"
-                             packages="bl_mynn_in;bl_ysu_in;cu_ntiedtke_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
+                             packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in;cu_ntiedtke_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
 
                         <var name="qs" array_group="moist" units="kg kg^{-1}"
                              description="Snow mixing ratio"
@@ -1987,7 +1992,7 @@
 
                         <var name="tend_qc" name_in_code="qc" array_group="moist" units="kg m^{-3} s^{-1}"
                              description="Tendency of cloud water mass per unit volume divided by d(zeta)/dz"
-                             packages="bl_mynn_in;bl_ysu_in;cu_ntiedtke_in;mp_kessler_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
+                             packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in;cu_ntiedtke_in;mp_kessler_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
 
                         <var name="tend_qr" name_in_code="qr" array_group="moist" units="kg m^{-3} s^{-1}"
                              description="Tendency of rain water mass per unit volume divided by d(zeta)/dz"
@@ -1995,7 +2000,7 @@
 
                         <var name="tend_qi" name_in_code="qi" array_group="moist" units="kg m^{-3} s^{-1}"
                              description="Tendency of ice mass per unit volume divided by d(zeta)/dz"
-                             packages="bl_mynn_in;bl_ysu_in;cu_ntiedtke_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
+                             packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in;cu_ntiedtke_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
 
                         <var name="tend_qs" name_in_code="qs" array_group="moist" units="kg m^{-3} s^{-1}"
                              description="Tendency of snow mass per unit volume divided by d(zeta)/dz"
@@ -2205,6 +2210,21 @@
                      description="logical for turning on/off top-down, radiation_driven mixing"
                      possible_values=".true. to turn on top-down radiation_driven mixing; .false. otherwise"/>
 
+                <nml_option name="config_shinhong_scu_mixing" type="logical" default_value="false" in_defaults="false"
+                     units="-"
+                     description="logical for turning on/off top-down, radiation_driven mixing"
+                     possible_values=".true. to turn on top-down radiation_driven mixing; .false. otherwise"/>
+
+                <nml_option name="config_shinhong_nonlocal_flux" type="logical" default_value="false" in_defaults="false"
+                     units="-"
+                     description="logical for shinhong nonlocal flux"
+                     possible_values=".true. to turn on shinhong nonlocal flux; .false. ysu nonlocal"/>
+
+                <nml_option name="config_shinhong_ke_dissipation" type="logical" default_value="false" in_defaults="false"
+                     units="-"
+                     description="logical for kinetic energy dissipative heating"
+                     possible_values=".true. to turn on dissipative heating; .false. otherwise"/>
+
                 <nml_option name="config_urban_physics" type="logical" default_value="false" in_defaults="false"
                      units="-"
                      description="logical for turn on/off the urban physics parameterization"
@@ -2273,12 +2293,12 @@
                 <nml_option name="config_pbl_scheme" type="character" default_value="suite" in_defaults="false"
                      units="-"
                      description="configuration for planetary boundary layer schemes"
-                     possible_values="`suite',`bl_ysu',`bl_mynn',`off'"/>
+                     possible_values="`suite',`bl_ysu',`bl_shinhong',`bl_mynn',`off'"/>
 
                 <nml_option name="config_gwdo_scheme" type="character" default_value="suite" in_defaults="false"
                      units="-"
                      description="configuration of gravity wave drag over orography"
-                     possible_values="`suite',`bl_ysu_gwdo',`bl_ugwp_gwdo',`off'"/>
+                     possible_values="`suite',`bl_kim_gwdo',`bl_ugwp_gwdo',`off'"/>
 
                 <nml_option name="config_ngw_scheme" type="logical" default_value="false" in_defaults="false"
                      units="-"
@@ -2651,37 +2671,45 @@
 
                 <var name="kpbl" type="integer" dimensions="nCells Time" units="unitless"
                      description="index level of PBL top"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
                 <var name="hpbl" type="real" dimensions="nCells Time" units="m"
                      description="Planetary Boundary Layer (PBL) height"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
 		<var name="kzh" type="real" dimensions="nVertLevels nCells Time" units="m^{2} s^{-1}"
                      description="vertical diffusion coefficient of potential temperature"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
 		<var name="kzm" type="real" dimensions="nVertLevels nCells Time" units="m^{2} s^{-1}"
                      description="vertical diffusion coefficient of mommentum"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
 		<var name="kzq" type="real" dimensions="nVertLevels nCells Time" units="m^{2} s^{-1}"
                      description="vertical diffusion coefficient of water vapor and cloud condensates"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
+
+                <var name="tke_pbl" type="real" dimensions="nVertLevels nCells Time" units="m^{2} s^{-2}"
+                     description="turbulent kinetic energy from PBL"
+                     packages="bl_mynn_in;bl_shinhong_in"/>
+
+                <var name="el_pbl" type="real" dimensions="nVertLevels nCells Time" units="m"
+                     description="mixing length from PBL scheme"
+                     packages="bl_mynn_in;bl_shinhong_in"/>
 
 
-                <!-- YSU PBL SCHEME: -->
+                <!-- SHINHONG/YSU PBL SCHEME: -->
                 <var name="delta" type="real" dimensions="nCells Time" units="m"
                      description="entrainment layer depth from PBL scheme"
-                     packages="bl_ysu_in"/>
+                     packages="bl_ysu_in;bl_shinhong_in"/>
 
                 <var name="wstar" type="real" dimensions="nCells Time" units="m s^{-1}"
                      description="mixed velocity scale from PBL scheme"
-                     packages="bl_ysu_in"/>
+                     packages="bl_ysu_in;bl_shinhong_in"/>
 
                 <var name="exch_h" type="real" dimensions="nVertLevels nCells Time" units="m^{2} s^{-1}"
                      description="exchange coefficient"
-                     packages="bl_ysu_in"/>
+                     packages="bl_ysu_in;bl_shinhong_in"/>
 
 
                 <!-- MYNN PBL SCHEME: -->
@@ -2701,10 +2729,6 @@
                      description="liquid water - liquid water potential temperature covariance"
                      packages="bl_mynn_in"/>
 
-                <var name="el_pbl" type="real" dimensions="nVertLevels nCells Time" units="m"
-                     description="mixing length from PBL scheme"
-                     packages="bl_mynn_in"/>
-
                 <var name="qke" type="real" dimensions="nVertLevels nCells Time" units="m^{2} s^{-2}"
                      description="twice turbulent kinetic energy"
                      packages="bl_mynn_in"/>
@@ -2719,10 +2743,6 @@
 
                 <var name="tsq" type="real" dimensions="nVertLevels nCells Time" units="K^{2}"
                      description="liquid water potential temperature variance"
-                     packages="bl_mynn_in"/>
-
-                <var name="tke_pbl" type="real" dimensions="nVertLevels nCells Time" units="m^{2} s^{-2}"
-                     description="turbulent kinetic energy from PBL"
                      packages="bl_mynn_in"/>
 
                 <var name="dqke" type="real" dimensions="nVertLevels nCells Time" units="m^{2} s^{-2}"
@@ -2792,121 +2812,121 @@
 
                 <var name="hfx" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="upward heat flux at the surface"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
                 <var name="mavail" type="real" dimensions="nCells Time" units="unitless"
                      description="surface moisture availability (between 0 and 1)"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
                 <var name="mol" type="real" dimensions="nCells Time" units="K"
                      description="T* in similarity theory"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
                 <var name="qfx" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}"
                      description="upward moisture flux at the surface"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
                 <var name="qsfc" type="real"  dimensions="nCells Time" units="kg kg^{-1}"
                      description="specific humidity at lower boundary"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
                 <var name="ust" type="real" dimensions="nCells Time" units="m s^{-1}"
                      description="U* in similarity theory"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
                 <var name="ustm" type="real" dimensions="nCells Time" units="m s^{-1}"
                      description="U* in similarity theory without vconv"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
                 <var name="zol" type="real" dimensions="nCells Time" units="unitless"
                      description="z/L height over Monin-Obukhov length"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
                 <var name="br" type="real" dimensions="nCells Time" units="unitless"
                      description="Richardson number"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
                 <var name="cd" type="real" dimensions="nCells Time" units="unitless"
                      description="drag coefficient at 10-meter"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
                 <var name="cda" type="real" dimensions="nCells Time" units="unitless"
                      description="drag coefficient at lowest model level"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
                 <var name="chs" type="real" dimensions="nCells Time" units="m s^{-1}"
                      description="surface exchange coefficient for heat and moisture"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
                 <var name="chs2" type="real" dimensions="nCells Time" units="m s^{-1}"
                      description="surface exchange coefficient for heat at 2-meter"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
                 <var name="cqs2" type="real" dimensions="nCells Time" units="m s^{-1}"
                      description="surface exchange coefficient for moisture at 2-meter"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
                 <var name="ck" type="real" dimensions="nCells Time" units="unitless"
                      description="enthalpy exchange coeff at 10-meter"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
                 <var name="cka" type="real" dimensions="nCells Time" units="unitless"
                      description="enthalpy exchange coefficient at lowest model level"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
                 <var name="cpm" type="real" dimensions="nCells Time" units="J K^{-1} kg^{-1}"
                      description="specific heat of dry air at constant pressure at lowest model level"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
                 <var name="flhc" type="real" dimensions="nCells Time" units="W m^{-2} K^{-1}"
                      description="exchange coefficient for heat"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
                 <var name="flqc" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}"
                      description="exchange coefficient for moisture"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
                 <var name="gz1oz0" type="real" dimensions="nCells Time" units="unitless"
                      description="log(z/z0) where z0 is roughness length"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
                 <var name="lh" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="latent heat flux at the surface"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
                 <var name="psim" type="real" dimensions="nCells Time" units="unitless"
                      description="similarity stability function for momentum"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
                 <var name="psih" type="real" dimensions="nCells Time" units="unitless"
                      description="similarity stability function for heat"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
                 <var name="qgh" type="real" dimensions="nCells Time" units="kg kg^{-1}"
                      description="lowest level saturation mixing ratio"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
                 <var name="regime" type="real" dimensions="nCells Time" units="unitless"
                      description="flag indicating the PBL regime (stable,unstable,...)"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
                 <var name="rmol" type="real" dimensions="nCells Time" units="unitless"
                      description="1./L Monin Obukhov length"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
                 <var name="wspd" type="real" dimensions="nCells Time" units="m s^{-1}"
                      description="wind speed at lowest model level"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
 
                 <!-- ... MONIN-OBUKHOV (SFCLAY): -->
                 <var name="fh" type="real" dimensions="nCells Time" units="unitless"
                      description="integrated stability function for heat"
-                     packages="bl_ysu_in"/>
+                     packages="bl_ysu_in;bl_shinhong_in"/>
 
                 <var name="fm" type="real" dimensions="nCells Time" units="unitless"
                      description="integrated stability function for moisture"
-                     packages="bl_ysu_in"/>
+                     packages="bl_ysu_in;bl_shinhong_in"/>
 
 
                 <!-- ... MYNN: -->
@@ -2928,19 +2948,19 @@
 
 
                 <!-- DIAGNOSTICS: -->
-                <var name="u10" type="real" dimensions="nCells Time" packages="bl_mynn_in;bl_ysu_in" units="m s^{-1}"
+                <var name="u10" type="real" dimensions="nCells Time" packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in" units="m s^{-1}"
                      description="10-meter zonal wind"/>
 
-                <var name="v10" type="real" dimensions="nCells Time" packages="bl_mynn_in;bl_ysu_in" units="m s^{-1}"
+                <var name="v10" type="real" dimensions="nCells Time" packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in" units="m s^{-1}"
                      description="10-meter meridional wind"/>
 
-                <var name="q2" type="real" dimensions="nCells Time" packages="bl_mynn_in;bl_ysu_in" units="kg kg^{-1}"
+                <var name="q2" type="real" dimensions="nCells Time" packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in" units="kg kg^{-1}"
                      description="2-meter specific humidity"/>
 
-                <var name="t2m" type="real" dimensions="nCells Time" packages="bl_mynn_in;bl_ysu_in" units="K"
+                <var name="t2m" type="real" dimensions="nCells Time" packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in" units="K"
                      description="2-meter temperature"/>
 
-                <var name="th2m" type="real" dimensions="nCells Time" packages="bl_mynn_in;bl_ysu_in" units="K"
+                <var name="th2m" type="real" dimensions="nCells Time" packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in" units="K"
                      description="2-meter potential temperature"/>
 
 
@@ -3549,27 +3569,27 @@
 
                 <var name="rublten" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1} s^{-1}"
                      description="tendency of zonal wind due to pbl processes"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
                 <var name="rvblten" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1} s^{-1}"
                      description="tendency of meridional wind due to pbl processes"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
                 <var name="rthblten" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
                      description="tendency of potential temperature due to pbl processes"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
                 <var name="rqvblten" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
                      description="tendency of water vapor mixing ratio due to pbl processes"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
                 <var name="rqcblten" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
                      description="tendency of cloud water mixing ratio due to pbl processes"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
                 <var name="rqiblten" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
                      description="tendency of cloud ice mixing ratio due to pbl processes"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in"/>
 
                 <var name="rqsblten" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
                      description="tendency of snow mixing ratio due to pbl processes"
@@ -3885,7 +3905,7 @@
                           units="kg kg^{-1}"
                           description="Water vapor mixing ratio increment"/>
 
-                     <var name="qc_amb"  name_in_code="qc" array_group="moist" packages="bl_mynn_in;bl_ysu_in;cu_ntiedtke_in;mp_kessler_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"
+                     <var name="qc_amb"  name_in_code="qc" array_group="moist" packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in;cu_ntiedtke_in;mp_kessler_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"
                           units="kg kg^{-1}"
                           description="Cloud water mixing ratio increment"/>
 
@@ -3893,7 +3913,7 @@
                           units="kg kg^{-1}"
                           description="Rain water mixing ratio increment"/>
 
-                     <var name="qi_amb"  name_in_code="qi" array_group="moist" packages="bl_mynn_in;bl_ysu_in;cu_ntiedtke_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"
+                     <var name="qi_amb"  name_in_code="qi" array_group="moist" packages="bl_mynn_in;bl_ysu_in;bl_shinhong_in;cu_ntiedtke_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"
                           units="kg kg^{-1}"
                           description="Ice mixing ratio increment"/>
 

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -372,6 +372,7 @@ module atm_core
       use mpas_vector_reconstruction
       use mpas_stream_manager
       use mpas_atm_boundaries, only : mpas_atm_setup_bdy_masks
+      use mpas_constants, only : omega
 #ifdef DO_PHYSICS
 !     use mpas_atmphys_aquaplanet
       use mpas_atmphys_control
@@ -405,6 +406,7 @@ module atm_core
       real (kind=RKIND), dimension(:), pointer :: dvEdge, invDvEdge
       real (kind=RKIND), dimension(:), pointer :: dcEdge, invDcEdge
       real (kind=RKIND), dimension(:), pointer :: areaTriangle, invAreaTriangle
+      real (kind=RKIND), dimension(:), pointer :: fcell, latcell
       integer, pointer :: nCells_ptr, nEdges_ptr, nVertices_ptr, nVertLevels_ptr, nEdgesSolve
       integer :: nCells, nEdges, nVertices, nVertLevels
       integer :: thread
@@ -444,6 +446,8 @@ module atm_core
       
       call mpas_pool_get_array(mesh, 'areaTriangle', areaTriangle)
       call mpas_pool_get_array(mesh, 'invAreaTriangle', invAreaTriangle)
+      call mpas_pool_get_array(mesh, 'fCell', fcell)
+      call mpas_pool_get_array(mesh, 'latCell', latcell)
       
       call mpas_pool_get_dimension(mesh, 'nCells', nCells_ptr)      
       call mpas_pool_get_dimension(mesh, 'nEdges', nEdges_ptr)
@@ -469,6 +473,10 @@ module atm_core
          invAreaTriangle(iVertex) = 1.0_RKIND / areaTriangle(iVertex)
       end do
       
+      do iCell=1,nCells 
+         fcell(iCell) =  2. * omega * sin(latcell(iCell))
+      end do
+
       !!!!! End compute inverses
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/core_atmosphere/physics/mpas_atmphys_control.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_control.F
@@ -83,6 +83,8 @@
 ! * in the mesoscale_reference suite, replaced the MM5 surface layer scheme with the MM5 revised surface layer
 !   scheme as the default option for config_sfclayer_scheme.
 !   Laura D. Fowler (laura@ucar.edu) / 2024-06-18.
+! * added the option bl_shinhong   
+!   Songyou Hong (hong@ucar.edu) / 2025-11-27.
 
 
  contains
@@ -133,8 +135,8 @@
     if (trim(config_microp_scheme)     == 'suite') config_microp_scheme     = 'mp_wsm6'
     if (trim(config_convection_scheme) == 'suite') config_convection_scheme = 'cu_ntiedtke'
     if (trim(config_pbl_scheme)        == 'suite') config_pbl_scheme        = 'bl_ysu'
-    if (trim(config_gwdo_scheme)       == 'suite') config_gwdo_scheme       = 'bl_ysu_gwdo'
     if (trim(config_radt_lw_scheme)    == 'suite') config_radt_lw_scheme    = 'rrtmg_lw'
+    if (trim(config_gwdo_scheme)       == 'suite') config_gwdo_scheme       = 'bl_ysu_gwdo'
     if (trim(config_radt_sw_scheme)    == 'suite') config_radt_sw_scheme    = 'rrtmg_sw'
     if (trim(config_radt_cld_scheme)   == 'suite') config_radt_cld_scheme   = 'cld_fraction'
     if (trim(config_sfclayer_scheme)   == 'suite') config_sfclayer_scheme   = 'sf_monin_obukhov_rev'
@@ -201,6 +203,7 @@
 !pbl scheme:
  if(.not. (config_pbl_scheme .eq. 'off'     .or. &
            config_pbl_scheme .eq. 'bl_mynn' .or. &
+           config_pbl_scheme .eq. 'bl_shinhong' .or. &
            config_pbl_scheme .eq. 'bl_ysu')) then
 
     write(mpas_err_message,'(A,A20)') 'illegal value for pbl_scheme: ', &
@@ -279,10 +282,10 @@
  else
     if(config_pbl_scheme == 'bl_mynn') then
        config_sfclayer_scheme = 'sf_mynn'
-    elseif(config_pbl_scheme == 'bl_ysu') then
+    elseif(config_pbl_scheme == 'bl_shinhong' .or. config_pbl_scheme == 'bl_ysu') then
        if(config_sfclayer_scheme /= 'sf_monin_obukhov' .and. &
           config_sfclayer_scheme /= 'sf_monin_obukhov_rev') then
-          write(mpas_err_message,'(A,A20)') 'wrong choice for surface layer scheme with YSU PBL: ', &
+          write(mpas_err_message,'(A,A20)') 'wrong choice for surface layer scheme with SHINHONG/YSU PBL: ', &
                 trim(config_sfclayer_scheme)
           call physics_error_fatal(mpas_err_message)
        endif

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
@@ -16,6 +16,7 @@
 
  use bl_mynn,only: bl_mynn_init
  use module_bl_mynn,only: mynn_bl_driver
+ use module_bl_shinhong
  use module_bl_ysu
 
  implicit none
@@ -39,6 +40,7 @@
 !
 ! WRF physics called from driver_pbl:
 ! -----------------------------------
+! * module_bl_shinhong : SHINHONG PBL scheme.
 ! * module_bl_ysu : YSU PBL scheme.
 !
 ! add-ons and modifications to sourcecode:
@@ -78,6 +80,8 @@
 !   Laura D. Fowler (laura@ucar.edu) / 2024-02-14.
 ! * updated the MYNN PBL scheme to the sourcecode from WRF version 4.6.
 !   Laura D. Fowler (laura@ucar.edu) / 2024-02.15.
+! * added the option SHINHONG PBL scheme, incorporating revisions and additions from WRF version 4.7
+!   Songyou Hong (hong@ucar.edu) / 2025-11.27.
 
 
  contains
@@ -102,6 +106,7 @@
  if(.not.allocated(ust_p)  ) allocate(ust_p(ims:ime,jms:jme)  )
  if(.not.allocated(wspd_p) ) allocate(wspd_p(ims:ime,jms:jme) )
  if(.not.allocated(xland_p)) allocate(xland_p(ims:ime,jms:jme))
+ if(.not.allocated(fcell_p)) allocate(fcell_p(ims:ime,jms:jme))
  if(.not.allocated(hpbl_p) ) allocate(hpbl_p(ims:ime,jms:jme) )
  if(.not.allocated(kpbl_p) ) allocate(kpbl_p(ims:ime,jms:jme) )
  if(.not.allocated(znt_p)  ) allocate(znt_p(ims:ime,jms:jme)  )
@@ -125,6 +130,21 @@
 
  pbl_select: select case (trim(pbl_scheme))
 
+    case("bl_shinhong")
+       !from surface-layer model:
+       if(.not.allocated(br_p)    ) allocate(br_p(ims:ime,jms:jme)          )
+       if(.not.allocated(dx_p)        ) allocate(dx_p(ims:ime,jms:jme)                )
+       if(.not.allocated(ctopo_p) ) allocate(ctopo_p(ims:ime,jms:jme)       )
+       if(.not.allocated(ctopo2_p)) allocate(ctopo2_p(ims:ime,jms:jme)      )
+       if(.not.allocated(delta_p) ) allocate(delta_p(ims:ime,jms:jme)       )
+       if(.not.allocated(psih_p)  ) allocate(psih_p(ims:ime,jms:jme)        )
+       if(.not.allocated(psim_p)  ) allocate(psim_p(ims:ime,jms:jme)        )
+       if(.not.allocated(u10_p)   ) allocate(u10_p(ims:ime,jms:jme)         )
+       if(.not.allocated(v10_p)   ) allocate(v10_p(ims:ime,jms:jme)         )
+       if(.not.allocated(exch_p)  ) allocate(exch_p(ims:ime,kms:kme,jms:jme))
+       if(.not.allocated(wstar_p) ) allocate(wstar_p(ims:ime,jms:jme)       )
+       if(.not.allocated(elpbl_p)     ) allocate(elpbl_p(ims:ime,kms:kme,jms:jme)     )
+       if(.not.allocated(tkepbl_p)    ) allocate(tkepbl_p(ims:ime,kms:kme,jms:jme)    )
     case("bl_ysu")
        !from surface-layer model:
        if(.not.allocated(br_p)    ) allocate(br_p(ims:ime,jms:jme)          )
@@ -211,6 +231,7 @@
  if(allocated(ust_p)  ) deallocate(ust_p  )
  if(allocated(wspd_p) ) deallocate(wspd_p )
  if(allocated(xland_p)) deallocate(xland_p)
+ if(allocated(fcell_p)) deallocate(fcell_p)
  if(allocated(hpbl_p) ) deallocate(hpbl_p )
  if(allocated(kpbl_p) ) deallocate(kpbl_p )
  if(allocated(znt_p)  ) deallocate(znt_p  )
@@ -234,6 +255,21 @@
 
  pbl_select: select case (trim(pbl_scheme))
 
+    case("bl_shinhong")
+       !from surface-layer model:
+       if(allocated(br_p)    ) deallocate(br_p    )
+       if(allocated(dx_p)    ) deallocate(dx_p    )
+       if(allocated(ctopo_p) ) deallocate(ctopo_p )
+       if(allocated(ctopo2_p)) deallocate(ctopo2_p)
+       if(allocated(delta_p) ) deallocate(delta_p )
+       if(allocated(psih_p)  ) deallocate(psih_p  )
+       if(allocated(psim_p)  ) deallocate(psim_p  )
+       if(allocated(u10_p)   ) deallocate(u10_p   )
+       if(allocated(v10_p)   ) deallocate(v10_p   )
+       if(allocated(exch_p)  ) deallocate(exch_p  )
+       if(allocated(wstar_p) ) deallocate(wstar_p )
+       if(allocated(elpbl_p)     ) deallocate(elpbl_p     )
+       if(allocated(tkepbl_p)    ) deallocate(tkepbl_p    )
     case("bl_ysu")
        !from surface-layer model:
        if(allocated(br_p)    ) deallocate(br_p    )
@@ -321,13 +357,17 @@
 !local pointers:
  character(len=StrKIND),pointer:: pbl_scheme
 
- real(kind=RKIND),dimension(:),pointer:: hfx,hpbl,qfx,ust,wspd,xland,znt
+ real(kind=RKIND),dimension(:),pointer:: hfx,hpbl,qfx,ust,wspd,xland,znt,fcell
  real(kind=RKIND),dimension(:),pointer:: delta,wstar
 
 !local pointers for YSU scheme:
  logical,pointer:: config_ysu_pblmix
  real(kind=RKIND),dimension(:),pointer:: br,fh,fm,u10,v10
  real(kind=RKIND),dimension(:,:),pointer:: rthratenlw,rthratensw
+!local pointers for SHINHONG scheme:
+ logical,pointer:: config_shinhong_nonlocal_flux
+ logical,pointer:: config_shinhong_scu_mixing
+ logical,pointer:: config_shinhong_ke_dissipation
 
 !local pointers for MYNN scheme:
  real(kind=RKIND),pointer:: len_disp
@@ -353,6 +393,7 @@
  call mpas_pool_get_array(tend_physics,'rthratensw',rthratensw)
 
  call mpas_pool_get_array(sfc_input,'xland',xland)
+ call mpas_pool_get_array(mesh,'fCell',fcell)
 
  do j = jts,jte
  do i = its,ite
@@ -363,6 +404,7 @@
     ust_p(i,j)   = ust(i)
     wspd_p(i,j)  = wspd(i)
     xland_p(i,j) = xland(i)
+    fcell_p(i,j) = fcell(i)
     kpbl_p(i,j)  = 1
     znt_p(i,j)   = znt(i)
     !... ocean currents are set to zero:
@@ -377,6 +419,56 @@
  enddo
 
  pbl_select: select case (trim(pbl_scheme))
+
+    case("bl_shinhong")
+       call mpas_pool_get_config(configs,'config_shinhong_nonlocal_flux',config_shinhong_nonlocal_flux)
+       call mpas_pool_get_config(configs,'config_shinhong_scu_mixing',config_shinhong_scu_mixing)
+       call mpas_pool_get_config(configs,'config_shinhong_ke_dissipation',config_shinhong_ke_dissipation)
+       call mpas_pool_get_config(configs,'config_len_disp',len_disp)
+
+       call mpas_pool_get_array(mesh,'meshDensity',meshDensity)
+       call mpas_pool_get_array(diag_physics,'br'   ,br   )
+       call mpas_pool_get_array(diag_physics,'delta',delta)
+       call mpas_pool_get_array(diag_physics,'fm'   ,fm   )
+       call mpas_pool_get_array(diag_physics,'fh'   ,fh   )
+       call mpas_pool_get_array(diag_physics,'u10'  ,u10  )
+       call mpas_pool_get_array(diag_physics,'v10'  ,v10  )
+       call mpas_pool_get_array(diag_physics,'wstar',wstar)
+
+       call mpas_pool_get_array(diag_physics,'el_pbl'    ,el_pbl    )
+       call mpas_pool_get_array(diag_physics,'tke_pbl'    ,tke_pbl    )
+
+       do j = jts,jte
+       do i = its,ite
+          dx_p(i,j)   = len_disp / meshDensity(i)**0.25
+       enddo
+       enddo
+
+       do j = jts,jte
+       do i = its,ite
+          !from surface-layer model:
+          br_p(i,j)     = br(i)
+          psim_p(i,j)   = fm(i)
+          psih_p(i,j)   = fh(i)
+          u10_p(i,j)    = u10(i)
+          v10_p(i,j)    = v10(i)
+          delta_p(i,j)  = delta(i)
+          wstar_p(i,j)  = wstar(i)
+          !initialization for YSU/SHINHONG PBL scheme:
+          ctopo_p(i,j)  = 1._RKIND
+          ctopo2_p(i,j) = 1._RKIND
+       enddo
+       enddo
+
+       do j = jts,jte
+       do k = kts,kte
+       do i = its,ite
+          exch_p(i,k,j) = 0._RKIND
+          tkepbl_p(i,k,j)    = tke_pbl(k,i)
+          elpbl_p(i,k,j)    = el_pbl(k,i)
+       enddo
+       enddo
+       enddo
 
     case("bl_ysu")
        call mpas_pool_get_config(configs,'config_ysu_pblmix',config_ysu_pblmix)
@@ -608,6 +700,27 @@
 
  pbl_select: select case (trim(pbl_scheme))
 
+    case("bl_shinhong")
+       call mpas_pool_get_array(diag_physics,'delta',delta  )
+       call mpas_pool_get_array(diag_physics,'wstar' ,wstar )
+       call mpas_pool_get_array(diag_physics,'exch_h',exch_h)
+       call mpas_pool_get_array(diag_physics,'tke_pbl',tke_pbl)
+       call mpas_pool_get_array(diag_physics,'el_pbl',el_pbl)
+
+       do j = jts,jte
+       do i = its,ite
+          delta(i) = delta_p(i,j)
+          wstar(i) = wstar_p(i,j)
+       enddo
+       do k = kts,kte
+       do i = its,ite
+          exch_h(k,i) = exch_p(i,k,j)
+          tke_pbl(k,i) = tkepbl_p(i,k,j)
+          el_pbl(k,i) = elpbl_p(i,k,j)
+       enddo
+       enddo
+       enddo
+
     case("bl_ysu")
        call mpas_pool_get_array(diag_physics,'delta',delta  )
        call mpas_pool_get_array(diag_physics,'wstar' ,wstar )
@@ -774,6 +887,10 @@
                    config_do_restart,   &
                    bl_mynn_tkeadvect
 
+ logical,pointer:: config_shinhong_nonlocal_flux,  &
+                   config_shinhong_scu_mixing,     &
+                   config_shinhong_ke_dissipation
+
  character(len=StrKIND),pointer:: pbl_scheme
 
  integer,pointer:: bl_mynn_cloudpdf,    &
@@ -821,6 +938,43 @@
  if(config_do_restart .or. itimestep > 1) initflag = 0
 
  pbl_select: select case (trim(pbl_scheme))
+
+    case("bl_shinhong")
+       call mpas_timer_start('bl_shinhong')
+       call mpas_pool_get_config(configs,'config_shinhong_nonlocal_flux',config_shinhong_nonlocal_flux)
+       call mpas_pool_get_config(configs,'config_shinhong_scu_mixing',config_shinhong_scu_mixing)
+       call mpas_pool_get_config(configs,'config_shinhong_ke_dissipation',config_shinhong_ke_dissipation)
+
+       call shinhong ( &
+                 p3d      = pres_hyd_p , p3di     = pres2_hyd_p , psfc     = psfc_p     , &
+                 t3d      = t_p        , dz8w     = dz_p        , pi3d     = pi_p       , &
+                 u3d      = u_p        , v3d      = v_p         , qv3d     = qv_p       , &
+                 qc3d     = qc_p       , qi3d     = qi_p        , rublten  = rublten_p  , &
+                 rvblten  = rvblten_p  , rthblten = rthblten_p  , rqvblten = rqvblten_p , &
+                 rqcblten = rqcblten_p , rqiblten = rqiblten_p  , flag_qc  = f_qc       , &
+                 flag_qi  = f_qi       , cp       = cp          , g        = gravity    , &
+                 rovcp    = rcp        , rd       = R_d         , rovg     = rdg        , & 
+                 ep1      = ep_1       , ep2      = ep_2        , karman   = karman     , &
+                 xlv      = xlv        , rv       = R_v         , znt      = znt_p      , &
+                 ust      = ust_p      , hpbl     = hpbl_p      , psim     = psim_p     , &
+                 psih     = psih_p     , xland    = xland_p     , hfx      = hfx_p      , &
+                 qfx      = qfx_p      , wspd     = wspd_p      , br       = br_p       , &
+                 dt       = dt_pbl     , kpbl2d   = kpbl_p      , exch_h   = kzh_p      , &
+                 exch_m   = kzm_p      , wstar    = wstar_p     , delta    = delta_p    , &
+                 shinhong_nonlocal_flux      = config_shinhong_nonlocal_flux            , &
+                 shinhong_dissi_heating = config_shinhong_ke_dissipation                , &
+                 shinhong_scu_mixing    = config_shinhong_scu_mixing                    , &
+                 tke = tkepbl_p        , el=  elpbl_p           , corf=fcell_p          , &
+                 uoce     = uoce_p     , voce     = voce_p      , rthraten = rthraten_p , &
+                 u10      = u10_p      , v10      = v10_p       , ctopo    = ctopo_p    , &
+                 ctopo2   = ctopo2_p   , flag_bep = flag_bep    , idiff    = idiff      , &
+                 dx   = dx_p   ,  &
+                 errmsg   = errmsg     , errflg   = errflg      ,                         &
+                 ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde  , &
+                 ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme  , &
+                 its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte    &
+                )
+       call mpas_timer_stop('bl_shinhong')
 
     case("bl_ysu")
        call mpas_timer_start('bl_ysu')

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
@@ -15,6 +15,7 @@
  use mpas_atmphys_vars
 
  use bl_mynn,only: bl_mynn_init
+ use bl_shinhong,only: bl_shinhong_init
  use module_bl_mynn,only: mynn_bl_driver
  use module_bl_shinhong
  use module_bl_ysu
@@ -837,11 +838,13 @@
  end subroutine pbl_to_MPAS
  
 !=================================================================================================================
- subroutine init_pbl(configs)
+ subroutine init_pbl(configs,diag_physics)
 !=================================================================================================================
 
 !input arguments:
  type(mpas_pool_type),intent(in):: configs
+ type(mpas_pool_type),intent(in):: diag_physics
+ real(kind=RKIND),dimension(:,:),pointer:: tke_pbl
 
 !local variables and pointers:
  character(len=StrKIND),pointer:: pbl_scheme
@@ -859,6 +862,9 @@
        call bl_mynn_init(cp,cpv,cice,cliq,ep_1,ep_2,gravity,karman,P0,R_d,R_v,svp1,svp2,svp3,svpt0, &
                          xlf,xls,xlv,errmsg,errflg)
 !      call mpas_log_write('--- end subroutine bl_mynn_init:')
+    case("bl_shinhong")
+       call mpas_pool_get_array(diag_physics,'tke_pbl'   ,tke_pbl   )
+       call bl_shinhong_init(errmsg,errflg,tke_pbl,kms,kme,ims,ime)
 
     case default
 
@@ -944,6 +950,7 @@
        call mpas_pool_get_config(configs,'config_shinhong_nonlocal_flux',config_shinhong_nonlocal_flux)
        call mpas_pool_get_config(configs,'config_shinhong_scu_mixing',config_shinhong_scu_mixing)
        call mpas_pool_get_config(configs,'config_shinhong_ke_dissipation',config_shinhong_ke_dissipation)
+
 
        call shinhong ( &
                  p3d      = pres_hyd_p , p3di     = pres2_hyd_p , psfc     = psfc_p     , &

--- a/src/core_atmosphere/physics/mpas_atmphys_init.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_init.F
@@ -391,7 +391,7 @@ use mpas_stream_manager
     call init_microphysics(dminfo,configs,mesh,state,time_lev,sfc_input,diag_physics)
 
 !initialization of PBL processes:
- if(config_pbl_scheme .ne. 'off') call init_pbl(configs)
+ if(config_pbl_scheme .ne. 'off') call init_pbl(configs,diag_physics)
 
 !initialization of surface layer processes:
  if(config_sfclayer_scheme .ne. 'off') call init_sfclayer(configs)

--- a/src/core_atmosphere/physics/mpas_atmphys_packages.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_packages.F
@@ -39,7 +39,7 @@
  character(len=StrKIND),pointer:: config_lsm_scheme
  logical,pointer:: mp_kessler_in,mp_thompson_in,mp_thompson_aers_in,mp_wsm6_in
  logical,pointer:: cu_grell_freitas_in,cu_kain_fritsch_in,cu_ntiedtke_in
- logical,pointer:: bl_mynn_in,bl_ysu_in
+ logical,pointer:: bl_mynn_in,bl_ysu_in,bl_shinhong_in
  logical,pointer:: sf_noahmp_in
 
  integer :: ierr
@@ -150,8 +150,11 @@
  nullify(bl_ysu_in)
  call mpas_pool_get_package(packages,'bl_ysu_inActive',bl_ysu_in)
 
+ nullify(bl_shinhong_in)
+ call mpas_pool_get_package(packages,'bl_shinhong_inActive',bl_shinhong_in)
+
  if(.not.associated(bl_mynn_in) .or. &
-    .not.associated(bl_ysu_in)) then
+    .not.associated(bl_ysu_in) .or.  .not.associated(bl_shinhong_in) ) then
     call mpas_log_write('====================================================================================',messageType=MPAS_LOG_ERR)
     call mpas_log_write('* Error while setting up packages for planetary layer  options in atmosphere core.',  messageType=MPAS_LOG_ERR)
     call mpas_log_write('====================================================================================',messageType=MPAS_LOG_ERR)
@@ -161,15 +164,19 @@
 
  bl_mynn_in = .false.
  bl_ysu_in  = .false.
+ bl_shinhong_in  = .false.
 
  if(config_pbl_scheme=='bl_mynn') then
     bl_mynn_in = .true.
  elseif(config_pbl_scheme == 'bl_ysu') then
     bl_ysu_in = .true.
+ elseif(config_pbl_scheme == 'bl_shinhong') then
+    bl_shinhong_in = .true.
  endif
 
  call mpas_log_write('    bl_mynn_in              = $l', logicArgs=(/bl_mynn_in/))
  call mpas_log_write('    bl_ysu_in               = $l', logicArgs=(/bl_ysu_in/))
+ call mpas_log_write('    bl_shinhong_in               = $l', logicArgs=(/bl_shinhong_in/))
  call mpas_log_write('')
 
 !--- initialization of all packages for parameterizations of land surface processes:

--- a/src/core_atmosphere/physics/mpas_atmphys_vars.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_vars.F
@@ -374,11 +374,11 @@
 !=================================================================================================================
 
  logical,parameter:: &
-    flag_bep = .false. !flag to use BEP/BEP+BEM for use in the YSU PBL scheme (with urban physics). since we do
+    flag_bep = .false. !flag to use BEP/BEP+BEM for use in the SHINHONG/YSU PBL scheme (with urban physics). since we do
                        !not run urban physics, flag_bep is always set to false.
 
  integer,parameter:: &
-    idiff = 0          !BEP/BEM+BEM diffusion flag for use in the YSU PBL scheme (with urban physics). since we
+    idiff = 0          !BEP/BEM+BEM diffusion flag for use in the SHINHONG/YSU PBL scheme (with urban physics). since we
                        !do not run urban physics, idiff is set to zero.
 
  integer:: ysu_pblmix
@@ -394,6 +394,7 @@
     hpbl_p,           &!PBL height                                                                             [m]
     delta_p,          &!
     wstar_p,          &!
+    fcell_p,          &!
     uoce_p,           &!
     voce_p             !
 
@@ -469,8 +470,8 @@
     sina_p             !sine of map rotation                                                                   [-]
 
  real(kind=RKIND),dimension(:,:),allocatable:: &
-    var2d_p,          &!orographic variance                                                                   [m2]
-    con_p,            &!orographic convexity                                                                  [m2]
+    var2d_p,          &!orographic variance (indeed standard deviation)                                                                   [m]
+    con_p,            &!orographic convexity                                                                   [-]
     oa1_p,            &!orographic direction asymmetry function                                                [-]
     oa2_p,            &!orographic direction asymmetry function                                                [-]
     oa3_p,            &!orographic direction asymmetry function                                                [-]

--- a/src/core_atmosphere/physics/physics_wrf/Makefile
+++ b/src/core_atmosphere/physics/physics_wrf/Makefile
@@ -14,6 +14,7 @@ OBJS = \
 	module_bl_ugwp_gwdo.o          \
 	module_bl_mynn.o               \
 	module_bl_ysu.o                \
+	module_bl_shinhong.o                \
 	module_cam_error_function.o    \
 	module_cam_shr_kind_mod.o      \
 	module_cam_support.o           \

--- a/src/core_atmosphere/physics/physics_wrf/module_bl_shinhong.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_bl_shinhong.F
@@ -1,0 +1,499 @@
+#define NEED_B4B_DURING_CCPP_TESTING 1
+!=================================================================================================================
+ module module_bl_shinhong
+ use mpas_kind_types,only: kind_phys => RKIND
+ use bl_shinhong
+
+
+ implicit none
+ private
+ public:: shinhong
+
+
+ contains
+
+
+!=================================================================================================================
+   subroutine shinhong(u3d,v3d,t3d,qv3d,qc3d,qi3d,p3d,p3di,pi3d,               &
+                  rublten,rvblten,rthblten,                                    &
+                  rqvblten,rqcblten,rqiblten,flag_qc,flag_qi,                  &
+                  cp,g,rovcp,rd,rovg,ep1,ep2,karman,xlv,rv,                    &
+                  dz8w,psfc,                                                   &
+                  znt,ust,hpbl,psim,psih,                                      &
+                  xland,hfx,qfx,wspd,br,                                       &
+                  dt,kpbl2d,                                                   &
+                  exch_h,exch_m,                                               &
+                  wstar,delta,                                                 &
+                  shinhong_nonlocal_flux,                                      &
+                  tke,el,corf,                                                 &
+                  u10,v10,                                                     &
+                  uoce,voce,                                                   &
+                  rthraten,shinhong_scu_mixing,                                &
+                  shinhong_dissi_heating,                                      &
+                  ctopo,ctopo2,dx,                                             &
+                  idiff,flag_bep,frc_urb2d,                                    &
+                  a_u_bep,a_v_bep,a_t_bep,                                     &
+                  a_q_bep,                                                     &
+                  a_e_bep,b_u_bep,b_v_bep,                                     &
+                  b_t_bep,b_q_bep,                                             &
+                  b_e_bep,dlg_bep,                                             &
+                  dl_u_bep,sf_bep,vl_bep,                                      &
+                  ids,ide, jds,jde, kds,kde,                                   &
+                  ims,ime, jms,jme, kms,kme,                                   &
+                  its,ite, jts,jte, kts,kte,                                   &
+                  errmsg,errflg                                                &
+                 )
+!-------------------------------------------------------------------------------
+  implicit none
+!-------------------------------------------------------------------------------
+!-- u3d         3d u-velocity interpolated to theta points (m/s)
+!-- v3d         3d v-velocity interpolated to theta points (m/s)
+!-- th3d        3d potential temperature (k)
+!-- t3d         temperature (k)
+!-- qv3d        3d water vapor mixing ratio (kg/kg)
+!-- qc3d        3d cloud mixing ratio (kg/kg)
+!-- qi3d        3d ice mixing ratio (kg/kg)
+!               (note: if P_QI<PARAM_FIRST_SCALAR this should be zero filled)
+!-- p3d         3d pressure (pa)
+!-- p3di        3d pressure (pa) at interface level
+!-- pi3d        3d exner function (dimensionless)
+!-- rr3d        3d dry air density (kg/m^3)
+!-- rublten     u tendency due to
+!               pbl parameterization (m/s/s)
+!-- rvblten     v tendency due to
+!               pbl parameterization (m/s/s)
+!-- rthblten    theta tendency due to
+!               pbl parameterization (K/s)
+!-- rqvblten    qv tendency due to
+!               pbl parameterization (kg/kg/s)
+!-- rqcblten    qc tendency due to
+!               pbl parameterization (kg/kg/s)
+!-- rqiblten    qi tendency due to
+!               pbl parameterization (kg/kg/s)
+!-- cp          heat capacity at constant pressure for dry air (j/kg/k)
+!-- g           acceleration due to gravity (m/s^2)
+!-- rovcp       r/cp
+!-- rd          gas constant for dry air (j/kg/k)
+!-- rovg        r/g
+!-- dz8w        dz between full levels (m)
+!-- xlv         latent heat of vaporization (j/kg)
+!-- rv          gas constant for water vapor (j/kg/k)
+!-- psfc        pressure at the surface (pa)
+!-- znt         roughness length (m)
+!-- ust         u* in similarity theory (m/s)
+!-- hpbl        pbl height (m)
+!-- psim        similarity stability function for momentum
+!-- psih        similarity stability function for heat
+!-- xland       land mask (1 for land, 2 for water)
+!-- hfx         upward heat flux at the surface (w/m^2)
+!-- qfx         upward moisture flux at the surface (kg/m^2/s)
+!-- wspd        wind speed at lowest model level (m/s)
+!-- u10         u-wind speed at 10 m (m/s)
+!-- v10         v-wind speed at 10 m (m/s)
+!-- uoce        sea surface zonal currents (m s-1)
+!-- voce        sea surface meridional currents (m s-1)
+!-- br          bulk richardson number in surface layer
+!-- dx          model grid interval (m)
+!-- dt          time step (s)
+!-- rvovrd      r_v divided by r_d (dimensionless)
+!-- ep1         constant for virtual temperature (r_v/r_d - 1)
+!-- ep2         constant for specific humidity calculation
+!-- karman      von karman constant
+!-- idiff       diff3d BEP/BEM+BEM diffusion flag
+!-- flag_bep    flag to use BEP/BEP+BEM
+!-- frc_urb2d   urban fraction
+!-- a_u_bep     BEP/BEP+BEM implicit component u-mom
+!-- a_v_bep     BEP/BEP+BEM implicit component v-mom
+!-- a_t_bep     BEP/BEP+BEM implicit component pot. temp.
+!-- a_q_bep     BEP/BEP+BEM implicit component vapor mixing ratio
+!-- a_e_bep     BEP/BEP+BEM implicit component TKE
+!-- b_u_bep     BEP/BEP+BEM explicit component u-mom
+!-- b_v_bep     BEP/BEP+BEM explicit component v-mom
+!-- b_t_bep     BEP/BEP+BEM explicit component pot.temp.
+!-- b_q_bep     BEP/BEP+BEM explicit component vapor mixing ratio
+!-- b_e_bep     BEP/BEP+BEM explicit component TKE
+!-- dlg_bep     Height above ground Martilli et al. (2002) Eq. 24
+!-- dl_u_bep    modified length scale Martilli et al. (2002) Eq. 22
+!-- sf_bep      fraction of vertical surface not occupied by buildings
+!-- vl_bep      volume fraction of grid cell not occupied by buildings
+!-- ids         start index for i in domain
+!-- ide         end index for i in domain
+!-- jds         start index for j in domain
+!-- jde         end index for j in domain
+!-- kds         start index for k in domain
+!-- kde         end index for k in domain
+!-- ims         start index for i in memory
+!-- ime         end index for i in memory
+!-- jms         start index for j in memory
+!-- jme         end index for j in memory
+!-- kms         start index for k in memory
+!-- kme         end index for k in memory
+!-- its         start index for i in tile
+!-- ite         end index for i in tile
+!-- jts         start index for j in tile
+!-- jte         end index for j in tile
+!-- kts         start index for k in tile
+!-- kte         end index for k in tile
+!-------------------------------------------------------------------------------
+!
+!
+   integer,  intent(in   )   ::      ids,ide, jds,jde, kds,kde,                &
+                                     ims,ime, jms,jme, kms,kme,                &
+                                     its,ite, jts,jte, kts,kte
+
+!
+   real(kind=kind_phys),     intent(in   )   ::      dt,cp,g,rovcp,rovg,rd,xlv,rv
+!
+   real(kind=kind_phys),     intent(in )     ::      ep1,ep2,karman
+!
+   real(kind=kind_phys),     dimension( ims:ime, kms:kme, jms:jme )          , &
+             intent(in   )   ::                                          qv3d, &
+                                                                         qc3d, &
+                                                                         qi3d, &
+                                                                          p3d, &
+                                                                         pi3d, &
+                                                                          t3d, &
+                                                                         dz8w, &
+                                                                     rthraten
+   real(kind=kind_phys),     dimension( ims:ime, kms:kme, jms:jme )          , &
+             intent(in   )   ::                                          p3di
+!
+   real(kind=kind_phys),     dimension( ims:ime, kms:kme, jms:jme )          , &
+             intent(out  )   ::                                       rublten, &
+                                                                      rvblten, &
+                                                                     rthblten, &
+                                                                     rqvblten, &
+                                                                     rqcblten, &
+                                                                     rqiblten
+!
+   real(kind=kind_phys),     dimension( ims:ime, kms:kme, jms:jme )          , &
+             intent(out  )   ::                                        exch_h, &
+                                                                       exch_m
+   real(kind=kind_phys),     dimension( ims:ime, kms:kme, jms:jme )          , &
+             intent(out  )   ::                                           tke, &
+                                                                           el
+   real(kind=kind_phys),     dimension( ims:ime, jms:jme )                   , &
+             intent(out  )   ::                                         wstar
+   real(kind=kind_phys),     dimension( ims:ime, jms:jme )                   , &
+             intent(out  )   ::                                         delta
+   real(kind=kind_phys),     dimension( ims:ime, jms:jme )                   , &
+             intent(inout)   ::                                           u10, &
+                                                                          v10
+   real(kind=kind_phys),     dimension( ims:ime, jms:jme )                   , &
+             intent(in   )   ::                                          uoce, &
+                                                                         voce
+!
+   real(kind=kind_phys),     dimension( ims:ime, jms:jme )                   , &
+             intent(in   )   ::                                         xland, &
+                                                                          hfx, &
+                                                                          qfx, &
+                                                                           br, &
+                                                                           dx, &
+                                                                         corf, &
+                                                                         psfc
+   real(kind=kind_phys),     dimension( ims:ime, jms:jme )                   , &
+             intent(in   )   ::                                                &
+                                                                         psim, &
+                                                                         psih
+   real(kind=kind_phys),     dimension( ims:ime, jms:jme )                   , &
+             intent(in   )   ::                                           znt, &
+                                                                          ust, &
+                                                                          wspd
+   real(kind=kind_phys),     dimension( ims:ime, jms:jme )                   , &
+             intent(out  )   ::                                          hpbl
+!
+   real(kind=kind_phys),     dimension( ims:ime, kms:kme, jms:jme )          , &
+             intent(in   )   ::                                           u3d, &
+                                                                          v3d
+!
+   integer,  dimension( ims:ime, jms:jme )                                   , &
+             intent(out  )   ::                                        kpbl2d
+!
+   logical,  intent(in)      ::                                       flag_qc, &
+                                                                      flag_qi
+   logical,  intent(in)      ::                        shinhong_nonlocal_flux, &
+                                                          shinhong_scu_mixing, &
+                                                       shinhong_dissi_heating
+!
+   integer,  intent(in)      ::                                          idiff
+   logical,  intent(in)      ::                                       flag_bep
+   real(kind=kind_phys),     dimension( ims:ime, kms:kme, jms:jme )          , &
+             optional                                                        , &
+             intent(in)      ::                                       a_u_bep, &
+                                                              a_v_bep,a_t_bep, &
+                                                              a_e_bep,b_u_bep, &
+                                                              a_q_bep,b_q_bep, &
+                                                              b_v_bep,b_t_bep, &
+                                                              b_e_bep,dlg_bep, &
+                                                                     dl_u_bep, &
+                                                                vl_bep,sf_bep
+   real(kind=kind_phys),     dimension(ims:ime,jms:jme)                      , &
+             optional                                                        , &
+             intent(in)      ::                                     frc_urb2d
+!
+   real(kind=kind_phys),     dimension( ims:ime, jms:jme )                   , &
+             optional                                                        , &
+             intent(in   )   ::                                         ctopo, &
+                                                                       ctopo2
+!
+   character(len=*), intent(out)   ::                                  errmsg
+   integer,          intent(out)   ::                                  errflg
+!local
+   integer ::  i,j,k
+
+!temporary allocation of local chemical species and/or passive tracers that are vertically-
+!mixed in subroutine bl_shinhong_run:
+
+   integer,  parameter :: nmix = 0
+   integer :: n
+
+   real(kind=kind_phys),   dimension(ims:ime,kms:kme,jms:jme,nmix)::       qmix
+   real(kind=kind_phys),   dimension(ims:ime,kms:kme,jms:jme,nmix):: rqmixblten
+
+   !  Local tile-sized arrays for contiguous data for bl_shinhong_run call.
+
+   real(kind=kind_phys),   dimension(its:ite,kts:kte,nmix) ::              &
+                                                             qmix_hv     , &
+                                                             rqmixblten_hv
+
+   real(kind=kind_phys),   dimension(its:ite,kts:kte)      ::              &
+                                                             u3d_hv      , &
+                                                             v3d_hv      , &
+                                                             t3d_hv      , &
+                                                             qv3d_hv     , &
+                                                             qc3d_hv     , &
+                                                             qi3d_hv     , &
+                                                             p3d_hv      , &
+                                                             pi3d_hv     , &
+                                                             rublten_hv  , &
+                                                             rvblten_hv  , &
+                                                             rthblten_hv , &
+                                                             rqvblten_hv , &
+                                                             rqcblten_hv , &
+                                                             rqiblten_hv , &
+                                                             dz8w_hv     , &
+                                                             exch_h_hv   , &
+                                                             exch_m_hv   , &
+                                                             rthraten_hv
+   real(kind=kind_phys),   dimension(its:ite,kts:kte)      ::              &
+                                                             tke_hv      , &
+                                                              el_hv
+
+   real(kind=kind_phys),   dimension(its:ite,kts:kte)      ::              &
+                                                             a_u_hv      , &
+                                                             a_v_hv      , &
+                                                             a_t_hv      , &
+                                                             a_e_hv      , &
+                                                             b_u_hv      , &
+                                                             a_q_hv      , &
+                                                             b_q_hv      , &
+                                                             b_v_hv      , &
+                                                             b_t_hv      , &
+                                                             b_e_hv      , &
+                                                             dlg_hv      , &
+                                                             dl_u_hv     , &
+                                                             vlk_hv      , &
+                                                             sfk_hv
+   real(kind=kind_phys),   dimension(its:ite,kts:kte+1)    ::              &
+                                                             p3di_hv
+
+   real(kind=kind_phys),   dimension(its:ite)              ::              &
+                                                             psfc_hv     , &
+                                                             znt_hv      , &
+                                                             ust_hv      , &
+                                                             hpbl_hv     , &
+                                                             psim_hv     , &
+                                                             psih_hv     , &
+                                                             xland_hv    , &
+                                                             dx_hv       , &
+                                                             corf_hv     , &
+                                                             hfx_hv      , &
+                                                             qfx_hv      , &
+                                                             wspd_hv     , &
+                                                             br_hv       , &
+                                                             wstar_hv    , &
+                                                             delta_hv    , &
+                                                             u10_hv      , &
+                                                             v10_hv      , &
+                                                             uoce_hv     , &
+                                                             voce_hv     , &
+                                                             ctopo_hv    , &
+                                                             ctopo2_hv
+
+   integer,                dimension(its:ite)              ::              &
+                                                             kpbl2d_hv
+   real(kind=kind_phys),   dimension(its:ite)              ::              &
+                                                             frcurb_hv
+
+!-----------------------------------------------------------------------------------------------------------------
+
+
+   do j = jts,jte
+!
+      !  Assign input data to local tile-sized arrays.
+
+      do n = 1, nmix
+         do k = kts, kte
+            do i = its, ite
+               qmix_hv(i,k,n) = qmix(i,k,j,n)
+            end do
+         end do
+      end do
+
+      do k = kts, kte+1
+         do i = its, ite
+            p3di_hv(i,k) = p3di(i,k,j)
+         end do
+      end do
+
+      do k = kts, kte
+         do i = its, ite
+            u3d_hv(i,k) = u3d(i,k,j)
+            v3d_hv(i,k) = v3d(i,k,j)
+            t3d_hv(i,k) = t3d(i,k,j)
+            qv3d_hv(i,k) = qv3d(i,k,j)
+            qc3d_hv(i,k) = qc3d(i,k,j)
+            qi3d_hv(i,k) = qi3d(i,k,j)
+            p3d_hv(i,k) = p3d(i,k,j)
+            pi3d_hv(i,k) = pi3d(i,k,j)
+            dz8w_hv(i,k) = dz8w(i,k,j)
+            rthraten_hv(i,k) = rthraten(i,k,j)
+         end do
+      end do
+
+      if(present(a_u_bep) .and. present(a_v_bep) .and. present(a_t_bep) .and.  &
+         present(a_q_bep) .and. present(a_e_bep) .and. present(b_u_bep) .and.  &
+         present(b_v_bep) .and. present(b_t_bep) .and. present(b_q_bep) .and.  &
+         present(b_e_bep) .and. present(dlg_bep) .and. present(dl_u_bep) .and. &
+         present(sf_bep)  .and. present(vl_bep)  .and. present(frc_urb2d)) then
+         do k = kts, kte
+            do i = its,ite
+               a_u_hv(i,k)  = a_u_bep(i,k,j)
+               a_v_hv(i,k)  = a_v_bep(i,k,j)
+               a_t_hv(i,k)  = a_t_bep(i,k,j)
+               a_q_hv(i,k)  = a_q_bep(i,k,j)
+               a_e_hv(i,k)  = a_e_bep(i,k,j)
+               b_u_hv(i,k)  = b_u_bep(i,k,j)
+               b_v_hv(i,k)  = b_v_bep(i,k,j)
+               b_t_hv(i,k)  = b_t_bep(i,k,j)
+               b_q_hv(i,k)  = b_q_bep(i,k,j)
+               b_e_hv(i,k)  = b_e_bep(i,k,j)
+               dlg_hv(i,k)  = dlg_bep(i,k,j)
+               dl_u_hv(i,k) = dl_u_bep(i,k,j)
+               vlk_hv(i,k) = vl_bep(i,k,j)
+               sfk_hv(i,k)  = sf_bep(i,k,j)
+            enddo
+         enddo
+         do i = its, ite
+            frcurb_hv(i) = frc_urb2d(i,j)
+         enddo
+      endif
+
+      do i = its, ite
+         psfc_hv(i) = psfc(i,j)
+         znt_hv(i) = znt(i,j)
+         ust_hv(i) = ust(i,j)
+         wspd_hv(i) = wspd(i,j)
+         psim_hv(i) = psim(i,j)
+         psih_hv(i) = psih(i,j)
+         xland_hv(i) = xland(i,j)
+         dx_hv(i) = dx(i,j)
+         corf_hv(i) = corf(i,j)
+         hfx_hv(i) = hfx(i,j)
+         qfx_hv(i) = qfx(i,j)
+         br_hv(i) = br(i,j)
+         u10_hv(i) = u10(i,j)
+         v10_hv(i) = v10(i,j)
+         uoce_hv(i) = uoce(i,j)
+         voce_hv(i) = voce(i,j)
+         ctopo_hv(i) = ctopo(i,j)
+         ctopo2_hv(i) = ctopo2(i,j)
+      end do
+!
+      call bl_shinhong_run(ux=u3d_hv,vx=v3d_hv                                      &
+              ,tx=t3d_hv                                                       &
+              ,qvx=qv3d_hv,qcx=qc3d_hv,qix=qi3d_hv                             &
+              ,f_qc=flag_qc,f_qi=flag_qi                                       &
+              ,nmix=nmix,qmix=qmix_hv                                          &
+              ,p2d=p3d_hv,p2di=p3di_hv                                         &
+              ,pi2d=pi3d_hv                                                    &
+              ,utnp=rublten_hv,vtnp=rvblten_hv                                 &
+              ,ttnp=rthblten_hv,qvtnp=rqvblten_hv                              &
+              ,qctnp=rqcblten_hv,qitnp=rqiblten_hv                             &
+              ,qmixtnp=rqmixblten_hv                                           &
+              ,cp=cp,g=g,rovcp=rovcp,rd=rd,rovg=rovg                           &    
+              ,xlv=xlv,rv=rv                                                   &
+              ,ep1=ep1,ep2=ep2,karman=karman                                   &
+              ,dz8w2d=dz8w_hv                                                  &
+              ,psfcpa=psfc_hv,znt=znt_hv,ust=ust_hv                            &
+              ,hpbl=hpbl_hv                                                    &
+              ,psim=psim_hv                                                    &
+              ,psih=psih_hv,xland=xland_hv                                     &
+              ,hfx=hfx_hv,qfx=qfx_hv                                           &
+              ,wspd=wspd_hv,br=br_hv                                           &
+              ,dt=dt,kpbl1d=kpbl2d_hv                                          &
+              ,exch_hx=exch_h_hv                                               &
+              ,exch_mx=exch_m_hv                                               &
+              ,wstar=wstar_hv                                                  &
+              ,delta=delta_hv                                                  &
+              ,if_shinhong_nonlocal_flux=shinhong_nonlocal_flux                &
+              ,tke=tke_hv,el_pbl=el_hv,corf=corf_hv                            &
+              ,u10=u10_hv,v10=v10_hv                                           &
+              ,uox=uoce_hv,vox=voce_hv                                         &
+              ,rthraten=rthraten_hv                                            &
+              ,if_scu_mixing=shinhong_scu_mixing                               &
+              ,if_dissipative_heating=shinhong_dissi_heating                   &
+              ,ctopo=ctopo_hv,ctopo2=ctopo2_hv                                 &
+              ,dxmeter=dx_hv                                                   &
+              ,a_u=a_u_hv,a_v=a_v_hv,a_t=a_t_hv,a_q=a_q_hv,a_e=a_e_hv          &
+              ,b_u=b_u_hv,b_v=b_v_hv,b_t=b_t_hv,b_q=b_q_hv,b_e=b_e_hv          &
+              ,sfk=sfk_hv,vlk=vlk_hv,dlu=dl_u_hv,dlg=dlg_hv,frcurb=frcurb_hv   &
+              ,flag_bep=flag_bep                                               &
+              ,its=its,ite=ite,kte=kte,kme=kme                                 &
+              ,errmsg=errmsg,errflg=errflg                                     )
+!
+      !  Assign local data back to full-sized arrays.
+      !  Only required for the INTENT(OUT) or INTENT(INOUT) arrays.
+
+      do n = 1, nmix
+         do k = kts, kte
+            do i = its, ite
+               rqmixblten(i,k,j,n) = rqmixblten_hv(i,k,n)
+            end do
+         end do
+      end do
+
+      do k = kts, kte
+         do i = its, ite
+            rublten(i,k,j) = rublten_hv(i,k)
+            rvblten(i,k,j) = rvblten_hv(i,k)
+#if (NEED_B4B_DURING_CCPP_TESTING == 1)
+            rthblten(i,k,j) = rthblten_hv(i,k)/pi3d_hv(i,k)
+#elif (NEED_B4B_DURING_CCPP_TESTING != 1)
+            rthblten(i,k,j) = rthblten_hv(i,k)
+#endif
+            rqvblten(i,k,j) = rqvblten_hv(i,k)
+            rqcblten(i,k,j) = rqcblten_hv(i,k)
+            rqiblten(i,k,j) = rqiblten_hv(i,k)
+            exch_h(i,k,j) = exch_h_hv(i,k)
+            exch_m(i,k,j) = exch_m_hv(i,k)
+            tke(i,k,j) = tke_hv(i,k)
+            el(i,k,j) = el_hv(i,k)
+         end do
+      end do
+
+      do i = its, ite
+         u10(i,j) = u10_hv(i)
+         v10(i,j) = v10_hv(i)
+         hpbl(i,j) = hpbl_hv(i)
+         kpbl2d(i,j) = kpbl2d_hv(i)
+         wstar(i,j) = wstar_hv(i)
+         delta(i,j) = delta_hv(i)
+      end do
+   enddo
+
+ end subroutine shinhong
+
+!=================================================================================================================
+ end module module_bl_shinhong
+!=================================================================================================================

--- a/src/core_atmosphere/physics/physics_wrf/module_bl_shinhong.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_bl_shinhong.F
@@ -358,6 +358,8 @@
             pi3d_hv(i,k) = pi3d(i,k,j)
             dz8w_hv(i,k) = dz8w(i,k,j)
             rthraten_hv(i,k) = rthraten(i,k,j)
+            tke_hv(i,k) = tke(i,k,j)
+            el_hv(i,k) = el(i,k,j)
          end do
       end do
 


### PR DESCRIPTION

The entrainment flux was re-formulated in the SHINHONG PBL.
One caan select either SHINHONG (config_shinhong_nonlocal_flux=tue) or YSU (=false; default) scheme.

See the below examples for more information.
https://github.com/MPAS-Dev/MPAS/pull/930
https://github.com/MPAS-Dev/MPAS/pull/931

