### PR TITLE
Fix crash in dynamics due to Fortran standard violation

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -5809,7 +5809,7 @@ module atm_time_integration
       ! Dummy arguments
       !
       type (mpas_pool_type), intent(inout) :: tend
-      type (mpas_pool_type), pointer :: tend_physics
+      type (mpas_pool_type), pointer, intent(in) :: tend_physics
       type (mpas_pool_type), intent(in) :: state
       type (mpas_pool_type), intent(in) :: diag
       type (mpas_pool_type), intent(in) :: mesh

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -5813,7 +5813,7 @@ module atm_time_integration
       type (mpas_pool_type), intent(in) :: state
       type (mpas_pool_type), intent(in) :: diag
       type (mpas_pool_type), intent(in) :: mesh
-      type (mpas_pool_type), intent(in) :: diag_physics
+      type (mpas_pool_type), pointer, intent(in) :: diag_physics
       type (mpas_pool_type), intent(in) :: configs
       integer, intent(in) :: nVertLevels              ! for allocating stack variables
       integer, intent(in) :: rk_step, dynamics_substep

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -1918,7 +1918,7 @@ module atm_time_integration
       type (mpas_pool_type), pointer :: diag_physics
       type (mpas_pool_type), pointer :: mesh
       type (mpas_pool_type), pointer :: tend
-      type (mpas_pool_type), pointer :: tend_physics => null()
+      type (mpas_pool_type), pointer :: tend_physics
       type (mpas_pool_type), pointer :: lbc  ! regional_MPAS addition
 
       real (kind=RKIND), dimension(:,:), pointer :: w


### PR DESCRIPTION
At [line 1970](https://github.com/MPAS-Dev/MPAS-Model/blob/v8.4.0/src/core_atmosphere/dynamics/mpas_atm_time_integration.F#L1969-L1971) inside the `atm_srk3` time stepping subroutine, if the `DO_PHYSICS` macro is undefined, the `diag_physics` pointer will not be initialized by the call to `mpas_pool_get_subpool`, and therefore its pointer association status will remain undefined.

However, at [line 2250](https://github.com/MPAS-Dev/MPAS-Model/blob/v8.4.0/src/core_atmosphere/dynamics/mpas_atm_time_integration.F#L2250-L2257), this pointer is used as an actual argument to call `atm_compute_dyn_tend`, which constitutes a Fortran standard violation.

Quoted from Fortran 2023,

> 15.5.2.4 Argument association
> Except in references to intrinsic inquiry functions, a pointer actual argument that corresponds to a nonoptional nonpointer dummy argument shall be pointer associated with a target.

This bug can lead to a runtime crash for models that use MPAS as a dynamical core (e.g., CAM, CAM-SIMA).

Fix this issue by adding the `pointer` attribute to the `diag_physics` dummy argument for the `atm_compute_dyn_tend` subroutine.

In addition, two one-line changes have also been introduced to better conform to the Fortran best practices.