### PR TITLE
Fix crash in atm_compute_dyn_tend when DO_PHYSICS is not defined in build

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -5025,11 +5025,14 @@ module atm_time_integration
       call mpas_pool_get_array(tend_physics, 'rthdynten', rthdynten)
 
       nullify(ustm)
-      call mpas_pool_get_array(diag_physics,'ustm',ustm)
       nullify(hfx)
-      call mpas_pool_get_array(diag_physics,'hfx',hfx)
       nullify(qfx)
+
+#ifdef DO_PHYSICS
+      call mpas_pool_get_array(diag_physics,'ustm',ustm)
+      call mpas_pool_get_array(diag_physics,'hfx',hfx)
       call mpas_pool_get_array(diag_physics,'qfx',qfx)
+#endif
 
       nopbl = .false.
       if (.not. associated(ustm) &


### PR DESCRIPTION
This PR fixes a crash in the `atm_compute_dyn_tend` routine when `DO_PHYSICS` is not defined in a build of the `atmosphere` core.

When `DO_PHYSICS` is not defined, the `diag_physics` pool/var_struct is not defined in the `Registry.xml` file, leading to a crash in the `atm_compute_dyn_tend` routine when attempting to query `ustm`, `hfx`, or `qfx` from the `diag_physics` pool.

The simple fix in this PR is to guard the calls to `mpas_pool_get_array` for `ustm`, `hfx`, and `qfx` in the `atm_compute_dyn_tend` with preprocessor directives, so that the access of these arrays from the `diag_physics` pool occurs only when `DO_PHYSICS` is defined.

Note that the `atm_compute_dyn_tend` routine already contains logic to accommodate situations in which `ustm`, `hfx`, and `qfx` are not available (because they are allocated only when the either of the `bl_mynn_in` or `bl_ysu_in` packages are active), and so it's only the calls to set pointers to these arrays from the `diag_physics` pool that need to be guarded.