### PR TITLE
Fix premature assignment to optional argument before checking existence

### DIFF
--- a/src/framework/mpas_stream_manager.F
+++ b/src/framework/mpas_stream_manager.F
@@ -4073,7 +4073,9 @@ module mpas_stream_manager
         type (MPAS_TimeInterval_type) :: filename_interval
         type (MPAS_Time_type) :: now_time
 
-        ierr = 0
+        if ( present(ierr) ) then
+           ierr = MPAS_STREAM_MGR_NOERR
+        end if
 
         if ( present(blockID) ) then
            blockID_local = blockID


### PR DESCRIPTION
This PR fixes an issue within `mpas_get_stream_filename()` where the optional argument `ierr` was being assigned to before checking if it was passed in.

The routine now checks if `ierr` is present, and if so initializes it to `MPAS_STREAM_MGR_NOERR`.