### PR TITLE
Generalize the name of the 'mp_thompson_aers_in' package in init_atmosphere core

### DIFF
--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -385,7 +385,7 @@
                 <package name="met_stage_in" description="Active only if meteorological fields are being interpolated"/>
                 <package name="met_stage_out" description="Active only if meteorological fields are being interpolated"/>
                 <package name="first_guess_field" description="3-d atmospheric or land-surface fields on first-guess levels"/>
-                <package name="mp_thompson_aers_in" description="initialization of GOCART-based Thompson water- and ice-friendly aerosols"/>
+                <package name="microphysics_aerosols" description="Initialization of GOCART-based water- and ice-friendly aerosols for Thompson and TEMPO microphysics"/>
                 <package name="noahmp" description="Whether to process, read, and write static fields only required by Noah-MP"/>
         </packages>
 
@@ -599,7 +599,7 @@
                         <var name="v_init" packages="met_stage_out"/>
                         <var name="t_init" packages="met_stage_out"/>
                         <var name="qv_init" packages="met_stage_out"/>
-                        <var_array name="scalars" packages="met_stage_out;mp_thompson_aers_in"/>
+                        <var_array name="scalars" packages="met_stage_out;microphysics_aerosols"/>
                         <var name="u" packages="met_stage_out"/>
                         <var name="w" packages="met_stage_out"/>
                         <var name="dz" packages="met_stage_out"/>
@@ -1025,15 +1025,15 @@
                 <!-- GOCART aerosol fields -->
                 <var name="nifa_gocart_clim" type="real" dimensions="nMonths nGocartLevels nCells" units="nb kg^{-1}"
                      description="climatological Gocart ice-friendly number concentration"
-                     packages="mp_thompson_aers_in"/>
+                     packages="microphysics_aerosols"/>
 
                 <var name="nwfa_gocart_clim" type="real" dimensions="nMonths nGocartLevels nCells" units="nb kg^{-1}"
                      description="climatological Gocart water-friendly number concentration"
-                     packages="mp_thompson_aers_in"/>
+                     packages="microphysics_aerosols"/>
 
                 <var name="pwif_gocart_clim" type="real"  dimensions="nMonths nGocartLevels nCells" units="Pa"
                      description="climatological Gocart pressure levels"
-                     packages="mp_thompson_aers_in"/>
+                     packages="microphysics_aerosols"/>
 
                 <!-- description of the vertical grid structure -->
                 <var name="hx" type="real" dimensions="nVertLevelsP1 nCells" units="m"
@@ -1166,11 +1166,12 @@
 
                         <var name="nifa" array_group="number" units="nb kg^{-1}"
                              description="Gocart ice-friendly aerosol number concentration"
-                             packages="mp_thompson_aers_in"/>
+                             packages="microphysics_aerosols"/>
 
                         <var name="nwfa" array_group="number" units="nb kg^{-1}"
                              description="Gocart water-friendly aerosol number concentration"
-                             packages="mp_thompson_aers_in"/>
+                             packages="microphysics_aerosols"/>
+
                         <var name="tke" array_group="turbulence" units="m^2 s^{-2}"
                              description="Turbulent kinetic energy for the prognostic tke LES scheme"/>
                 </var_array>
@@ -1210,11 +1211,11 @@
 
                         <var name="lbc_nifa" array_group="number" units="nb kg^{-1}"
                              description="Gocart ice-friendly aerosol number concentration on lateral boundary cells"
-                             packages="mp_thompson_aers_in"/>
+                             packages="microphysics_aerosols"/>
 
                         <var name="lbc_nwfa" array_group="number" units="nb kg^{-1}"
                              description="Gocart water-friendly aerosol number concentration on lateral boundary cells"
-                             packages="mp_thompson_aers_in"/>
+                             packages="microphysics_aerosols"/>
                 </var_array>
 
         </var_struct>

--- a/src/core_init_atmosphere/mpas_init_atm_core_interface.F
+++ b/src/core_init_atmosphere/mpas_init_atm_core_interface.F
@@ -120,7 +120,7 @@ module init_atm_core_interface
       logical, pointer :: config_native_gwd_static, config_static_interp, config_vertical_grid, config_met_interp
       logical, pointer :: config_native_gwd_gsl_static
       logical, pointer :: first_guess_field
-      logical, pointer :: mp_thompson_aers_in
+      logical, pointer :: microphysics_aerosols
       integer, pointer :: config_init_case
       logical, pointer :: noahmp, config_noahmp_static
 
@@ -167,8 +167,8 @@ module init_atm_core_interface
       nullify(met_stage_out)
       call mpas_pool_get_package(packages, 'met_stage_outActive', met_stage_out)
 
-      nullify(mp_thompson_aers_in)
-      call mpas_pool_get_package(packages, 'mp_thompson_aers_inActive', mp_thompson_aers_in)
+      nullify(microphysics_aerosols)
+      call mpas_pool_get_package(packages, 'microphysics_aerosolsActive', microphysics_aerosols)
 
       if (.not. associated(initial_conds) .or. &
           .not. associated(sfc_update) .or. &
@@ -179,7 +179,7 @@ module init_atm_core_interface
           .not. associated(vertical_stage_out) .or. &
           .not. associated(met_stage_in) .or. &
           .not. associated(met_stage_out) .or. &
-          .not. associated(mp_thompson_aers_in)) then
+          .not. associated(microphysics_aerosols)) then
          call mpas_log_write('********************************************************************************', messageType=MPAS_LOG_ERR)
          call mpas_log_write('* Error while setting up packages for init_atmosphere core.',                      messageType=MPAS_LOG_ERR)
          call mpas_log_write('********************************************************************************', messageType=MPAS_LOG_ERR)
@@ -197,12 +197,12 @@ module init_atm_core_interface
 
       if (config_init_case == 9) then
          lbcs = .true.
-         mp_thompson_aers_in = .false.
+         microphysics_aerosols = .false.
          inquire(file="QNWFA_QNIFA_SIGMA_MONTHLY.dat",exist=lexist)
-         if(lexist) mp_thompson_aers_in = .true.
+         if(lexist) microphysics_aerosols = .true.
       else
          lbcs = .false.
-         mp_thompson_aers_in = .false.
+         microphysics_aerosols = .false.
       end if
 
       if (config_init_case == 7) then
@@ -226,9 +226,9 @@ module init_atm_core_interface
                         (.not. config_vertical_grid)
          met_stage_out = config_met_interp
 
-         mp_thompson_aers_in = .false.
+         microphysics_aerosols = .false.
          inquire(file="QNWFA_QNIFA_SIGMA_MONTHLY.dat",exist=lexist)
-         if((lexist .and. met_stage_out) .or. (lexist .and. met_stage_in)) mp_thompson_aers_in = .true.
+         if((lexist .and. met_stage_out) .or. (lexist .and. met_stage_in)) microphysics_aerosols = .true.
 
       else if (config_init_case == 8) then
          gwd_stage_in = .false.
@@ -252,9 +252,9 @@ module init_atm_core_interface
          met_stage_in = .true.
          met_stage_out = .true.
 
-         mp_thompson_aers_in = .false.
+         microphysics_aerosols = .false.
          inquire(file="QNWFA_QNIFA_SIGMA_MONTHLY.dat",exist=lexist)
-         if((lexist .and. met_stage_out) .or. (lexist .and. met_stage_in)) mp_thompson_aers_in = .true.
+         if((lexist .and. met_stage_out) .or. (lexist .and. met_stage_in)) microphysics_aerosols = .true.
 
          initial_conds = .false.   ! Also, turn off the initial_conds package to avoid writing the IC "output" stream
 


### PR DESCRIPTION
This PR generalizes the name of the `mp_thompson_aers_in` package in the `init_atmosphere` core.

The processing of GOCART-based water- and ice-friendly aerosols in the `init_atmosphere` core currently supports only the aerosol-aware Thompson microphysics scheme, but planned additions to MPAS-Atmosphere (specifically, the TEMPO microphysics scheme) will make use of these same aerosol fields. Accordingly, this PR generalizes the name of the `mp_thompson_aers_in` package to `microphysics_aerosols` in the `init_atmosphere` core.