### PR TITLE
Openmp bug fixes

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -1974,6 +1974,7 @@ module atm_time_integration
       theta_m_2(:,cellEnd+1) = 0.0_RKIND
       !$acc end kernels
 
+!$OMP BARRIER
       !$acc parallel default(present)
       !$acc loop gang worker
       do iEdge = edgeStart,edgeEnd
@@ -2015,6 +2016,7 @@ module atm_time_integration
          end do
       end do
       !$acc end parallel
+!$OMP BARRIER
 
       MPAS_ACC_TIMER_START('atm_rk_integration_setup [ACC_data_xfer]')
       !$acc exit data copyout(ru_save, rw_save, rtheta_p_save, rho_p_save, u_2, &

--- a/src/core_atmosphere/physics/mpas_atmphys_driver.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver.F
@@ -292,11 +292,10 @@
        call deallocate_lsm
 
        elseif(config_lsm_scheme == 'sf_noahmp') then
-          do thread=1,nThreads
+         ! Do not use Openmp here: the routine accepts thread loop bounds but does not use them
              call driver_lsm_noahmp(block%configs,mesh,state,time_lev,diag,diag_physics,   &
                                     diag_physics_noahmp,output_noahmp,sfc_input,itimestep, &
-                                    cellSolveThreadStart(thread),cellSolveThreadEnd(thread))
-          enddo
+                                    cellSolveThreadStart(1),cellSolveThreadEnd(nThreads))
        endif
 
        call allocate_seaice(block%configs)


### PR DESCRIPTION
This PR resolves the problems raised in issue https://github.com/issues/created?issue=MPAS-Dev%7CMPAS-Model%7C1403. Namely, that one subroutine needed barriers to fix random errors and another subroutine needed to called without threading to fix reproducibility with multiple OMP threads.


Changes:

mpas_atm_time_integration.F :
        Bug: Add OMP barriers in atm_rk_integration_setup to keep array use in sync (fixes random bad values at thread bounds). It's not clear to me why barriers are needed at both the beginning and end, but neither by itself resolved the bad value errors.
        Efficiency: Turn off OMP parallel for atm_advance_scalars_mono because it slows down with multi-threading (insufficient work in loops) (no change to results). The subroutine could be restructured to push the scalar loop inside the column loop, but would use more memory for local arrays.

mpas_atmphys_driver.F : 
         Bug: Remove OMP parallel for noahmp because it ignores thread bounds (does all cells). The OMP threading was causing the land surface rates to be accumulated multiple times and thus changed the solution.

Tested on MacOS with gfortran/gcc 12.4 and clang version 17.0.0