### PR TITLE
Remove defc_a and defc_b from the init_atmosphere and atmosphere cores

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -552,8 +552,6 @@
 			<var name="zb3"/>
 			<var name="dss"/>
 			<var name="deriv_two"/>
-			<var name="defc_a"/>
-			<var name="defc_b"/>
 			<var name="coeffs_reconstruct"/>
 #ifdef MPAS_CAM_DYCORE
 			<var name="cell_gradient_coef_x"/>
@@ -1619,13 +1617,6 @@
                 <var name="nAdvCellsForEdge" type="integer" dimensions="nEdges" units="-"
                      description="Number of cells used to reconstruct a cell-based field at an edge"/>
 
-                <!-- Space needed for deformation calculation weights -->
-                <var name="defc_a" type="real" dimensions="maxEdges nCells" units="unitless"
-                     description="Coefficients for computing the off-diagonal components of the horizontal deformation"/>
-
-                <var name="defc_b" type="real" dimensions="maxEdges nCells" units="unitless"
-                     description="Coefficients for computing the diagonal components of the horizontal deformation"/>
-
 #ifdef MPAS_CAM_DYCORE
                 <var name="cell_gradient_coef_x" type="real" dimensions="maxEdges nCells" units="m^-1"
                      description="Coefficients for computing the x (zonal) derivative of a cell-centered variable"/>
@@ -1633,6 +1624,7 @@
                 <var name="cell_gradient_coef_y" type="real" dimensions="maxEdges nCells" units="m^-1"
                      description="Coefficients for computing the y (meridional) derivative of a cell-centered variable"/>
 #endif
+                <!-- Space needed for deformation calculation weights -->
                 <var name="deformation_coef_c2" type="real" dimensions="maxEdges nCells" units="unitless"
                      description="Coefficients for computing the cos-squared terms of the 3d deformation"/>
 

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -291,8 +291,6 @@ module atm_time_integration
       real (kind=RKIND), dimension(:), pointer :: latCell
       real (kind=RKIND), dimension(:), pointer :: lonCell
       real (kind=RKIND), dimension(:,:,:), pointer :: coeffs_reconstruct
-      real (kind=RKIND), dimension(:,:), pointer :: defc_a
-      real (kind=RKIND), dimension(:,:), pointer :: defc_b
       real (kind=RKIND), dimension(:), pointer :: latEdge
       real (kind=RKIND), dimension(:), pointer :: angleEdge
       real (kind=RKIND), dimension(:), pointer :: meshScalingDel2
@@ -484,12 +482,6 @@ module atm_time_integration
 
       call mpas_pool_get_array(mesh, 'coeffs_reconstruct', coeffs_reconstruct)
       !$acc enter data copyin(coeffs_reconstruct)
-
-      call mpas_pool_get_array(mesh, 'defc_a', defc_a)
-      !$acc enter data copyin(defc_a)
-
-      call mpas_pool_get_array(mesh, 'defc_b', defc_b)
-      !$acc enter data copyin(defc_b)
 
       call mpas_pool_get_array(mesh, 'latEdge', latEdge)
       !$acc enter data copyin(latEdge)
@@ -1560,8 +1552,6 @@ module atm_time_integration
       real (kind=RKIND), dimension(:), pointer :: latCell
       real (kind=RKIND), dimension(:), pointer :: lonCell
       real (kind=RKIND), dimension(:,:,:), pointer :: coeffs_reconstruct
-      real (kind=RKIND), dimension(:,:), pointer :: defc_a
-      real (kind=RKIND), dimension(:,:), pointer :: defc_b
       real (kind=RKIND), dimension(:), pointer :: latEdge
       real (kind=RKIND), dimension(:), pointer :: angleEdge
       real (kind=RKIND), dimension(:), pointer :: meshScalingDel2
@@ -1752,12 +1742,6 @@ module atm_time_integration
 
       call mpas_pool_get_array(mesh, 'coeffs_reconstruct', coeffs_reconstruct)
       !$acc exit data delete(coeffs_reconstruct)
-
-      call mpas_pool_get_array(mesh, 'defc_a', defc_a)
-      !$acc exit data delete(defc_a)
-
-      call mpas_pool_get_array(mesh, 'defc_b', defc_b)
-      !$acc exit data delete(defc_b)
 
       call mpas_pool_get_array(mesh, 'latEdge', latEdge)
       !$acc exit data delete(latEdge)
@@ -5877,7 +5861,6 @@ module atm_time_integration
       real (kind=RKIND), pointer :: r_earth
       real (kind=RKIND), dimension(:,:), pointer :: ur_cell, vr_cell
 
-      real (kind=RKIND), dimension(:,:), pointer :: defc_a, defc_b
       real (kind=RKIND), dimension(:,:), pointer :: deformation_coef_c2, deformation_coef_s2, deformation_coef_cs
       real (kind=RKIND), dimension(:,:), pointer :: deformation_coef_c, deformation_coef_s
       real (kind=RKIND), dimension(:,:), pointer :: prandtl_3d_inv
@@ -6014,8 +5997,6 @@ module atm_time_integration
       call mpas_pool_get_array(mesh, 'latCell', latCell)
       call mpas_pool_get_array(mesh, 'latEdge', latEdge)
       call mpas_pool_get_array(mesh, 'angleEdge', angleEdge)
-      call mpas_pool_get_array(mesh, 'defc_a', defc_a)
-      call mpas_pool_get_array(mesh, 'defc_b', defc_b)
       call mpas_pool_get_array(mesh, 'deformation_coef_c2', deformation_coef_c2)
       call mpas_pool_get_array(mesh, 'deformation_coef_s2', deformation_coef_s2)
       call mpas_pool_get_array(mesh, 'deformation_coef_cs', deformation_coef_cs)
@@ -6091,7 +6072,7 @@ module atm_time_integration
          theta_m_save, exner, rr_save, scalars, tend_u_euler, tend_w_euler, tend_theta_euler, deriv_two, &
          cellsOnEdge, verticesOnEdge, edgesOnCell, edgesOnEdge, cellsOnCell, edgesOnVertex, nEdgesOnCell, nEdgesOnEdge, &
          latCell, latEdge, angleEdge, u_init, v_init, advCellsForEdge, nAdvCellsForEdge, adv_coefs, adv_coefs_3rd, &
-         rdzu, rdzw, fzm, fzp, qv_init, t_init, cf1, cf2, cf3, r_earth, ur_cell, vr_cell, defc_a, defc_b, &
+         rdzu, rdzw, fzm, fzp, qv_init, t_init, cf1, cf2, cf3, r_earth, ur_cell, vr_cell, &
          deformation_coef_c2,deformation_coef_s2,deformation_coef_cs,deformation_coef_c,deformation_coef_s, &
          tend_w_pgf, tend_w_buoy, coef_3rd_order, c_s, config_mix_full, config_mix_scalars, config_horiz_mixing, les_model_opt, &
          les_surface_opt, prandtl_3d_inv, config_del4u_div_factor, &
@@ -6126,7 +6107,7 @@ module atm_time_integration
       theta_m_save, exner, rr_save, scalars, tend_u_euler, tend_w_euler, tend_theta_euler, deriv_two, &
       cellsOnEdge, verticesOnEdge, edgesOnCell, edgesOnEdge, cellsOnCell, edgesOnVertex, nEdgesOnCell, nEdgesOnEdge, &
       latCell, latEdge, angleEdge, u_init, v_init, advCellsForEdge, nAdvCellsForEdge, adv_coefs, adv_coefs_3rd, &
-      rdzu, rdzw, fzm, fzp, qv_init, t_init, cf1, cf2, cf3, r_earth, ur_cell, vr_cell, defc_a, defc_b, &
+      rdzu, rdzw, fzm, fzp, qv_init, t_init, cf1, cf2, cf3, r_earth, ur_cell, vr_cell, &
       deformation_coef_c2,deformation_coef_s2,deformation_coef_cs,deformation_coef_c,deformation_coef_s, &
       tend_w_pgf, tend_w_buoy, coef_3rd_order, c_s, config_mix_full, config_mix_scalars, config_horiz_mixing, les_model_opt, &
       les_surface_opt, prandtl_3d_inv, config_del4u_div_factor, &
@@ -6242,8 +6223,6 @@ module atm_time_integration
       real (kind=RKIND), dimension(nVertLevels,nCells+1) :: ur_cell
       real (kind=RKIND), dimension(nVertLevels,nCells+1) :: vr_cell
 
-      real (kind=RKIND), dimension(maxEdges,nCells+1) :: defc_a
-      real (kind=RKIND), dimension(maxEdges,nCells+1) :: defc_b
       real (kind=RKIND), dimension(maxEdges,nCells+1) :: deformation_coef_c2, deformation_coef_s2, deformation_coef_cs
       real (kind=RKIND), dimension(maxEdges,nCells+1) :: deformation_coef_c, deformation_coef_s
 

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -474,8 +474,6 @@
                         <var name="ol3" packages="vertical_stage_in;met_stage_in"/>
                         <var name="ol4" packages="vertical_stage_in;met_stage_in"/>
                         <var name="deriv_two" packages="gwd_stage_in;vertical_stage_in;met_stage_in"/>
-                        <var name="defc_a" packages="gwd_stage_in;vertical_stage_in;met_stage_in"/>
-                        <var name="defc_b" packages="gwd_stage_in;vertical_stage_in;met_stage_in"/>
                         <var name="cell_gradient_coef_x" packages="gwd_stage_in;vertical_stage_in;met_stage_in"/>
                         <var name="cell_gradient_coef_y" packages="gwd_stage_in;vertical_stage_in;met_stage_in"/>
                         <var name="coeffs_reconstruct" packages="gwd_stage_in;vertical_stage_in;met_stage_in"/>
@@ -579,8 +577,6 @@
                         <var name="ol3" packages="gwd_stage_out;vertical_stage_out;met_stage_out"/>
                         <var name="ol4" packages="gwd_stage_out;vertical_stage_out;met_stage_out"/>
                         <var name="deriv_two"/>
-                        <var name="defc_a"/>
-                        <var name="defc_b"/>
                         <var name="cell_gradient_coef_x"/>
                         <var name="cell_gradient_coef_y"/>
                         <var name="coeffs_reconstruct"/>
@@ -1110,13 +1106,6 @@
 
                 <var name="advCells" type="integer" dimensions="TWENTYONE nCells" units="-"
                      description="cells used in least squares fit of polynomial for advection"/>
-
-                <!-- deformation calculation weights -->
-                <var name="defc_a" type="real" dimensions="maxEdges nCells" units="unitless"
-                     description="Coefficients for computing the off-diagonal components of the horizontal deformation"/>
-
-                <var name="defc_b" type="real" dimensions="maxEdges nCells" units="unitless"
-                     description="Coefficients for computing the diagonal components of the horizontal deformation"/>
 
                 <var name="cell_gradient_coef_x" type="real" dimensions="maxEdges nCells" units="m^-1"
                      description="Coefficients for computing the x (zonal) derivative of a cell-centered variable"/>

--- a/src/core_init_atmosphere/mpas_atm_advection.F
+++ b/src/core_init_atmosphere/mpas_atm_advection.F
@@ -756,7 +756,6 @@ module atm_advection
 
 !  local variables
 
-      real (kind=RKIND), dimension(:,:), pointer :: defc_a, defc_b
       real (kind=RKIND), dimension(:,:), pointer :: cell_gradient_coef_x, cell_gradient_coef_y
       integer, dimension(:,:), pointer :: cellsOnEdge, edgesOnCell, cellsOnCell, verticesOnCell
       integer, dimension(:), pointer :: nEdgesOnCell
@@ -778,11 +777,9 @@ module atm_advection
 
       integer :: iv
       logical :: do_the_cell
-      real (kind=RKIND) :: area_cell, sint2, cost2, sint_cost, dx, dy
+      real (kind=RKIND) :: area_cell, dx, dy
 
 
-      call mpas_pool_get_array(mesh, 'defc_a', defc_a)
-      call mpas_pool_get_array(mesh, 'defc_b', defc_b)
       call mpas_pool_get_array(mesh, 'cell_gradient_coef_x', cell_gradient_coef_x)
       call mpas_pool_get_array(mesh, 'cell_gradient_coef_y', cell_gradient_coef_y)
       call mpas_pool_get_array(mesh, 'nEdgesOnCell', nEdgesOnCell)
@@ -796,9 +793,6 @@ module atm_advection
       call mpas_pool_get_array(mesh, 'xVertex', xVertex)
       call mpas_pool_get_array(mesh, 'yVertex', yVertex)
       call mpas_pool_get_array(mesh, 'zVertex', zVertex)
-
-      defc_a(:,:) = 0.
-      defc_b(:,:) = 0.
 
       cell_gradient_coef_x(:,:) = 0.
       cell_gradient_coef_y(:,:) = 0.
@@ -920,18 +914,8 @@ module atm_advection
             ip1 = i+1
             if (ip1 == n) ip1 = 1
             dl = sqrt((xp(ip1)-xp(i))**2 + (yp(ip1)-yp(i))**2)
-            sint2 = (sin(thetat(i)))**2
-            cost2 = (cos(thetat(i)))**2
-            sint_cost = sin(thetat(i))*cos(thetat(i))
-            defc_a(i,iCell) = dl*(cost2 - sint2)/area_cell
-            defc_b(i,iCell) = dl*2.*sint_cost/area_cell
             cell_gradient_coef_x(i,iCell) = dl*cos(thetat(i))/area_cell
             cell_gradient_coef_y(i,iCell) = dl*sin(thetat(i))/area_cell
-            if (cellsOnEdge(1,EdgesOnCell(i,iCell)) /= iCell) then
-               defc_a(i,iCell) = - defc_a(i,iCell)
-               defc_b(i,iCell) = - defc_b(i,iCell)
-            end if
- 
          end do
 
       end do


### PR DESCRIPTION
This PR removes the `defc_a` and `defc_b` fields from the `init_atmosphere` and `atmosphere` cores.

With the introduction of the `deformation_coef_*` fields in merge commit 63f2d449 (PR #1405), the `defc_a` and `defc_b` fields are no longer needed in either the `init_atmosphere` core or the `atmosphere` core. Accordingly, this PR removes the `defc_a` and `defc_b` fields from the `Registry.xml` files as well as from the source code of both of these cores.