### PR TITLE
Fix small memory leaks

### DIFF
--- a/src/external/ezxml/ezxml.c
+++ b/src/external/ezxml/ezxml.c
@@ -481,6 +481,7 @@ ezxml_t ezxml_parse_str(char *s, size_t len)
     int l, i, j;
 
     root->m = s;
+    root->len = -1; // so we know to free s in ezxml_free()
     if (! len) return ezxml_err(root, NULL, "root tag missing");
     root->u = ezxml_str2utf8(&s, &len); // convert utf-16 to utf-8
     root->e = (root->s = s) + len; // record start and end of work area

--- a/src/framework/mpas_block_creator.F
+++ b/src/framework/mpas_block_creator.F
@@ -249,6 +249,8 @@ module mpas_block_creator
      call mpas_dmpar_alltoall_field(cellsOnCellBlock, cellsOnCell_0Halo, sendingHaloLayers)
      call mpas_dmpar_alltoall_field(verticesOnCellBlock, verticesOnCell_0Halo, sendingHaloLayers)
      call mpas_dmpar_alltoall_field(edgesOnCellBlock, edgesOnCell_0Halo, sendingHaloLayers)
+
+     deallocate(sendingHaloLayers)
    end subroutine mpas_block_creator_build_0halo_cell_fields!}}}
 
 !***********************************************************************

--- a/src/framework/mpas_domain_routines.F
+++ b/src/framework/mpas_domain_routines.F
@@ -46,10 +46,7 @@ module mpas_domain_routines
       allocate(dom % dminfo)
       nullify(dom % blocklist)
 
-      allocate(dom % configs)
-      allocate(dom % packages)
       allocate(dom % clock)
-      allocate(dom % streamManager)
       allocate(dom % ioContext)
 
       call mpas_pool_create_pool(dom % configs)
@@ -87,9 +84,6 @@ module mpas_domain_routines
 
       b % domain => dom
 
-      allocate(b % structs)
-      allocate(b % dimensions)
-      allocate(b % allFields)
       call mpas_pool_create_pool(b % structs)
       call mpas_pool_create_pool(b % dimensions)
       call mpas_pool_create_pool(b % allFields)

--- a/src/framework/mpas_domain_routines.F
+++ b/src/framework/mpas_domain_routines.F
@@ -163,17 +163,17 @@ module mpas_domain_routines
       call mpas_pool_destroy_pool(b % structs)
       call mpas_pool_destroy_pool(b % dimensions)
 
-      deallocate(b % parinfo % cellsToSend)
-      deallocate(b % parinfo % cellsToRecv)
-      deallocate(b % parinfo % cellsToCopy)
+      call mpas_dmpar_destroy_mulithalo_exchange_list(b % parinfo % cellsToSend)
+      call mpas_dmpar_destroy_mulithalo_exchange_list(b % parinfo % cellsToRecv)
+      call mpas_dmpar_destroy_mulithalo_exchange_list(b % parinfo % cellsToCopy)
 
-      deallocate(b % parinfo % edgesToSend)
-      deallocate(b % parinfo % edgesToRecv)
-      deallocate(b % parinfo % edgesToCopy)
+      call mpas_dmpar_destroy_mulithalo_exchange_list(b % parinfo % edgesToSend)
+      call mpas_dmpar_destroy_mulithalo_exchange_list(b % parinfo % edgesToRecv)
+      call mpas_dmpar_destroy_mulithalo_exchange_list(b % parinfo % edgesToCopy)
 
-      deallocate(b % parinfo % verticesToSend)
-      deallocate(b % parinfo % verticesToRecv)
-      deallocate(b % parinfo % verticesToCopy)
+      call mpas_dmpar_destroy_mulithalo_exchange_list(b % parinfo % verticesToSend)
+      call mpas_dmpar_destroy_mulithalo_exchange_list(b % parinfo % verticesToRecv)
+      call mpas_dmpar_destroy_mulithalo_exchange_list(b % parinfo % verticesToCopy)
 
       deallocate(b % parinfo)
 

--- a/src/framework/mpas_domain_routines.F
+++ b/src/framework/mpas_domain_routines.F
@@ -138,6 +138,8 @@ module mpas_domain_routines
       deallocate(dom % clock)
       deallocate(dom % ioContext)
 
+      deallocate(dom % dminfo)
+
    end subroutine mpas_deallocate_domain!}}}
 
 

--- a/src/framework/mpas_framework.F
+++ b/src/framework/mpas_framework.F
@@ -65,7 +65,6 @@ module mpas_framework
       integer, intent(in), optional :: external_comm
 #endif
 
-      allocate(dminfo)
       call mpas_dmpar_init(dminfo, external_comm)
 
    end subroutine mpas_framework_init_phase1!}}}
@@ -182,13 +181,13 @@ module mpas_framework
 
       call MPAS_io_finalize(domain % ioContext, .false.)
 
-      call mpas_deallocate_domain(domain)
-
       call mpas_dmpar_finalize(dminfo)
 
       call mpas_finish_block_proc_list(dminfo)
 
       call mpas_timekeeping_finalize()
+
+      call mpas_deallocate_domain(domain)
 
    end subroutine mpas_framework_finalize!}}}
 

--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -1256,6 +1256,7 @@ module mpas_io
             ! TODO: Can we get the dimension sizes to see whether they match those from the file?
    
          end if
+         if (associated(inq_dimnames)) deallocate(inq_dimnames)
 
          return
       end if

--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -210,7 +210,6 @@ module mpas_io
 #endif
 
 #ifdef MPAS_SMIOL_SUPPORT
-         allocate(ioContext % smiol_context)
 #ifdef MPAS_USE_MPI_F08
          local_ierr = SMIOLf_init(ioContext % dminfo % comm % mpi_val, &
 #else

--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -6344,6 +6344,7 @@ module mpas_io
          deallocate(fieldlist_del % fieldhandle % dims)
 
          deallocate(fieldlist_del % fieldhandle)
+         deallocate(fieldlist_del)
       end do
       nullify(handle % fieldlist_head)
       nullify(handle % fieldlist_tail)
@@ -6353,6 +6354,7 @@ module mpas_io
          dimlist_del => dimlist_ptr 
          dimlist_ptr => dimlist_ptr % next
          deallocate(dimlist_del % dimhandle)
+         deallocate(dimlist_del)
       end do
       nullify(handle % dimlist_head)
       nullify(handle % dimlist_tail)

--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -6336,6 +6336,7 @@ module mpas_io
             if (attlist_del % atthandle % attType == MPAS_ATT_INTA) deallocate(attlist_del % atthandle % attValueIntA)
             if (attlist_del % atthandle % attType == MPAS_ATT_REALA) deallocate(attlist_del % atthandle % attValueRealA)
             deallocate(attlist_del % atthandle)
+            deallocate(attlist_del)
          end do
          nullify(fieldlist_del % fieldhandle % attlist_head)
          nullify(fieldlist_del % fieldhandle % attlist_tail)
@@ -6363,6 +6364,7 @@ module mpas_io
          if (attlist_del % atthandle % attType == MPAS_ATT_INTA) deallocate(attlist_del % atthandle % attValueIntA)
          if (attlist_del % atthandle % attType == MPAS_ATT_REALA) deallocate(attlist_del % atthandle % attValueRealA)
          deallocate(attlist_del % atthandle)
+         deallocate(attlist_del)
       end do
       nullify(handle % attlist_head)
       nullify(handle % attlist_tail)

--- a/src/framework/mpas_pool_routines.F
+++ b/src/framework/mpas_pool_routines.F
@@ -229,6 +229,14 @@ module mpas_pool_routines
                      deallocate(ptr % data % simple_int)
                   end if
    
+               else if (ptr % contentsType == MPAS_POOL_PACKAGE) then
+   
+                  dptr => ptr % data
+   
+                  if (dptr % contentsType == MPAS_POOL_LOGICAL) then
+                     deallocate(dptr % simple_logical)
+                  end if
+   
                else if (ptr % contentsType == MPAS_POOL_CONFIG) then
    
                   dptr => ptr % data

--- a/src/framework/mpas_pool_routines.F
+++ b/src/framework/mpas_pool_routines.F
@@ -5795,6 +5795,7 @@ module mpas_pool_routines
                      end if
 
 !TODO: are there cases where we need to delete more data here?
+                     if (associated(ptr_prev % data)) deallocate(ptr_prev % data)
                      deallocate(ptr_prev)
                   end if
                   pool_remove_member = .true.
@@ -5828,6 +5829,7 @@ module mpas_pool_routines
                         end if
 
 !TODO: are there cases where we need to delete more data here?
+                        if (associated(ptr % data)) deallocate(ptr % data)
                         deallocate(ptr)
                      end if
                      pool_remove_member = .true.

--- a/src/framework/mpas_stream_manager.F
+++ b/src/framework/mpas_stream_manager.F
@@ -246,6 +246,19 @@ module mpas_stream_manager
            end if
 
            !
+           ! Remove all items from manager % alarms_in(put) list
+           !
+           stream_cursor => manager % alarms_in % head
+           do while (associated(stream_cursor))
+               call MPAS_stream_list_destroy(stream_cursor % streamList, ierr=err_local)
+               if (err_local /= MPAS_STREAM_LIST_NOERR) then
+                   if (present(ierr)) ierr = MPAS_STREAM_MGR_ERROR
+                   STREAM_ERROR_WRITE('Problems while destroying input alarms item')
+               end if
+               stream_cursor => stream_cursor % next
+           end do
+
+           !
            ! Free up list of input alarms
            !
            call MPAS_stream_list_destroy(manager % alarms_in, ierr=err_local)
@@ -253,6 +266,19 @@ module mpas_stream_manager
                if (present(ierr)) ierr = MPAS_STREAM_MGR_ERROR
                STREAM_ERROR_WRITE('Problems while destroying input alarms list')
            end if
+
+           !
+           ! Remove all items from manager % alarms_out(put) list
+           !
+           stream_cursor => manager % alarms_out % head
+           do while (associated(stream_cursor))
+               call MPAS_stream_list_destroy(stream_cursor % streamList, ierr=err_local)
+               if (err_local /= MPAS_STREAM_LIST_NOERR) then
+                   if (present(ierr)) ierr = MPAS_STREAM_MGR_ERROR
+                   STREAM_ERROR_WRITE('Problems while destroying output alarms list')
+               end if
+               stream_cursor => stream_cursor % next
+           end do
 
            !
            ! Free up list of output alarms

--- a/src/framework/xml_stream_parser.c
+++ b/src/framework/xml_stream_parser.c
@@ -1057,7 +1057,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 	const char *streamID2, *interval_in2, *interval_out2;
 	char interval_name[256];
 	char match_stream_name[256];
-	char *packages, *package;
+	char *packages, *packages_ptr, *package;
 	char filename_interval_string[256];
 	char ref_time_local[256];
 	char rec_intv_local[256];
@@ -1379,6 +1379,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 		if (packagelist != NULL) {
 
 			packages = strdup(packagelist);
+			packages_ptr = packages;
 			package = strsep(&packages, ";");
 
 			stream_mgr_add_pkg_c(manager, streamID, package, &err);
@@ -1403,7 +1404,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 				}
 			}
 
-			free(packages);
+			free(packages_ptr);
 		}
 	}
 
@@ -1688,6 +1689,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 		if (packagelist != NULL) {
 
 			packages = strdup(packagelist);
+			packages_ptr = packages;
 			package = strsep(&packages, ";");
 
 			stream_mgr_add_pkg_c(manager, streamID, package, &err);
@@ -1712,7 +1714,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 				}
 			}
 
-			free(packages);
+			free(packages_ptr);
 		}
 
 		for (varfile_xml = ezxml_child(stream_xml, "file"); varfile_xml; varfile_xml = ezxml_next(varfile_xml)) {

--- a/src/tools/registry/gen_inc.c
+++ b/src/tools/registry/gen_inc.c
@@ -1086,6 +1086,7 @@ int parse_dimensions_from_registry(ezxml_t registry)/*{{{*/
 				}
 				fortprintf(fd, "         call mpas_pool_add_dimension(dimensionPool, '%s', %s)\n", dimname, dimname);
 
+				fortprintf(fd, "         deallocate(%s)\n", dimname);
 				fortprintf(fd, "          else if ( %s == MPAS_MISSING_DIM ) then\n", dimname, dimname);
 				// Namelist defined dimension
 				if(strncmp(dimdef, "namelist:", 9) == 0){
@@ -1101,6 +1102,7 @@ int parse_dimensions_from_registry(ezxml_t registry)/*{{{*/
 				fortprintf(fd, "         allocate(%s)\n", dimname);
 				fortprintf(fd, "         %s = MPAS_MISSING_DIM\n", dimname);
 				fortprintf(fd, "         call mpas_pool_add_dimension(dimensionPool, '%s', %s)\n", dimname, dimname);
+				fortprintf(fd, "         deallocate(%s)\n", dimname);
 				fortprintf(fd, "      end if\n\n");
 			}
 		}


### PR DESCRIPTION
This PR fixes small memory leaks in various parts of the model, mostly within the framework. I ran the model compiled with the address sanitizer compiler flag and noticed hundreds of memory leak reports. All of them are located in the code executed during initialization, and they do not contribute to ever increasing memory consumption during model execution. So fixing them is not critical. Major benefit is cleaning up the log file to make it easier to spot potential real memory leaks.

Here is the initial sanitizer log file, showing all leaks originating in the model code. I suppressed leaks from the MPI library and several leaks originating in the ezxml library.

[dev_leak.0.txt](https://github.com/user-attachments/files/27493550/dev_leak.0.txt)

