### PR TITLE
Use the checkout_externals utility to checkout physics submodules with cmake

### DIFF
--- a/src/core_atmosphere/CMakeLists.txt
+++ b/src/core_atmosphere/CMakeLists.txt
@@ -97,20 +97,16 @@ set(ATMOSPHERE_CORE_PHYSICS_WRF_SOURCES
 list(TRANSFORM ATMOSPHERE_CORE_PHYSICS_WRF_SOURCES PREPEND physics/physics_wrf/)
 
 
-set(ATMOSPHERE_CORE_PHYSICS_MMM_DIR ${CMAKE_CURRENT_SOURCE_DIR}/physics/physics_mmm)
-
-if(NOT EXISTS ${ATMOSPHERE_CORE_PHYSICS_MMM_DIR})
-    set(PHYSICS_MMM_REPO_URL "https://github.com/NCAR/MMM-physics")
-    execute_process(COMMAND git clone ${PHYSICS_MMM_REPO_URL} ${ATMOSPHERE_CORE_PHYSICS_MMM_DIR}
-                    RESULT_VARIABLE GIT_CLONE_RESULT
-                    OUTPUT_VARIABLE GIT_CLONE_OUTPUT
-                    ERROR_VARIABLE GIT_CLONE_ERROR)
-    if(NOT GIT_CLONE_RESULT EQUAL 0)
-        message(FATAL_ERROR "Git clone failed with error: ${GIT_CLONE_ERROR}")
-    endif()
-
+set(CHECKOUT ${CMAKE_CURRENT_SOURCE_DIR}/tools/manage_externals/checkout_externals )
+execute_process( COMMAND
+                 ${CHECKOUT} --externals ${CMAKE_CURRENT_SOURCE_DIR}/Externals.cfg
+                 WORKING_DIRECTORY       ${CMAKE_CURRENT_SOURCE_DIR}/physics/
+                 RESULT_VARIABLE         MANAGE_EXTERNALS_STATUS
+                )
+if ( ${MANAGE_EXTERNALS_STATUS} AND NOT ${MANAGE_EXTERNALS_STATUS} EQUAL 0 )
+    message( FATAL_ERROR "Failed to checkout external repos via manage_externals" )
 else()
-    message(STATUS "Directory ${DIR_TO_CHECK} already exists, skipping clone")
+    message( STATUS "Finished checking out external repos via manage_externals" )
 endif()
 
 set(ATMOSPHERE_CORE_PHYSICS_MMM_SOURCES
@@ -129,22 +125,6 @@ set(ATMOSPHERE_CORE_PHYSICS_MMM_SOURCES
 )
 
 list(TRANSFORM ATMOSPHERE_CORE_PHYSICS_MMM_SOURCES PREPEND physics/physics_mmm/)
-
-set(ATMOSPHERE_CORE_PHYSICS_NOAA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/physics/physics_noaa/UGWP)
-
-if(NOT EXISTS ${ATMOSPHERE_CORE_PHYSICS_NOAA_DIR})
-    set(PHYSICS_NOAA_REPO_URL "https://github.com/NOAA-GSL/UGWP.git")
-    execute_process(COMMAND git clone ${PHYSICS_NOAA_REPO_URL} ${ATMOSPHERE_CORE_PHYSICS_NOAA_DIR}
-                    RESULT_VARIABLE GIT_CLONE_RESULT
-                    OUTPUT_VARIABLE GIT_CLONE_OUTPUT
-                    ERROR_VARIABLE GIT_CLONE_ERROR)
-    if(NOT GIT_CLONE_RESULT EQUAL 0)
-        message(FATAL_ERROR "Git clone failed with error: ${GIT_CLONE_ERROR}")
-    endif()
-
-else()
-    message(STATUS "Directory ${DIR_TO_CHECK} already exists, skipping clone")
-endif()
 
 set(ATMOSPHERE_CORE_PHYSICS_NOAA_SOURCES
     bl_ugwp.F


### PR DESCRIPTION

core_atmosphere requires specific versions of the physics code from https://github.com/NCAR/MMM-physics.git and https://github.com/NOAA-GSL/UGWP.git

The checkout_externals utility uses the versions of those repositories specified in src/core_atmosphere/Externals.cfg.
The gnu make build system uses checkout_externals; this change modifies the cmake build files to use the same mechanism as the make build system.

This PR fixes [issue 1420](https://github.com/MPAS-Dev/MPAS-Model/issues/1420)

This was tested by building MPAS-Model code with cmake. It was also tested by building [mpas-bundle](https://github.com/JCSDA-internal/mpas-bundle).

This change was copied from [wrf-model](https://github.com/wrf-model/WRF/blob/f15568ccc1447780e3bd664b9f0196edd784bf33/CMakeLists.txt#L332-L351) where it has been in use for about a year.