### PR TITLE
This PR fix the error in PR#1438 

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_initialize_real.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_initialize_real.F
@@ -606,6 +606,7 @@
  real(kind=RKIND),pointer:: tsk_seaice_threshold
  real(kind=RKIND),dimension(:),pointer  :: vegfra
  real(kind=RKIND),dimension(:),pointer  :: seaice,snoalb,xice
+ real(kind=RKIND),dimension(:),pointer  :: snow, snowh, snowc
  real(kind=RKIND),dimension(:),pointer  :: skintemp,tmn,xland
  real(kind=RKIND),dimension(:,:),pointer:: tslb,smois,sh2o,smcrel
 
@@ -637,6 +638,9 @@
 
  call mpas_pool_get_array(input, 'seaice', seaice)
  call mpas_pool_get_array(input, 'xice', xice)
+ call mpas_pool_get_array(input, 'snowc', xice)
+ call mpas_pool_get_array(input, 'snowh', xice)
+ call mpas_pool_get_array(input, 'snow', xice)
  call mpas_pool_get_array(input, 'vegfra', vegfra)
 
  call mpas_pool_get_array(input, 'skintemp', skintemp)
@@ -699,6 +703,9 @@
           call mpas_log_write('$i $r $r $r', intArgs=(/iCell/), &
                                              realArgs=(/real(landmask(iCell),kind=RKIND),xland(iCell),xice(iCell)/))
        xice(iCell) = 0._RKIND
+       snowc(iCell) = 0._RKIND  ! snow = 0 over water points
+       snowh(iCell) = 0._RKIND   
+       snow(iCell) = 0._RKIND   
     endif
 
  enddo

--- a/src/core_atmosphere/physics/mpas_atmphys_initialize_real.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_initialize_real.F
@@ -638,9 +638,9 @@
 
  call mpas_pool_get_array(input, 'seaice', seaice)
  call mpas_pool_get_array(input, 'xice', xice)
- call mpas_pool_get_array(input, 'snowc', xice)
- call mpas_pool_get_array(input, 'snowh', xice)
- call mpas_pool_get_array(input, 'snow', xice)
+ call mpas_pool_get_array(input, 'snowc', snowc)
+ call mpas_pool_get_array(input, 'snowh', snowh)
+ call mpas_pool_get_array(input, 'snow', snow)
  call mpas_pool_get_array(input, 'vegfra', vegfra)
 
  call mpas_pool_get_array(input, 'skintemp', skintemp)
@@ -703,9 +703,11 @@
           call mpas_log_write('$i $r $r $r', intArgs=(/iCell/), &
                                              realArgs=(/real(landmask(iCell),kind=RKIND),xland(iCell),xice(iCell)/))
        xice(iCell) = 0._RKIND
-       snowc(iCell) = 0._RKIND  ! snow = 0 over water points
-       snowh(iCell) = 0._RKIND   
-       snow(iCell) = 0._RKIND   
+       if(landmask(iCell) .eq. 0) then
+          snowc(iCell) = 0._RKIND  ! snow = 0 over water points
+          snowh(iCell) = 0._RKIND   
+          snow(iCell) = 0._RKIND   
+       endif
     endif
 
  enddo

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -4539,9 +4539,6 @@ module init_atm_cases
                interp_list(2) = W_AVERAGE4
                interp_list(3) = 0
 
-               masked = 0
-               fillval = 0.0
-
                nInterpPoints = nCells
                latPoints => latCell
                lonPoints => lonCell


### PR DESCRIPTION
This PR fixes the issue in PR#1438 that all snow information, snow water equivalent(swe), snow depth(snowh), and snow cover(snowc),   over land areas  are removed mistakenly. 

In the initialization of snow over seaice areas, we use xice as a criteria to determine whether snow should exit or not. When xice at a grid cell is smaller than a specified threshold, this grid cell is treated as a water point (swe=0, snowh=0, snowc=0)

However, xice ==0  over land. When using the above approach to determine snow, we mistakenly  remove snow from land areas. 

The present PR  fixes the mistake and results are reasonable. 