### PR TITLE
Fix calls to mpas_halo_exch_group_full_halo_exch in mpas_halo_testing

### DIFF
--- a/src/core_test/mpas_halo_testing.F
+++ b/src/core_test/mpas_halo_testing.F
@@ -168,7 +168,7 @@ module mpas_halo_testing
       end do
       end do
 
-      call mpas_halo_exch_group_full_halo_exch(domain, 'persistent_group', ierr_local)
+      call mpas_halo_exch_group_full_halo_exch(domain, 'persistent_group', iErr=ierr_local)
       ierr = ior(ierr, ierr_local)
 
       diff = 0.0_RKIND
@@ -228,7 +228,7 @@ module mpas_halo_testing
       end do
       end do
 
-      call mpas_halo_exch_group_full_halo_exch(domain, 'scratch_group', ierr_local)
+      call mpas_halo_exch_group_full_halo_exch(domain, 'scratch_group', iErr=ierr_local)
       ierr = ior(ierr, ierr_local)
 
       diff = 0.0_RKIND


### PR DESCRIPTION
 This PR introduces explicit argument names for the optional argument iErr in calls to `mpas_halo_exch_group_full_halo_exch` in `mpas_halo_testing`.

 The merge of PR #1355 to develop, which introduced an extra optional argument (`withGPUAwareMPI`) to the signature of `mpas_halo_exch_group_full_halo_exch`, broke the build of the test core. This PR fixes the issue by using named arguments when referencing the optional arguments in the function.