### PR TITLE
Fix bugs in the initialization of snow

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_initialize_real.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_initialize_real.F
@@ -699,6 +699,9 @@
           call mpas_log_write('$i $r $r $r', intArgs=(/iCell/), &
                                              realArgs=(/real(landmask(iCell),kind=RKIND),xland(iCell),xice(iCell)/))
        xice(iCell) = 0._RKIND
+       snowc(iCell) = 0._RKIND  ! snow = 0 over water points
+       snowh(iCell) = 0._RKIND   
+       snow(iCell) = 0._RKIND   
     endif
 
  enddo

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -4538,8 +4538,8 @@ module init_atm_cases
                interp_list(2) = W_AVERAGE4
                interp_list(3) = 0
 
-               masked = 0
-               fillval = 0.0
+               ! masked = 0
+               ! fillval = 0.0
 
                nInterpPoints = nCells
                latPoints => latCell


### PR DESCRIPTION
This PR fixes the bug in snow initialization over Arctic Ocean and other areas covered by seaice.

Snow water equivalent (and snow depth, snow cover) in the initial condition of MPAS is always zero over seaice area. This leads to large cold biases of skintemp if MPAS is initialized in winter over the polar region. 

This PR corrects snow initialization, making it physically reasonable over Arctic Ocean and other areas covered by seaice in winter.        
