### PR TITLE
Initialize the mpi_errcode argument to MPI_Abort in MPAS's log_abort routine

### DIFF
--- a/src/framework/mpas_abort.F
+++ b/src/framework/mpas_abort.F
@@ -94,6 +94,8 @@ module mpas_abort
    
       if (.not. local_deferredAbort) then
 #ifdef _MPI
+         mpi_errcode = 6   ! corresponds to POSIX SIGABRT, though the specific
+                           ! value here probably does not matter much
          call MPI_Abort(MPI_COMM_WORLD, mpi_errcode, mpi_ierr)
 #else
          stop

--- a/src/framework/mpas_dmpar.F
+++ b/src/framework/mpas_dmpar.F
@@ -349,6 +349,8 @@ include 'mpif.h'
 #ifdef _MPI
       integer :: mpi_ierr, mpi_errcode
 
+      mpi_errcode = 6   ! corresponds to POSIX SIGABRT, though the specific
+                        ! value here probably does not matter much
       call MPI_Abort(dminfo % comm, mpi_errcode, mpi_ierr)
 #endif
 

--- a/src/framework/mpas_log.F
+++ b/src/framework/mpas_log.F
@@ -847,6 +847,8 @@ module mpas_log
       deallocate(mpas_log_info)
 
 #ifdef _MPI
+      mpi_errcode = 6   ! corresponds to POSIX SIGABRT, though the specific
+                        ! value here probably does not matter much
       call MPI_Abort(MPI_COMM_WORLD, mpi_errcode, mpi_ierr)
 #else
       stop


### PR DESCRIPTION
This PR initializes the `mpi_errcode` argument to `MPI_Abort` in several MPAS routines.

The `mpi_errcode` variable in MPAS's `log_abort`, `mpas_dmpar_global_abort`, and `mpas_dmpar_abort` routines that is passed as the `errorcode` input argument to `MPI_Abort` was previously uninitialized, leading to the potential use of uninitialized memory in `MPI_Abort` (or in routines called by `MPI_Abort`).

In practice, the uninitialized value in `mpi_errcode` caused no problems, though when running MPAS with valgrind's memcheck tool, it could lead to the generation of (possibly numerous) uninitialized memory errors in the log from memcheck.

Note that although this PR initializes the `mpi_errcode` variable with a value of 6, corresponding to the POSIX SIGABRT signal number, the specific value is probably not important.