### PR TITLE
Fix DEBUG build issue due to LDFLAGS for the 'ifort' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -288,7 +288,7 @@ ifort:   # BUILDTARGET Intel Fortran, C, and C++ compiler suite
 	"FFLAGS_DEBUG = -g -convert big_endian -free -check all -fpe0 -traceback" \
 	"CFLAGS_DEBUG = -g -traceback" \
 	"CXXFLAGS_DEBUG = -g -traceback" \
-	"LDFLAGS_DEBUG = -g -fpe0 -traceback" \
+	"LDFLAGS_DEBUG = -g -traceback" \
 	"FFLAGS_OMP = -qopenmp" \
 	"CFLAGS_OMP = -qopenmp" \
 	"PICFLAG = -fpic" \


### PR DESCRIPTION
This PR fixes a similar issue in [PR1327](https://github.com/MPAS-Dev/MPAS-Model/pull/1327). 

There is a DEBUG build issue due to the use of Fortran-only LDFLAGS_DEBUG in the `ifort` build target.

Builds of MPAS with `make ifort CORE=atmosphere DEBUG=true` were broken with the following error message: 

```
Checking for a working PnetCDF library...
*********************************************************
ERROR: Test PnetCDF C program could not be compiled by mpicc.
Please ensure you have a working PnetCDF library installed.

The following compilation command failed with errors:
mpicc pnetcdf.c  -I/glade/u/apps/casper/23.10/spack/opt/spack/netcdf/4.9.2/openmpi/4.1.6/oneapi/2023.2.1/x5i2/include -I/glade/u/apps/casper/23.10/spack/opt/spack/parallel-netcdf/1.12.3/openmpi/4.1.6/oneapi/2023.2.1/ormb/include -g -traceback -DSINGLE_PRECISION -g -fpe0 -traceback -L/glade/u/apps/casper/23.10/spack/opt/spack/parallel-netcdf/1.12.3/openmpi/4.1.6/oneapi/2023.2.1/ormb/lib -lpnetcdf -o pnetcdf.out

Test program pnetcdf.c and output pnetcdf.log have been left
in the top-level MPAS directory for further debugging
*********************************************************
```

pnetcdf.log: 
```
icx: error: unknown argument: '-fpe0'
icx: remark: Note that use of '-g' without any optimization-level option will turn off most compiler optimizations similar to use of '-O0'; use '-Rno-debug-disables-optimization' to disable this remark [-Rdebug-disables-optimization]
```

Thus, this PR removes `-fpe0` from the definition of LDFLAGS_DEBUG for the `ifort` target.