### PR TITLE
Added SST field to mpas_init_atm_cases.F

### DIFF
--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -3585,6 +3585,7 @@ module init_atm_cases
              trim(field % field) == 'PRESSURE' .or. &
              trim(field % field) == 'SNOW' .or. &
              trim(field % field) == 'SEAICE' .or. &
+             trim(field % field) == 'SST' .or. &
              trim(field % field) == 'SKINTEMP') then
 
             if (trim(field % field) == 'SM000010' .or. &
@@ -4560,6 +4561,13 @@ module init_atm_cases
                latPoints => latCell
                lonPoints => lonCell
                call mpas_pool_get_array(fg, 'xice', destField1d)
+               ndims = 1
+            else if (trim(field % field) == 'SST') then
+               call mpas_log_write('Interpolating SST')
+               nInterpPoints = nCells
+               latPoints => latCell
+               lonPoints => lonCell
+               call mpas_pool_get_array(fg, 'sst', destField1d)
                ndims = 1
             else if (trim(field % field) == 'SKINTEMP') then
                call mpas_log_write('Interpolating SKINTEMP')

--- a/src/core_init_atmosphere/mpas_init_atm_surface.F
+++ b/src/core_init_atmosphere/mpas_init_atm_surface.F
@@ -213,7 +213,7 @@
  do while (istatus == 0)
 
     !sea-surface data:
-    if((trim(field % field) == 'SKINTEMP') .or. (trim(field % field) ==  'SST')) then
+    if(trim(field % field) ==  'SST') then
 !      call mpas_log_write('... Processing SST:')
        sst(1:nCells) = 0.0_RKIND
        destField1d => sst


### PR DESCRIPTION

The title above should be a 1 line short summary of the pull request (i.e. what the project the PR represents is intended to do).

Enter a description of this PR. This should include why this PR was created, and what it does.

This allows sea surface temperatures to be ingested in to
init files. Previously, SSTs were not read in from intermediate files. Therefore, all SSTs defaulted to the
skin temperature, which produced unphysically
cold SST values in the Arctic, where the skin
temperature above sea ice is well below freezing. Additionally, modified mpas_init_atm_surface.F such that SST update files must be made with SSTs, rather than either SSTs or skintemps.

A more in depth discussion of this issue and solution can be found in the mpas forum at https://forum.mmm.ucar.edu/threads/sst-bias-underneath-sea-ice.25524/page-2#post-61310

Testing and relations to other Pull Requests should be added as subsequent comments.

See the below examples for more information.
https://github.com/MPAS-Dev/MPAS/pull/930
https://github.com/MPAS-Dev/MPAS/pull/931

