### PR TITLE
Fix for parallel reproducibility issue with `3d_smagorinsky`

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -2254,7 +2254,8 @@ module atm_time_integration
                                           edgeThreadStart(thread), edgeThreadEnd(thread), &
                                           cellSolveThreadStart(thread), cellSolveThreadEnd(thread), &
                                           vertexSolveThreadStart(thread), vertexSolveThreadEnd(thread), &
-                                          edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread))
+                                          edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread), &
+                                          domain, config_gpu_aware_mpi, exchange_halo_group)
             end do
 !$OMP END PARALLEL DO
 
@@ -5787,7 +5788,8 @@ module atm_time_integration
 
    subroutine atm_compute_dyn_tend(tend, tend_physics, state, diag, mesh, diag_physics, configs, nVertLevels, rk_step, dynamics_substep, dt, &
                                    cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd, &
-                                   cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd)
+                                   cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd, &
+                                   domain, config_gpu_aware_mpi, exchange_halo_group)
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
    ! Compute height and normal wind tendencies, as well as diagnostic variables
    !
@@ -5820,6 +5822,9 @@ module atm_time_integration
       real (kind=RKIND), intent(in) :: dt
       integer, intent(in) :: cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd
       integer, intent(in) :: cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd
+      type (domain_type), intent(inout) :: domain
+      logical, intent(in) :: config_gpu_aware_mpi
+      procedure (halo_exchange_routine) :: exchange_halo_group
 
       !
       ! Local variables
@@ -6092,7 +6097,8 @@ module atm_time_integration
          config_surface_heat_flux, config_surface_moisture_flux, config_surface_drag_coefficient, &
          rthdynten, ustm, hfx, qfx, &
          cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd, &
-         cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd)
+         cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd, &
+         domain, config_gpu_aware_mpi, exchange_halo_group)
 
          if (nopbl) then
              deallocate(ustm)
@@ -6127,7 +6133,8 @@ module atm_time_integration
       config_surface_heat_flux, config_surface_moisture_flux, config_surface_drag_coefficient, &
       rthdynten, ustm, hfx, qfx, &
       cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd, &
-      cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd)
+      cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd, &
+      domain, config_gpu_aware_mpi, exchange_halo_group)
 
 
       use mpas_atm_dimensions
@@ -6266,6 +6273,9 @@ module atm_time_integration
       integer, intent(in) :: cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd
       integer, intent(in) :: cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd
 
+      type (domain_type), intent(inout) :: domain
+      logical, intent(in) :: config_gpu_aware_mpi
+      procedure (halo_exchange_routine) :: exchange_halo_group
 
       !
       ! Local variables
@@ -6384,6 +6394,10 @@ module atm_time_integration
                              scalars, tend_scalars, index_tke, rho_zz, meshScalingDel2,         &
                              cellStart, cellEnd, nEdgesOnCell, edgesOnCell, cellsOnEdge,        &
                              nCells, nEdges, nVertLevels, maxEdges, num_scalars                )
+
+            !$acc update self(eddy_visc_horz, eddy_visc_vert) if (.not. config_gpu_aware_mpi)
+            call exchange_halo_group(domain, 'dynamics:eddy_visc_horz,eddy_visc_vert', config_gpu_aware_mpi)
+            !$acc update device(eddy_visc_horz, eddy_visc_vert) if (.not. config_gpu_aware_mpi)
 
          end if
 

--- a/src/core_atmosphere/mpas_atm_halos.F
+++ b/src/core_atmosphere/mpas_atm_halos.F
@@ -122,6 +122,9 @@ module mpas_atm_halos
          call mpas_dmpar_exch_group_add_field(domain, 'dynamics:theta_m,pressure_p,rtheta_p', 'rtheta_p', &
                                               timeLevel=1, haloLayers=(/1,2/))
 
+         call mpas_dmpar_exch_group_create(domain, 'dynamics:eddy_visc_horz,eddy_visc_vert')
+         call mpas_dmpar_exch_group_add_field(domain, 'dynamics:eddy_visc_horz,eddy_visc_vert', 'eddy_visc_horz', timeLevel=1, haloLayers=(/1,2/))
+         call mpas_dmpar_exch_group_add_field(domain, 'dynamics:eddy_visc_horz,eddy_visc_vert', 'eddy_visc_vert', timeLevel=1, haloLayers=(/1,2/))
 
          call mpas_dmpar_exch_group_create(domain, 'dynamics:exner')
          call mpas_dmpar_exch_group_add_field(domain, 'dynamics:exner', 'exner', timeLevel=1, haloLayers=(/1,2/))
@@ -243,6 +246,10 @@ module mpas_atm_halos
                                              timeLevel=1, haloLayers=(/1,2/))
          call mpas_halo_exch_group_complete(domain, 'dynamics:theta_m,pressure_p,rtheta_p')
 
+         call mpas_halo_exch_group_create(domain, 'dynamics:eddy_visc_horz,eddy_visc_vert')
+         call mpas_halo_exch_group_add_field(domain, 'dynamics:eddy_visc_horz,eddy_visc_vert', 'eddy_visc_horz', timeLevel=1, haloLayers=(/1,2/))
+         call mpas_halo_exch_group_add_field(domain, 'dynamics:eddy_visc_horz,eddy_visc_vert', 'eddy_visc_vert', timeLevel=1, haloLayers=(/1,2/))
+         call mpas_halo_exch_group_complete(domain, 'dynamics:eddy_visc_horz,eddy_visc_vert')
 
          call mpas_halo_exch_group_create(domain, 'dynamics:exner')
          call mpas_halo_exch_group_add_field(domain, 'dynamics:exner', 'exner', timeLevel=1, haloLayers=(/1,2/))
@@ -367,6 +374,7 @@ module mpas_atm_halos
          call mpas_dmpar_exch_group_destroy(domain, 'dynamics:w,pv_edge,rho_edge,scalars')
          call mpas_dmpar_exch_group_destroy(domain, 'dynamics:theta_m,pressure_p,rtheta_p')
 
+         call mpas_dmpar_exch_group_destroy(domain, 'dynamics:eddy_visc_horz,eddy_visc_vert')
          call mpas_dmpar_exch_group_destroy(domain, 'dynamics:exner')
          call mpas_dmpar_exch_group_destroy(domain, 'dynamics:tend_u')
          call mpas_dmpar_exch_group_destroy(domain, 'dynamics:rho_pp')
@@ -403,6 +411,7 @@ module mpas_atm_halos
          call mpas_halo_exch_group_destroy(domain, 'dynamics:w,pv_edge,rho_edge,scalars')
          call mpas_halo_exch_group_destroy(domain, 'dynamics:theta_m,pressure_p,rtheta_p')
 
+         call mpas_halo_exch_group_destroy(domain, 'dynamics:eddy_visc_horz,eddy_visc_vert')
          call mpas_halo_exch_group_destroy(domain, 'dynamics:exner')
          call mpas_halo_exch_group_destroy(domain, 'dynamics:tend_u')
          call mpas_halo_exch_group_destroy(domain, 'dynamics:rho_pp')


### PR DESCRIPTION
This PR fixes parallel reproducibility issues (For ex, runs with 32 and 64 MPI tasks) when `config_les_model= 3d_smagorinsky`. This issue affects both CPU and GPU runs. This issue does not seem to affect parallel reproducibility when `config_les_model= prognostic_1.5_order`. 

This PR firstly introduces a new halo exchange group in `mpas_atm_halos` in order to perform halo exchanges for the two eddy viscosity fields relevant to LES model runs. This group is added to both `mpas_dmpar` and `mpas_halo` halo exchange methods in `mpas_atm_halos`. Then a halo exchange is performed using this group immediately after the call to `les_models` in `atm_compute_dyn_tend`.


### Background

With trial and error, it was observed that performing halo exchanges of the `eddy_visc_horz` and `eddy_visc_vert` fields, immediately after the call to `les_models` seemed to fix this error. The exact mechanism of this error propagation has not been fully understood yet and would need to be revisited. 

However, the issue originating with `eddy_visc_horz` might involve this [line](https://github.com/MPAS-Dev/MPAS-Model/blob/c0f839d525eaecf8be7ed59cd7f20bf98e716637/src/core_atmosphere/dynamics/mpas_atm_dissipation_models.F#L715). Both serialbox and simpler print debugging point to issues originating from this loop. The max(cell1,cell2) values in the loop seems to exceed `cellEnd`. 

It is also not yet understood why these discrepancies are not observed with `config_les_model= prognostic_1.5_order`
