### PR TITLE
Fix for ESMF link path

### DIFF
--- a/src/core_atmosphere/utils/Makefile
+++ b/src/core_atmosphere/utils/Makefile
@@ -7,7 +7,7 @@ endif
 all: $(UTILS)
 
 build_tables: build_tables.o atmphys_build_tables_thompson.o
-	$(LINKER) $(LDFLAGS) -o build_tables build_tables.o atmphys_build_tables_thompson.o -L../../framework -L../physics -lphys -lframework $(LIBS) $(MPAS_ESMF_LIBS)
+	$(LINKER) $(LDFLAGS) -o build_tables build_tables.o atmphys_build_tables_thompson.o -L../../framework -L../physics -lphys -lframework $(LIBS) $(MPAS_ESMF_LIB)
 	mv build_tables ../../..
 
 


### PR DESCRIPTION
This PR addresses the linking error that arises when building the MPAS atmosphere core with the `nvhpc` compiler in DEBUG mode. 

The incorrect make variable `MPAS_ESMF_LIBS` with `MPAS_ESMF_LIB`, which is the variable defined in the root Makefile.