### PR TITLE
Define new package, `les`, and attach it to the `tke` constituent of var_arrays

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -468,6 +468,9 @@
                 <package name="ugwp_orog_stream" description="Input stream (and variables) for UGWP orography"/>
                 <package name="ugwp_ngw_stream"  description="Input stream (and variables) for UGWP NGW lookup table"/>
                 <package name="ugwp_diags_stream" description="Output stream (and variables) for UGWP output diagnostics"/>
+                <package name="les"
+                         description="Variables and options associated with LES models"
+                         active_when="trim(config_les_model) /= 'none'"/>
         </packages>
 
 
@@ -1757,7 +1760,8 @@
                              packages="mp_thompson_aers_in"/>
 
                         <var name="tke" array_group="turbulence" units="m^2 s^{-2}"
-                             description="Turbulent kinetic energy for the prognostic tke LES scheme"/>
+                             description="Turbulent kinetic energy for the prognostic tke LES scheme"
+                             packages="les"/>
                 </var_array>
 #endif
 
@@ -2123,7 +2127,8 @@
                              packages="mp_thompson_aers_in"/>
 
                         <var name="tend_tke" name_in_code="tke" array_group="turbulence" units="kg m^{-3} m^2 s^{-2} s^{-1}" 
-                             description="Tendency of tke multiplied by dry air density divided by d(zeta)/dz"/>
+                             description="Tendency of tke multiplied by dry air density divided by d(zeta)/dz"
+                             packages="les"/>
                 </var_array>
 #endif
         </var_struct>
@@ -2205,7 +2210,8 @@
 
                         <var name="lbc_tke" name_in_code="tke" array_group="turbulence"
                              units="m^2 s^{-3}"
-                             description="Lateral boundary tendency of TKE"/>
+                             description="Lateral boundary tendency of TKE"
+                             packages="les"/>
                 </var_array>
         </var_struct>
 


### PR DESCRIPTION
This PR defines a new package, `les`, for the atmosphere core, and it attaches this package to the `tke` constituent of the `scalars`, `scalars_tend`, and `lbc_scalars` var_arrays in the atmosphere core's `Registry.xml` file.

The `tke` constituent is only required when an LES model has been selected at runtime (i.e., when `config_les_model = '3d_smagorinsky'` or `config_les_model = 'prognostic_1.5_order'`), and the `les` package is therefore active if and only if `config_les_model` is not `none`.