### PR TITLE
Fix an issue in snow initialization

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_initialize_real.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_initialize_real.F
@@ -606,6 +606,7 @@
  real(kind=RKIND),pointer:: tsk_seaice_threshold
  real(kind=RKIND),dimension(:),pointer  :: vegfra
  real(kind=RKIND),dimension(:),pointer  :: seaice,snoalb,xice
+ real(kind=RKIND),dimension(:),pointer  :: snow, snowh, snowc
  real(kind=RKIND),dimension(:),pointer  :: skintemp,tmn,xland
  real(kind=RKIND),dimension(:,:),pointer:: tslb,smois,sh2o,smcrel
 
@@ -637,6 +638,9 @@
 
  call mpas_pool_get_array(input, 'seaice', seaice)
  call mpas_pool_get_array(input, 'xice', xice)
+ call mpas_pool_get_array(input, 'snowc', snowc)
+ call mpas_pool_get_array(input, 'snowh', snowh)
+ call mpas_pool_get_array(input, 'snow', snow)
  call mpas_pool_get_array(input, 'vegfra', vegfra)
 
  call mpas_pool_get_array(input, 'skintemp', skintemp)
@@ -699,6 +703,11 @@
           call mpas_log_write('$i $r $r $r', intArgs=(/iCell/), &
                                              realArgs=(/real(landmask(iCell),kind=RKIND),xland(iCell),xice(iCell)/))
        xice(iCell) = 0._RKIND
+       if(landmask(iCell) .eq. 0) then
+          snowc(iCell) = 0._RKIND  ! snow = 0 over water points
+          snowh(iCell) = 0._RKIND
+          snow(iCell) = 0._RKIND
+       endif
     endif
 
  enddo

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -4122,9 +4122,6 @@ module init_atm_cases
                interp_list(2) = W_AVERAGE4
                interp_list(3) = 0
 
-               masked = 0
-               fillval = 0.0
-
                nInterpPoints = nCells
                latPoints => latCell
                lonPoints => lonCell


### PR DESCRIPTION
This PR fixes the bug in snow initialization over Arctic Ocean and other areas covered by seaice.

Snow water equivalent (as well as snow depth and snow cover) in the initial conditions of MPAS is currently set to zero over sea ice areas. This leads to a significant warm bias of skintemp during model integration. When MPAS is initialized in winter, the simulated conditions over polar regions become physically unrealistic.

This PR corrects snow initialization, making it physically reasonable over Arctic Ocean and other areas covered by seaice in winter. 