### PR TITLE
Remove PV diagnostics from default "output" stream in MPAS-Atmosphere

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -917,28 +917,7 @@
 			<var name="ke"/>
 			<var name="uReconstructZonal"/>
 			<var name="uReconstructMeridional"/>
-
-                        <!-- Begin Ertel PV diagnostics defined in diagnostics/Registry_pv.xml -->
-			<var name="ertel_pv"/>
-			<var name="u_pv"/>
-			<var name="v_pv"/>
-			<var name="theta_pv"/>
-			<var name="vort_pv"/>
-			<var name="iLev_DT"/>
 #ifdef DO_PHYSICS
-			<var name="depv_dt_lw"/>
-			<var name="depv_dt_sw"/>
-			<var name="depv_dt_bl"/>
-			<var name="depv_dt_cu"/>
-			<var name="depv_dt_mix"/>
-			<var name="dtheta_dt_mp"/>
-			<var name="depv_dt_mp"/>
-			<var name="depv_dt_diab"/>
-			<var name="depv_dt_fric"/>
-			<var name="depv_dt_diab_pv"/>
-			<var name="depv_dt_fric_pv"/>
-                        <!-- End Ertel PV diagnostics defined in diagnostics/Registry_pv.xml -->
-
 			<var name="i_rainnc"/>
 			<var name="rainnc"/>
 			<var name="precipw"/>


### PR DESCRIPTION
This PR removes the following PV diagnostic fields from the default "output" stream for MPAS-Atmosphere:

 - ertel_pv
 - u_pv
 - v_pv
 - theta_pv
 - vort_pv
 - iLev_DT
 - depv_dt_lw
 - depv_dt_sw
 - depv_dt_bl
 - depv_dt_cu
 - depv_dt_mix
 - dtheta_dt_mp
 - depv_dt_mp
 - depv_dt_diab
 - depv_dt_fric
 - depv_dt_diab_pv
 - depv_dt_fric_pv

These fields may not be of general interest, and so removing them saves space in output files (the "history" netCDF files are ~20% smaller based on testing with a global 60-km mesh).

Additionally, removing these fields from default output streams saves a small amount of computation time, as the logic in the `mpas_pv_diagnostics` module computes these diagnostics only if they are requested in an output stream.