### PR TITLE
Update config_init_case Registry.xml description to include LES case

### DIFF
--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -65,8 +65,9 @@
                                         7 = real-data initial conditions from, e.g., GFS, \newline
                                         8 = surface field (SST, sea-ice) update file for use with real-data simulations \newline
                                         9 = lateral boundary conditions update file for use with real-data simulations \newline
+                                        10 = idealized LES case \newline
                                         13 = CAM-MPAS 3-d grid with specified topography and zeta levels"
-                     possible_values="1 -- 9, or 13"/>
+                     possible_values="1 -- 10, or 13"/>
 
                 <nml_option name="config_calendar_type" type="character" default_value="gregorian" in_defaults="false"
                      units="-"


### PR DESCRIPTION
This PR updates the `Registry.xml` entry for the `config_init_case` namelist option in the `init_atmosphere` core so that its `description` and `possible_values` attributes reflect the addition of the new LES initialization case (case 10).