### PR TITLE
Limit the saturation vapor pressure e_s used in the Kessler microphysics

### DIFF
--- a/src/core_atmosphere/physics/physics_wrf/module_mp_kessler.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_mp_kessler.F
@@ -216,6 +216,7 @@ CONTAINS
        gam = 2.5e+06/(1004.*pii(i,k,j))
 !      qvs       = 380.*exp(17.27*(temp-273.)/(temp- 36.))/pressure
        es        = 1000.*svp1*exp(svp2*(temp-svpt0)/(temp-svp3))
+       es        = min(es, 0.99*pressure)
        qvs       = ep2*es/(pressure-es)
 !      prod(i,k,j) = (qv(i,k,j)-qvs) / (1.+qvs*f5/(temp-36.)**2)
        prod(i,k,j) = (qv(i,k,j)-qvs) / (1.+pressure/(pressure-es)*qvs*f5/(temp-svp3)**2)


### PR DESCRIPTION
This PR limits the saturation vapor pressure, `e_s`, used in the Kessler microphysics to a value at or below 99% of the full pressure. In the previous version of Kessler the saturation vapor pressure formula could produce unphysically large values of `e_s` at very low pressures (high model top) and cause the model to blow up.