### PR TITLE
Add units for config_mpas_cam_coef in atmosphere Registry.xml

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -299,7 +299,7 @@
                      possible_values="0 $\leq$ config_xnutr $\leq$ 1"/>
 
                 <nml_option name="config_mpas_cam_coef" type="real" default_value="0.0" in_defaults="false"
-                     units="-"
+                     units="m s^{-1}"
                      description="Coefficient for scaling the 2nd-order horizontal mixing in the mpas_cam absorbing layer"
                      possible_values="0 $\leq$ config_mpas_cam_coef $\leq$ 1, standard value is 0.2"/>
 


### PR DESCRIPTION
This PR adjusts the units for `config_mpas_cam_coef` in the Registry.xml for CORE=atmosphere