### PR TITLE
Implementation of MYNN-EDMF and MYNN-SFC submodules

### DIFF
--- a/src/core_atmosphere/CMakeLists.txt
+++ b/src/core_atmosphere/CMakeLists.txt
@@ -138,6 +138,29 @@ set(ATMOSPHERE_CORE_PHYSICS_NOAA_SOURCES
 
 list(TRANSFORM ATMOSPHERE_CORE_PHYSICS_NOAA_SOURCES PREPEND physics/physics_noaa/UGWP/)
 
+set(ATMOSPHERE_CORE_PHYSICS_MYNN-EDMF_DIR ${CMAKE_CURRENT_SOURCE_DIR}/physics/physics_noaa/MYNN-EDMF)
+
+if(NOT EXISTS ${ATMOSPHERE_CORE_PHYSICS_MYNN-EDMF_DIR})
+    set(PHYSICS_MYNN-EDMF_REPO_URL "https://github.com/NCAR/MYNN-EDMF.git")
+    execute_process(COMMAND git clone ${PHYSICS_MYNN-EDMF_REPO_URL} ${ATMOSPHERE_CORE_PHYSICS_MYNN-EDMF_DIR}
+                    RESULT_VARIABLE GIT_CLONE_RESULT
+                    OUTPUT_VARIABLE GIT_CLONE_OUTPUT
+                    ERROR_VARIABLE GIT_CLONE_ERROR)
+    if(NOT GIT_CLONE_RESULT EQUAL 0)
+        message(FATAL_ERROR "Git clone failed with error: ${GIT_CLONE_ERROR}")
+    endif()
+
+else()
+    message(STATUS "Directory ${DIR_TO_CHECK} already exists, skipping clone")
+endif()
+
+set(ATMOSPHERE_CORE_PHYSICS_MYNN-EDMF_SOURCES
+    module_bl_mynnedmf.F90
+    MPAS/module_bl_mynnedmf_common.F90
+    MPAS/module_bl_mynnedmf_driver.F90
+)
+list(TRANSFORM ATMOSPHERE_CORE_PHYSICS_MYNN-EDMF_SOURCES PREPEND physics/physics_noaa/MYNN-EDMF/)
+
 set(ATMOSPHERE_CORE_PHYSICS_NOAMP_UTILITY_SOURCES
     CheckNanMod.F90
     Machine.F90

--- a/src/core_atmosphere/CMakeLists.txt
+++ b/src/core_atmosphere/CMakeLists.txt
@@ -155,9 +155,9 @@ else()
 endif()
 
 set(ATMOSPHERE_CORE_PHYSICS_MYNN-EDMF_SOURCES
-    module_bl_mynnedmf.F90
-    MPAS/module_bl_mynnedmf_common.F90
-    MPAS/module_bl_mynnedmf_driver.F90
+    src/module_bl_mynnedmf.F90
+    src/MPAS/module_bl_mynnedmf_common.F90
+    src/module_bl_mynnedmf_driver.F90
 )
 list(TRANSFORM ATMOSPHERE_CORE_PHYSICS_MYNN-EDMF_SOURCES PREPEND physics/physics_noaa/MYNN-EDMF/)
 

--- a/src/core_atmosphere/CMakeLists.txt
+++ b/src/core_atmosphere/CMakeLists.txt
@@ -161,6 +161,31 @@ set(ATMOSPHERE_CORE_PHYSICS_MYNN-EDMF_SOURCES
 )
 list(TRANSFORM ATMOSPHERE_CORE_PHYSICS_MYNN-EDMF_SOURCES PREPEND physics/physics_noaa/MYNN-EDMF/)
 
+set(ATMOSPHERE_CORE_PHYSICS_MYNN-SFC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/physics/physics_noaa/MYNN-SFC)
+
+if(NOT EXISTS ${ATMOSPHERE_CORE_PHYSICS_MYNN-SFC_DIR})
+    set(PHYSICS_MYNN-SFC_REPO_URL "https://github.com/NCAR/MYNN-SFC.git")
+    execute_process(COMMAND git clone ${PHYSICS_MYNN-SFC_REPO_URL} ${ATMOSPHERE_CORE_PHYSICS_MYNN-SFC_DIR}
+                    RESULT_VARIABLE GIT_CLONE_RESULT
+                    OUTPUT_VARIABLE GIT_CLONE_OUTPUT
+                    ERROR_VARIABLE GIT_CLONE_ERROR)
+    if(NOT GIT_CLONE_RESULT EQUAL 0)
+        message(FATAL_ERROR "Git clone failed with error: ${GIT_CLONE_ERROR}")
+    endif()
+
+else()
+    message(STATUS "Directory ${DIR_TO_CHECK} already exists, skipping clone")
+endif()
+
+set(ATMOSPHERE_CORE_PHYSICS_MYNN-SFC_SOURCES
+    module_sf_mynnsfc_land.F90
+    module_sf_mynnsfc_water.F90
+    module_sf_mynnsfc_ice.F90
+    MPAS/module_sf_mynnsfc_common.F90
+    MPAS/module_sf_mynnsfc_driver.F90
+)
+list(TRANSFORM ATMOSPHERE_CORE_PHYSICS_MYNN-SFC_SOURCES PREPEND physics/physics_noaa/MYNN-SFC/)
+
 set(ATMOSPHERE_CORE_PHYSICS_NOAMP_UTILITY_SOURCES
     CheckNanMod.F90
     Machine.F90

--- a/src/core_atmosphere/Externals.cfg
+++ b/src/core_atmosphere/Externals.cfg
@@ -20,10 +20,10 @@ tag = v6.0.2
 required = True
 
 [MYNN-SFC]
-> local_path = ./physics_noaa/MYNN-SFC
-> protocol = git
-> repo_url = https://github.com/NCAR/MYNN-SFC.git
-> tag = v6.0.0
+local_path = ./physics_noaa/MYNN-SFC
+protocol = git
+repo_url = https://github.com/NCAR/MYNN-SFC.git
+tag = v6.0.0
 required = True
 
 [externals_description]

--- a/src/core_atmosphere/Externals.cfg
+++ b/src/core_atmosphere/Externals.cfg
@@ -16,7 +16,7 @@ required = True
 local_path = ./physics_noaa/MYNN-EDMF
 protocol = git
 repo_url = https://github.com/NCAR/MYNN-EDMF.git
-tag = v6.0.2
+tag = v6.0.3
 required = True
 
 [MYNN-SFC]

--- a/src/core_atmosphere/Externals.cfg
+++ b/src/core_atmosphere/Externals.cfg
@@ -19,5 +19,12 @@ repo_url = https://github.com/NCAR/MYNN-EDMF.git
 tag = v6.0.2
 required = True
 
+[MYNN-SFC]
+> local_path = ./physics_noaa/MYNN-SFC
+> protocol = git
+> repo_url = https://github.com/NCAR/MYNN-SFC.git
+> tag = v6.0.0
+required = True
+
 [externals_description]
 schema_version = 1.0.0

--- a/src/core_atmosphere/Externals.cfg
+++ b/src/core_atmosphere/Externals.cfg
@@ -16,7 +16,7 @@ required = True
 local_path = ./physics_noaa/MYNN-EDMF
 protocol = git
 repo_url = https://github.com/NCAR/MYNN-EDMF.git
-tag = v6.0.3
+tag = v6.0.4
 required = True
 
 [MYNN-SFC]

--- a/src/core_atmosphere/Externals.cfg
+++ b/src/core_atmosphere/Externals.cfg
@@ -12,5 +12,12 @@ repo_url = https://github.com/NOAA-GSL/UGWP.git
 tag = MPAS_20241223
 required = True
 
+[MYNN-EDMF]
+local_path = ./physics_noaa/MYNN-EDMF
+protocol = git
+repo_url = https://github.com/NCAR/MYNN-EDMF.git
+tag = v6.0.2
+required = True
+
 [externals_description]
 schema_version = 1.0.0

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -2566,7 +2566,7 @@
                      description="=0:activatevmixing of moisture species separately;= 1:activate mixing of total water in the mynn PBL scheme"
                      possible_values="0(keep=0),1"/>
 
-		<nml_option name="config_mynn_ess" type="integer" default_value="1" in_defaults="false"
+		<nml_option name="config_mynn_ess" type="integer" default_value="0" in_defaults="false"
                      units="-"
                      description="=0:use buoyancy-flux functions;= 1:use O-Gorman (2011)"
                      possible_values="0,1"/>

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -3037,6 +3037,10 @@
                      description="surface exchange coefficient for heat and moisture"
                      packages="sfclayer"/>
 
+		<var name="cqs" type="real" dimensions="nCells Time" units="m s^{-1}"
+                     description="surface exchange coefficient for moisture (mynn/ruc)"
+                     packages="sfclayer"/>
+
                 <var name="chs2" type="real" dimensions="nCells Time" units="m s^{-1}"
                      description="surface exchange coefficient for heat at 2-meter"
                      packages="sfclayer"/>

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -2906,43 +2906,43 @@
 
                 <var name="edmf_a" type="real" dimensions="nVertLevels nCells Time" units="unitless"
                      description="EDMF relative updraft area of moist updrafts in the MYNN PBL scheme"
-                     packages="bl_mynn_in;bl_mynnedmf_tkebudget_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_output_in"/>
 
                 <var name="edmf_w" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
                      description="EDMF vertical velocity of  moist updrafts in the MYNN PBL scheme"
-                     packages="bl_mynn_in;bl_mynnedmf_tkebudget_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_output_in"/>
 
                 <var name="edmf_qt" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1}"
                      description="EDMF total water mixing ratio in moist updrafts in the MYNN PBL scheme"
-                     packages="bl_mynn_in;bl_mynnedmf_tkebudget_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_output_in"/>
 
                 <var name="edmf_qc" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1}"
                      description="EDMF liquid water mixing ratio in moist updrafts in the MYNN PBL scheme"
-                     packages="bl_mynn_in;bl_mynnedmf_tkebudget_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_output_in"/>
 
                 <var name="edmf_thl" type="real" dimensions="nVertLevels nCells Time" units="K"
                      description="EDMF liquid-ice water potential temperature in moist updrafts in the MYNN PBL scheme"
-                     packages="bl_mynn_in;bl_mynnedmf_tkebudget_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_output_in"/>
 
                 <var name="edmf_ent" type="real" dimensions="nVertLevels nCells Time" units="m^{-1}"
                      description="EDMF entrainment rate in moist updrafts in the MYNN PBL scheme"
-                     packages="bl_mynn_in;bl_mynnedmf_tkebudget_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_output_in"/>
 
                 <var name="sub_thl" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
                      description="EDMF subsidence of liquid-ice potential temperature in the MYNN PBL scheme"
-                     packages="bl_mynn_in;bl_mynnedmf_tkebudget_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_output_in"/>
 
                 <var name="sub_qv" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
                      description="EDMF subsidence of water vapor mixing ratio in the MYNN PBL scheme"
-                     packages="bl_mynn_in;bl_mynnedmf_tkebudget_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_output_in"/>
 
                 <var name="det_thl" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
                      description="EDMF detrainment of liquid-ice potential temperature in the MYNN PBL scheme"
-                     packages="bl_mynn_in;bl_mynnedmf_tkebudget_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_output_in"/>
 
                 <var name="det_qv" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
                      description="EDMF detrainment of water vapor mixing ratio in the MYNN PBL scheme"
-                     packages="bl_mynn_in;bl_mynnedmf_tkebudget_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_output_in"/>
 
 		<var name="maxmf" type="real" dimensions="nCells Time" units="m s^{-1}"
                      description="Maximum mass flux in the each column"

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -2568,11 +2568,6 @@
                      description="=0:use buoyancy-flux functions;= 1:use O-Gorman (2011)"
                      possible_values="0,1"/>
 
-                <nml_option name="config_icloud_bl" type="integer" default_value="1" in_defaults="false"
-                     units="-"
-                     description="configuration for MYNN subgrid cloud coupling to radiation"
-                     possible_values="`0: uncoupled',`1: coupled'"/>
-
                 <nml_option name="config_spp_pbl" type="integer" default_value="0" in_defaults="false"
                      units="-"
                      description="configuration for spp boundary layer"

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -473,6 +473,9 @@
                 <package name="cu_ntiedtke_in" description="parameterization of Tiedtke convection."/>
                 <package name="bl_ysu_in" description="parameterization of YSU Planetary Boundary Layer."/>
                 <package name="bl_mynn_in" description="parameterization of MYNN Planetary Boundary Layer."/>
+                <package name="bl_mynnedmf_in" description="parameterization of MYNN-EDMF Planetary Boundary Layer."/>
+                <package name="bl_mynnedmf_tkebudget_in" description="TKE budget variables for output in MYNN-EDMF."/>
+                <package name="bl_mynnedmf_output_in" description="additional diagnostic variables output in MYNN-EDMF."/>
                 <package name="sf_noahmp_in" description="parameterization of NOAH-MP land surface scheme."/>
 
                 <package name="iau" description="Incremental Analysis Update"/>
@@ -1121,6 +1124,20 @@
 			<var name="q2"/>
 			<var name="t2m"/>
 			<var name="th2m"/>
+			<var name="cldfrac_bl"/>
+                        <var name="qc_bl"/>
+                        <var name="qi_bl"/>
+			<var name="maxmf"/>
+                        <var name="maxwidth"/>
+                        <var name="ztop_plume"/>
+			<var name="excess_h"/>
+                        <var name="excess_q"/>
+                        <var name="maxmf_dd"/>
+                        <var name="maxwidth_dd"/>
+                        <var name="maxtkeprod_dd"/>
+			<var name="cldtop_cooling"/>
+                        <var name="ent_eff"/>
+                        <var name="hpbl"/>
 #endif
 
                         <!-- Begin convective diagnostics defined in diagnostics/Registry_convective.xml -->
@@ -1271,6 +1288,20 @@
 			<var name="refl10cm_max"/>
 			<var name="rainc"/>
 			<var name="rainnc"/>
+			<var name="sh3d"/>
+                        <var name="sm3d"/>
+                        <var name="qke"/>
+                        <var name="qke_adv"/>
+                        <var name="cov"/>
+                        <var name="qsq"/>
+                        <var name="tsq"/>
+                        <var name="el_pbl"/>
+			<var name="cldfrac_bl"/>
+                        <var name="qc_bl"/>
+                        <var name="qi_bl"/>
+                        <var name="ch"/>
+                        <var name="kpbl"/>
+                        <var name="hpbl"/>
 			<var name="lai"/>
 			<var name="isice_lu"/>
 			<var name="iswater_lu"/>
@@ -1701,7 +1732,7 @@
 
                         <var name="qc" array_group="moist" units="kg kg^{-1}"
                              description="Cloud water mixing ratio"
-                             packages="bl_mynn_in;bl_ysu_in;cu_ntiedtke_in;mp_kessler_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
+                             packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in;cu_ntiedtke_in;mp_kessler_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
 
                         <var name="qr" array_group="moist" units="kg kg^{-1}"
                              description="Rain water mixing ratio"
@@ -1709,11 +1740,11 @@
 
                         <var name="qi" array_group="moist" units="kg kg^{-1}"
                              description="Ice mixing ratio"
-                             packages="bl_mynn_in;bl_ysu_in;cu_ntiedtke_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
+                             packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in;cu_ntiedtke_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
 
                         <var name="qs" array_group="moist" units="kg kg^{-1}"
                              description="Snow mixing ratio"
-                             packages="bl_mynn_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
+                             packages="bl_mynn_in;bl_mynnedmf_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
 
                         <var name="qg" array_group="moist" units="kg kg^{-1}"
                              description="Graupel mixing ratio"
@@ -1721,7 +1752,7 @@
 
                         <var name="ni" array_group="number" units="nb kg^{-1}"
                              description="Cloud ice number concentration"
-                             packages="bl_mynn_in;mp_thompson_in;mp_thompson_aers_in"/>
+                             packages="bl_mynn_in;bl_mynnedmf_in;mp_thompson_in;mp_thompson_aers_in"/>
 
                         <var name="nr" array_group="number" units="nb kg^{-1}"
                              description="Rain number concentration"
@@ -2068,7 +2099,7 @@
 
                         <var name="tend_qc" name_in_code="qc" array_group="moist" units="kg m^{-3} s^{-1}"
                              description="Tendency of cloud water mass per unit volume divided by d(zeta)/dz"
-                             packages="bl_mynn_in;bl_ysu_in;cu_ntiedtke_in;mp_kessler_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
+                             packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in;cu_ntiedtke_in;mp_kessler_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
 
                         <var name="tend_qr" name_in_code="qr" array_group="moist" units="kg m^{-3} s^{-1}"
                              description="Tendency of rain water mass per unit volume divided by d(zeta)/dz"
@@ -2076,11 +2107,11 @@
 
                         <var name="tend_qi" name_in_code="qi" array_group="moist" units="kg m^{-3} s^{-1}"
                              description="Tendency of ice mass per unit volume divided by d(zeta)/dz"
-                             packages="bl_mynn_in;bl_ysu_in;cu_ntiedtke_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
+                             packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in;cu_ntiedtke_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
 
                         <var name="tend_qs" name_in_code="qs" array_group="moist" units="kg m^{-3} s^{-1}"
                              description="Tendency of snow mass per unit volume divided by d(zeta)/dz"
-                             packages="bl_mynn_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
+                             packages="bl_mynn_in;bl_mynnedmf_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
 
                         <var name="tend_qg" name_in_code="qg" array_group="moist" units="kg m^{-3} s^{-1}"
                              description="Tendency of graupel mass per unit volume divided by d(zeta)/dz"
@@ -2088,7 +2119,7 @@
 
                         <var name="tend_ni" name_in_code="ni" array_group="number" units="nb m^{-3} s^{-1}"
                              description="Tendency of cloud ice number concentration multiplied by dry air density divided by d(zeta)/dz"
-                             packages="bl_mynn_in;mp_thompson_in;mp_thompson_aers_in"/>
+                             packages="bl_mynn_in;bl_mynnedmf_in;mp_thompson_in;mp_thompson_aers_in"/>
 
                         <var name="tend_nr" name_in_code="nr" array_group="number" units="nb m^{-3} s^{-1}" 
                              description="Tendency of rain number concentration multiplied by dry air density divided by d(zeta)/dz"
@@ -2148,7 +2179,7 @@
                              units="kg kg^{-1} s^{-1}"
                              description="Lateral boundary tendency of water vapor mixing ratio"/>
 
-                        <var name="lbc_qc" name_in_code="qc" array_group="moist"  packages="bl_mynn_in;cu_ntiedtke_in;mp_kessler_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"
+                        <var name="lbc_qc" name_in_code="qc" array_group="moist"  packages="bl_mynn_in;bl_mynnedmf_in;cu_ntiedtke_in;mp_kessler_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"
                              units="kg kg^{-1} s^{-1}"
                              description="Lateral boundary tendency of cloud water mixing ratio"/>
 
@@ -2156,7 +2187,7 @@
                              units="kg kg^{-1} s^{-1}"
                              description="Lateral boundary tendency of rain water mixing ratio"/>
 
-                        <var name="lbc_qi" name_in_code="qi" array_group="moist"  packages="bl_mynn_in;cu_ntiedtke_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"
+                        <var name="lbc_qi" name_in_code="qi" array_group="moist"  packages="bl_mynn_in;bl_mynnedmf_in;cu_ntiedtke_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"
                              units="kg kg^{-1} s^{-1}"
                              description="Lateral boundary tendency of ice mixing ratio"/>
 
@@ -2172,7 +2203,7 @@
                              units="m^{-3} s^{-1}"
                              description="Lateral boundary tendency of rain number concentration"/>
 
-                        <var name="lbc_ni" name_in_code="ni" array_group="number" packages="bl_mynn_in;mp_thompson_in;mp_thompson_aers_in"
+                        <var name="lbc_ni" name_in_code="ni" array_group="number" packages="bl_mynn_in;bl_mynnedmf_in;mp_thompson_in;mp_thompson_aers_in"
                              units="m^{-3} s^{-1}"
                              description="Lateral boundary tendency of ice number concentration"/>
 
@@ -2368,7 +2399,7 @@
                 <nml_option name="config_pbl_scheme" type="character" default_value="suite" in_defaults="false"
                      units="-"
                      description="configuration for planetary boundary layer schemes"
-                     possible_values="`suite',`bl_ysu',`bl_mynn',`off'"/>
+                     possible_values="`suite',`bl_ysu',`bl_mynn',`bl_mynnedmf',`off'"/>
 
                 <nml_option name="config_gwdo_scheme" type="character" default_value="suite" in_defaults="false"
                      units="-"
@@ -2393,7 +2424,7 @@
                 <nml_option name="config_radt_cld_scheme" type="character" default_value="suite" in_defaults="false"
                      units="-"
                      description="configuration for calculation of horizontal cloud fraction"
-                     possible_values="`suite',`cld_fraction',`cld_incidence'"/>
+                     possible_values="`suite',`cld_fraction',`cld_incidence',`cld_fraction_mynn'"/>
 
                 <nml_option name="config_radt_lw_scheme" type="character" default_value="suite" in_defaults="false"
                      units="-"
@@ -2408,7 +2439,17 @@
                 <nml_option name="config_sfclayer_scheme" type="character" default_value="suite" in_defaults="false"
                      units="-"
                      description="configuration for surface layer-scheme"
-                     possible_values="`suite',`sf_monin_obukhov',`sf_mynn',`off'"/>
+                     possible_values="`suite',`sf_monin_obukhov',`sf_mynn',`sf_mynnsfclay',`off'"/>
+
+		<nml_option name="config_mynn_sfcflux_land" type="integer" default_value="1" in_defaults="false"
+                     units="-"
+                     description="=configuration option for the calculation of zt and zq over land"
+                     possible_values="0:constant Czil, 1:variable Czil, 2:Yang"/>
+
+                <nml_option name="config_mynn_sfcflux_water" type="integer" default_value="0" in_defaults="false"
+                     units="-"
+                     description="=configuration option for the calculation of z0, zt and zq over water"
+                     possible_values="0:COARE3.0, 1:COARE3.5, 2:Davis/COARE3.5 ,3:Davis/Garratt, 4:Taylor-Yelland"/>
 
                 <nml_option name="config_radt_cld_overlap" type="character" default_value="maximum_random" in_defaults="false"
                      description="cloud overlapping option in the RRTMG lw and sw radiation schemes"
@@ -2438,20 +2479,20 @@
                      description="=1:option to add the MYNN TKE budget terms to output"
                      possible_values="0,1"/>
 
-                <nml_option name="config_mynn_closure" type="real" default_value="2.5" in_defaults="false"
+                <nml_option name="config_mynn_closure" type="real" default_value="2.6" in_defaults="false"
                      units="-"
-                     description="2.5 level or 3.0 level for the MYNN TKE turbulence closure"
-                     possible_values="2.0,2.5,3.0"/>
+                     description="closure level for the MYNN-EDMF scheme"
+                     possible_values="2.5,2.6,2.7,3.0"/>
 
                 <nml_option name="config_mynn_cloudpdf" type="integer" default_value="2" in_defaults="false"
                      units="-"
                      description="switch to different cloud PDFs to represent subgrid clouds in the MYNN PBL scheme"
-                     possible_values="0,1,2"/>
+                     possible_values="`0: Someria-Deardorff',`1: Someria-Deardorf 1st order',`2: Modified Chab-Bechtold'"/>
 
-                <nml_option name="config_mynn_mixlength" type="integer" default_value="2" in_defaults="false"
+                <nml_option name="config_mynn_mixlength" type="integer" default_value="1" in_defaults="false"
                      units="-"
-                     description="mixing length in the MYNN PBL scheme:=0(Nakanishi and Niino 2009);=1(RAP/HRRR);=2(Ito et al. 2015)"
-                     possible_values="0,1,2"/>
+                     description="mixing length option in the MYNN-EDMF scheme"
+                     possible_values="`0: orig',`1: operational',`2: research'"/>
 
                 <nml_option name="config_mynn_stfunc" type="integer" default_value="1" in_defaults="false"
                      units="-"
@@ -2482,7 +2523,7 @@
                      description="=1:activate the EDMF downdraft option in the MYNN PBL scheme (=0 otherwise)"
                      possible_values="0,1"/>
 
-                <nml_option name="config_mynn_edmf_mom" type="integer" default_value="0" in_defaults="false"
+                <nml_option name="config_mynn_edmf_mom" type="integer" default_value="1" in_defaults="false"
                      units="-"
                      description="=1:activate momentum transport with the EDMF option of the MYNN PBL scheme(=0 otherwise)"
                      possible_values="0,1"/>
@@ -2494,12 +2535,22 @@
 
                 <nml_option name="config_mynn_edmf_output" type="integer" default_value="0" in_defaults="false"
                      units="-"
-                     description="=0:suppress the allocation of variables needed in the EDMF option of the MYNN PBL scheme"
-                     possible_values="0,1"/>
+                     description="=control the allocation/output of variables used in the MF component of the MYNN-EDMF scheme"
+                     possible_values="0:do not allocate/output,1:updrafts,2:downdrafts"/>
 
-                <nml_option name="config_mynn_mixscalars" type="integer" default_value="1" in_defaults="false"
+                <nml_option name="config_mynn_mixscalars" type="integer" default_value="0" in_defaults="false"
                      units="-"
                      description="=1:activate mixing of scalars in the MYNN PBL scheme (=0 otherwise)"
+                     possible_values="0,1"/>
+
+		<nml_option name="config_mynn_mixaerosols" type="integer" default_value="1" in_defaults="false"
+                     units="-"
+                     description="=1:activate mixing of aerosols in the MYNN PBL scheme (=0 otherwise)"
+                     possible_values="0,1"/>
+
+                <nml_option name="config_mynn_mixnumcon" type="integer" default_value="1" in_defaults="false"
+                     units="-"
+                     description="=1:activate mixing of number concentrations in the MYNN PBL scheme (=0 otherwise)"
                      possible_values="0,1"/>
 
                 <nml_option name="config_mynn_mixclouds" type="integer" default_value="1" in_defaults="false"
@@ -2510,7 +2561,22 @@
                 <nml_option name="config_mynn_mixqt" type="integer" default_value="0" in_defaults="false"
                      units="-"
                      description="=0:activatevmixing of moisture species separately;= 1:activate mixing of total water in the mynn PBL scheme"
+                     possible_values="0(keep=0),1"/>
+
+		<nml_option name="config_mynn_ess" type="integer" default_value="1" in_defaults="false"
+                     units="-"
+                     description="=0:use buoyancy-flux functions;= 1:use O-Gorman (2011)"
                      possible_values="0,1"/>
+
+                <nml_option name="config_icloud_bl" type="integer" default_value="1" in_defaults="false"
+                     units="-"
+                     description="configuration for MYNN subgrid cloud coupling to radiation"
+                     possible_values="`0: uncoupled',`1: coupled'"/>
+
+                <nml_option name="config_spp_pbl" type="integer" default_value="0" in_defaults="false"
+                     units="-"
+                     description="configuration for spp boundary layer"
+                     possible_values="`0: off',`1: activated'"/>
 
                 <nml_option name="config_bucket_radt" type="real" default_value="1.0e9" in_defaults="false"
                      units="-"
@@ -2746,23 +2812,23 @@
 
                 <var name="kpbl" type="integer" dimensions="nCells Time" units="unitless"
                      description="index level of PBL top"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
                 <var name="hpbl" type="real" dimensions="nCells Time" units="m"
                      description="Planetary Boundary Layer (PBL) height"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
 		<var name="kzh" type="real" dimensions="nVertLevels nCells Time" units="m^{2} s^{-1}"
                      description="vertical diffusion coefficient of potential temperature"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
 		<var name="kzm" type="real" dimensions="nVertLevels nCells Time" units="m^{2} s^{-1}"
                      description="vertical diffusion coefficient of mommentum"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
 		<var name="kzq" type="real" dimensions="nVertLevels nCells Time" units="m^{2} s^{-1}"
                      description="vertical diffusion coefficient of water vapor and cloud condensates"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
 
                 <!-- YSU PBL SCHEME: -->
@@ -2782,39 +2848,39 @@
                 <!-- MYNN PBL SCHEME: -->
                 <var name="cldfrac_bl" type="real" dimensions="nVertLevels nCells Time" units="unitless"
                      description="cloud fraction in the MYNN PBL scheme"
-                     packages="bl_mynn_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in"/>
 
                 <var name="qc_bl" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1}"
                      descrition="cloud liquid water mixing ratio in the MYNN PBL scheme"
-                     packages="bl_mynn_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in"/>
 
                 <var name="qi_bl" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1}"
                      descrition="cloud ice mixing ratio in the MYNN PBL scheme"
-                     packages="bl_mynn_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in"/>
 
                 <var name="cov" type="real" dimensions="nVertLevels nCells Time" units="K kg kg^{-1}"
                      description="liquid water - liquid water potential temperature covariance"
-                     packages="bl_mynn_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in"/>
 
                 <var name="el_pbl" type="real" dimensions="nVertLevels nCells Time" units="m"
                      description="mixing length from PBL scheme"
-                     packages="bl_mynn_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in"/>
 
                 <var name="qke" type="real" dimensions="nVertLevels nCells Time" units="m^{2} s^{-2}"
                      description="twice turbulent kinetic energy"
-                     packages="bl_mynn_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in"/>
 
                 <var name="qke_adv" type="real" dimensions="nVertLevels nCells Time" units="m^{2} s^{-2}"
                      description="twice turbulent kinetic energy"
-                     packages="bl_mynn_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in"/>
 
                 <var name="qsq" type="real" dimensions="nVertLevels nCells Time" units="{kg kg^{-1}}^2"
                      description="liquid water variance"
-                     packages="bl_mynn_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in"/>
 
                 <var name="tsq" type="real" dimensions="nVertLevels nCells Time" units="K^{2}"
                      description="liquid water potential temperature variance"
-                     packages="bl_mynn_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in"/>
 
                 <var name="tke_pbl" type="real" dimensions="nVertLevels nCells Time" units="m^{2} s^{-2}"
                      description="turbulent kinetic energy from PBL"
@@ -2822,63 +2888,103 @@
 
                 <var name="dqke" type="real" dimensions="nVertLevels nCells Time" units="m^{2} s^{-2}"
                      description="TKE change"
-                     packages="bl_mynn_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_tkebudget_in"/>
 
                 <var name="qbuoy" type="real" dimensions="nVertLevels nCells Time" units="m^{2} s^{-2}"
                      description="TKE production - buoyancy"
-                     packages="bl_mynn_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_tkebudget_in"/>
 
                 <var name="qdiss" type="real" dimensions="nVertLevels nCells Time" units="m^{2} s^{-2}"
                      description="TKE dissipation"
-                     packages="bl_mynn_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_tkebudget_in"/>
 
                 <var name="qshear" type="real" dimensions="nVertLevels nCells Time" units="m^{2} s^{-2}"
                      description="TKE production - shear"
-                     packages="bl_mynn_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_tkebudget_in"/>
 
                 <var name="qwt" type="real" dimensions="nVertLevels nCells Time" units="m^{2} s^{-2}"
                      description="TKE vertical distribution"
-                     packages="bl_mynn_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_tkebudget_in"/>
 
                 <var name="edmf_a" type="real" dimensions="nVertLevels nCells Time" units="unitless"
                      description="EDMF relative updraft area of moist updrafts in the MYNN PBL scheme"
-                     packages="bl_mynn_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_tkebudget_in"/>
 
                 <var name="edmf_w" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
                      description="EDMF vertical velocity of  moist updrafts in the MYNN PBL scheme"
-                     packages="bl_mynn_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_tkebudget_in"/>
 
                 <var name="edmf_qt" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1}"
                      description="EDMF total water mixing ratio in moist updrafts in the MYNN PBL scheme"
-                     packages="bl_mynn_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_tkebudget_in"/>
 
                 <var name="edmf_qc" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1}"
                      description="EDMF liquid water mixing ratio in moist updrafts in the MYNN PBL scheme"
-                     packages="bl_mynn_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_tkebudget_in"/>
 
                 <var name="edmf_thl" type="real" dimensions="nVertLevels nCells Time" units="K"
                      description="EDMF liquid-ice water potential temperature in moist updrafts in the MYNN PBL scheme"
-                     packages="bl_mynn_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_tkebudget_in"/>
 
                 <var name="edmf_ent" type="real" dimensions="nVertLevels nCells Time" units="m^{-1}"
                      description="EDMF entrainment rate in moist updrafts in the MYNN PBL scheme"
-                     packages="bl_mynn_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_tkebudget_in"/>
 
                 <var name="sub_thl" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
                      description="EDMF subsidence of liquid-ice potential temperature in the MYNN PBL scheme"
-                     packages="bl_mynn_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_tkebudget_in"/>
 
                 <var name="sub_qv" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
                      description="EDMF subsidence of water vapor mixing ratio in the MYNN PBL scheme"
-                     packages="bl_mynn_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_tkebudget_in"/>
 
                 <var name="det_thl" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
                      description="EDMF detrainment of liquid-ice potential temperature in the MYNN PBL scheme"
-                     packages="bl_mynn_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_tkebudget_in"/>
 
                 <var name="det_qv" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
                      description="EDMF detrainment of water vapor mixing ratio in the MYNN PBL scheme"
-                     packages="bl_mynn_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_tkebudget_in"/>
+
+		<var name="maxmf" type="real" dimensions="nCells Time" units="m s^{-1}"
+                     description="Maximum mass flux in the each column"
+                     packages="bl_mynnedmf_in"/>
+
+                <var name="maxwidth" type="real" dimensions="nCells Time" units="m"
+                     description="Maximum width of updrafts"
+                     packages="bl_mynnedmf_in"/>
+
+                <var name="ztop_plume" type="real" dimensions="nCells Time" units="m"
+                     description="Height of highest penetrating plume"
+                     packages="bl_mynnedmf_in"/>
+
+                <var name="excess_h" type="real" dimensions="nCells Time" units="K"
+                     description="Maximum excess heat added to plumes"
+                     packages="bl_mynnedmf_in"/>
+
+                <var name="excess_q" type="real" dimensions="nCells Time" units="kg kg^{-1}"
+                     description="Maximum excess moisture added to plumes"
+                     packages="bl_mynnedmf_in"/>
+
+                <var name="maxmf_dd" type="real" dimensions="nCells Time" units="m s^{-1}"
+                     description="Maximum mass flux in the each column from downdrafts"
+                     packages="bl_mynnedmf_in"/>
+
+                <var name="maxwidth_dd" type="real" dimensions="nCells Time" units="m"
+                     description="Maximum width of downdrafts"
+                     packages="bl_mynnedmf_in"/>
+
+                <var name="maxtkeprod_dd" type="real" dimensions="nCells Time" units="m^2 s^{-2} hr^{-1}"
+                     description="Maximum tke production in column from downdrafts"
+                     packages="bl_mynnedmf_in"/>
+
+                <var name="cldtop_cooling" type="real" dimensions="nCells Time" units="K hr^{-1}"
+                     description="Maximum cooling at boundary layer cloud top"
+                     packages="bl_mynnedmf_in"/>
+
+                <var name="ent_eff" type="real" dimensions="nCells Time" units=""
+                     description="Entrainment efficiency"
+                     packages="bl_mynnedmf_in"/>
 
 
                 <!-- ================================================================================================== -->
@@ -2887,111 +2993,115 @@
 
                 <var name="hfx" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="upward heat flux at the surface"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
                 <var name="mavail" type="real" dimensions="nCells Time" units="unitless"
                      description="surface moisture availability (between 0 and 1)"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
                 <var name="mol" type="real" dimensions="nCells Time" units="K"
                      description="T* in similarity theory"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
                 <var name="qfx" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}"
                      description="upward moisture flux at the surface"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
                 <var name="qsfc" type="real"  dimensions="nCells Time" units="kg kg^{-1}"
                      description="specific humidity at lower boundary"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
                 <var name="ust" type="real" dimensions="nCells Time" units="m s^{-1}"
                      description="U* in similarity theory"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
                 <var name="ustm" type="real" dimensions="nCells Time" units="m s^{-1}"
                      description="U* in similarity theory without vconv"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
                 <var name="zol" type="real" dimensions="nCells Time" units="unitless"
                      description="z/L height over Monin-Obukhov length"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
                 <var name="br" type="real" dimensions="nCells Time" units="unitless"
                      description="Richardson number"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
                 <var name="cd" type="real" dimensions="nCells Time" units="unitless"
                      description="drag coefficient at 10-meter"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
                 <var name="cda" type="real" dimensions="nCells Time" units="unitless"
                      description="drag coefficient at lowest model level"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
                 <var name="chs" type="real" dimensions="nCells Time" units="m s^{-1}"
                      description="surface exchange coefficient for heat and moisture"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
                 <var name="chs2" type="real" dimensions="nCells Time" units="m s^{-1}"
                      description="surface exchange coefficient for heat at 2-meter"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
                 <var name="cqs2" type="real" dimensions="nCells Time" units="m s^{-1}"
                      description="surface exchange coefficient for moisture at 2-meter"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
+
+		<var name="cqs" type="real" dimensions="nCells Time" units="m s^{-1}"
+                     description="surface exchange coefficient for moisture at 2-meter"
+                     packages="bl_mynnedmf_in"/>
 
                 <var name="ck" type="real" dimensions="nCells Time" units="unitless"
                      description="enthalpy exchange coeff at 10-meter"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
                 <var name="cka" type="real" dimensions="nCells Time" units="unitless"
                      description="enthalpy exchange coefficient at lowest model level"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
                 <var name="cpm" type="real" dimensions="nCells Time" units="J K^{-1} kg^{-1}"
                      description="specific heat of dry air at constant pressure at lowest model level"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
                 <var name="flhc" type="real" dimensions="nCells Time" units="W m^{-2} K^{-1}"
                      description="exchange coefficient for heat"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
                 <var name="flqc" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}"
                      description="exchange coefficient for moisture"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
                 <var name="gz1oz0" type="real" dimensions="nCells Time" units="unitless"
                      description="log(z/z0) where z0 is roughness length"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
                 <var name="lh" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="latent heat flux at the surface"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
                 <var name="psim" type="real" dimensions="nCells Time" units="unitless"
                      description="similarity stability function for momentum"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
                 <var name="psih" type="real" dimensions="nCells Time" units="unitless"
                      description="similarity stability function for heat"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
                 <var name="qgh" type="real" dimensions="nCells Time" units="kg kg^{-1}"
                      description="lowest level saturation mixing ratio"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
                 <var name="regime" type="real" dimensions="nCells Time" units="unitless"
                      description="flag indicating the PBL regime (stable,unstable,...)"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
                 <var name="rmol" type="real" dimensions="nCells Time" units="unitless"
                      description="1./L Monin Obukhov length"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
                 <var name="wspd" type="real" dimensions="nCells Time" units="m s^{-1}"
                      description="wind speed at lowest model level"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
 
                 <!-- ... MONIN-OBUKHOV (SFCLAY): -->
@@ -3007,35 +3117,35 @@
                 <!-- ... MYNN: -->
                 <var name="ch" type="real" dimensions="nCells Time" units="m s^{-1}"
                      description="surface exchange coefficient for heat"
-                     packages="bl_mynn_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in"/>
 
                 <var name="qcg" type="real" dimensions="nCells Time" units="kg kg^{-1}"
                      description="cloud water mixing ratio at the ground surface"
-                     packages="bl_mynn_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in"/>
 
                 <var name="sh3d" type="real" dimensions="nVertLevels nCells Time" units="unitless"
                      description="stability function for heat"
-                     packages="bl_mynn_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in"/>
 
                 <var name="sm3d" type="real" dimensions="nVertLevels nCells Time" units="unitless"
                      description="stability function for moisture"
-                     packages="bl_mynn_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in"/>
 
 
                 <!-- DIAGNOSTICS: -->
-                <var name="u10" type="real" dimensions="nCells Time" packages="bl_mynn_in;bl_ysu_in" units="m s^{-1}"
+                <var name="u10" type="real" dimensions="nCells Time" packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in" units="m s^{-1}"
                      description="10-meter zonal wind"/>
 
-                <var name="v10" type="real" dimensions="nCells Time" packages="bl_mynn_in;bl_ysu_in" units="m s^{-1}"
+                <var name="v10" type="real" dimensions="nCells Time" packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in" units="m s^{-1}"
                      description="10-meter meridional wind"/>
 
-                <var name="q2" type="real" dimensions="nCells Time" packages="bl_mynn_in;bl_ysu_in" units="kg kg^{-1}"
+                <var name="q2" type="real" dimensions="nCells Time" packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in" units="kg kg^{-1}"
                      description="2-meter specific humidity"/>
 
-                <var name="t2m" type="real" dimensions="nCells Time" packages="bl_mynn_in;bl_ysu_in" units="K"
+                <var name="t2m" type="real" dimensions="nCells Time" packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in" units="K"
                      description="2-meter temperature"/>
 
-                <var name="th2m" type="real" dimensions="nCells Time" packages="bl_mynn_in;bl_ysu_in" units="K"
+                <var name="th2m" type="real" dimensions="nCells Time" packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in" units="K"
                      description="2-meter potential temperature"/>
 
 
@@ -3647,47 +3757,47 @@
 
                 <var name="rublten" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1} s^{-1}"
                      description="tendency of zonal wind due to pbl processes"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
                 <var name="rvblten" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1} s^{-1}"
                      description="tendency of meridional wind due to pbl processes"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
                 <var name="rthblten" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
                      description="tendency of potential temperature due to pbl processes"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
                 <var name="rqvblten" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
                      description="tendency of water vapor mixing ratio due to pbl processes"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
                 <var name="rqcblten" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
                      description="tendency of cloud water mixing ratio due to pbl processes"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
                 <var name="rqiblten" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
                      description="tendency of cloud ice mixing ratio due to pbl processes"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in"/>
 
                 <var name="rqsblten" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
                      description="tendency of snow mixing ratio due to pbl processes"
-                     packages="bl_mynn_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in"/>
 
                 <var name="rncblten" type="real" dimensions="nVertLevels nCells Time" units="nb kg^{-1} s^{-1}"
                      description="tendency of cloud liquid water number concentration due to pbl processes"
-                     packages="bl_mynn_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in"/>
 
                 <var name="rniblten" type="real" dimensions="nVertLevels nCells Time" units="nb kg^{-1} s^{-1}"
                      description="tendency of cloud ice number concentration due to pbl processes"
-                     packages="bl_mynn_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in"/>
 
                 <var name="rnifablten" type="real" dimensions="nVertLevels nCells Time" units="nb kg^{-1} s^{-1}"
                      description="tendency of ice-friendly aerosol number concentration due to pbl processes"
-                     packages="bl_mynn_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in"/>
 
                 <var name="rnwfablten" type="real" dimensions="nVertLevels nCells Time" units="nb kg^{-1} s^{-1}"
                      description="tendency of water-friendly aerosol number concentration due to pbl processes"
-                     packages="bl_mynn_in"/>
+                     packages="bl_mynn_in;bl_mynnedmf_in"/>
 
 	        <!-- MGD should we add packages to the field below? -->
 	        <var name="rublten_Edge" type="real"     dimensions="nVertLevels nEdges Time"/>
@@ -3983,7 +4093,7 @@
                           units="kg kg^{-1}"
                           description="Water vapor mixing ratio increment"/>
 
-                     <var name="qc_amb"  name_in_code="qc" array_group="moist" packages="bl_mynn_in;bl_ysu_in;cu_ntiedtke_in;mp_kessler_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"
+                     <var name="qc_amb"  name_in_code="qc" array_group="moist" packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in;cu_ntiedtke_in;mp_kessler_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"
                           units="kg kg^{-1}"
                           description="Cloud water mixing ratio increment"/>
 
@@ -3991,7 +4101,7 @@
                           units="kg kg^{-1}"
                           description="Rain water mixing ratio increment"/>
 
-                     <var name="qi_amb"  name_in_code="qi" array_group="moist" packages="bl_mynn_in;bl_ysu_in;cu_ntiedtke_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"
+                     <var name="qi_amb"  name_in_code="qi" array_group="moist" packages="bl_mynn_in;bl_mynnedmf_in;bl_ysu_in;cu_ntiedtke_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"
                           units="kg kg^{-1}"
                           description="Ice mixing ratio increment"/>
 

--- a/src/core_atmosphere/physics/Makefile
+++ b/src/core_atmosphere/physics/Makefile
@@ -1,4 +1,4 @@
-.SUFFIXES: .F .o
+.SUFFIXES: .F .o .F90
 
 ifeq ($(CORE),atmosphere)
 COREDEF = -Dmpas
@@ -64,12 +64,12 @@ core_UGWP: core_physics_init
 	(cd physics_noaa/UGWP; $(MAKE) all)
 
 core_mynnedmf: core_physics_init
-	(cd physics_noaa/MYNN-EDMF; cp ./MPAS/Makefile .; cp ./MPAS/module_bl_mynnedmf_driver.F90 .; cp ./MPAS/module_bl_mynnedmf_common.F90 .; $(MAKE) all COREDEF="$(COREDEF)")
+	(cd physics_noaa/MYNN-EDMF/src; ln -s ./MPAS/Makefile .; ln -s ./MPAS/module_bl_mynnedmf_common.F90 .; $(MAKE) all COREDEF="$(COREDEF)")
 
 core_mynnsfc: core_physics_init
 	(cd physics_noaa/MYNN-SFC; cp ./MPAS/Makefile .; cp ./MPAS/module_sf_mynnsfc_driver.F90 .; cp ./MPAS/module_sf_mynnsfc_common.F90 .; $(MAKE) all COREDEF="$(COREDEF)")
 
-core_physics_wrf: core_physics_init core_physics_mmm core_UGWP core_mynnedmf
+core_physics_wrf: core_physics_init core_physics_mmm core_UGWP
 	(cd physics_wrf; $(MAKE) all COREDEF="$(COREDEF)")
 
 core_physics_noahmp:
@@ -260,7 +260,7 @@ clean:
 	( cd physics_noahmp/src; $(MAKE) clean )
 	( cd physics_noahmp/utility; $(MAKE) clean )
 	( if [ -d physics_noaa/UGWP ]; then cd physics_noaa/UGWP; $(MAKE) clean; fi )
-	( if [ -d physics_noaa/MYNN-EDMF ]; then cd physics_noaa/MYNN-EDMF; $(MAKE) clean; fi )
+	( if [ -d physics_noaa/MYNN-EDMF ]; then cd physics_noaa/MYNN-EDMF/src; $(MAKE) -f ./MPAS/Makefile clean; fi )
 	( if [ -d physics_noaa/MYNN-SFC ]; then cd physics_noaa/MYNN-SFC; $(MAKE) clean; fi )
 	@# Certain systems with intel compilers generate *.i files
 	@# This removes them during the clean process
@@ -272,5 +272,14 @@ ifeq "$(GEN_F90)" "true"
 	$(CPP) $(CPPFLAGS) $(COREDEF) $(HYDROSTATIC) $(CPPINCLUDES) -I../../framework $< > $*.f90
 	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES) -I./physics_mmm -I./physics_wrf -I./physics_noahmp -I./physics_noahmp/utility -I./physics_noahmp/drivers/mpas -I./physics_noahmp/src -I./physics_noaa/UGWP -I.. -I../../framework $(MPAS_ESMF_INC)
 else
-	$(FC) $(CPPFLAGS) $(COREDEF) $(HYDROSATIC) $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I./physics_mmm -I./physics_wrf -I./physics_noahmp -I./physics_noahmp/utility -I./physics_noahmp/drivers/mpas -I./physics_noahmp/src -I./physics_noaa/UGWP -I./physics_noaa/MYNN-EDMF -I./physics_noaa/MYNN-SFC -I.. -I../../framework $(MPAS_ESMF_INC)
+	$(FC) $(CPPFLAGS) $(COREDEF) $(HYDROSATIC) $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I./physics_mmm -I./physics_wrf -I./physics_noahmp -I./physics_noahmp/utility -I./physics_noahmp/drivers/mpas -I./physics_noahmp/src -I./physics_noaa/UGWP -I./physics_noaa/MYNN-EDMF/src -I./physics_noaa/MYNN-SFC -I.. -I../../framework $(MPAS_ESMF_INC)
+endif
+
+.F90.o:
+	$(RM) $@ $*.mod
+ifeq "$(GEN_F90)" "true"
+        $(CPP) $(CPPFLAGS) $(COREDEF) $(HYDROSTATIC) $(CPPINCLUDES) $< > $*.f90
+	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES) -I./physics_mmm -I./physics_wrf -I./physics_noaa/UGWP -I./physics_noaa/MYNN-EDMF/src -I./physics_noaa/MYNN-SFC  -I.. -I../../framework $(MPAS_ESMF_INC)
+else
+	$(FC) $(CPPFLAGS) $(COREDEF) $(HYDROSATIC) $(FFLAGS) -c $*.F90 $(CPPINCLUDES) $(FCINCLUDES) -I./physics_mmm -I./physics_wrf -I./physics_noaa/TEMPO -I./physics_noaa/UGWP -I./physics_noaa/MYNN-EDMF/src -I./physics_noaa/MYNN-SFC -I.. -I../../framework $(MPAS_ESMF_INC)
 endif

--- a/src/core_atmosphere/physics/Makefile
+++ b/src/core_atmosphere/physics/Makefile
@@ -6,7 +6,7 @@ endif
 
 all:
 	./../tools/manage_externals/checkout_externals --externals ./../Externals.cfg
-	$(MAKE) lookup_tables core_physics_init core_physics_mmm core_UGWP core_mynnedmf core_physics_wrf core_physics_noahmp core_physics
+	$(MAKE) lookup_tables core_physics_init core_physics_mmm core_UGWP core_mynnedmf core_mynnsfc core_physics_wrf core_physics_noahmp core_physics
 
 dummy:
 	echo "****** compiling physics ******"
@@ -66,6 +66,9 @@ core_UGWP: core_physics_init
 core_mynnedmf: core_physics_init
 	(cd physics_noaa/MYNN-EDMF; cp ./MPAS/Makefile .; cp ./MPAS/module_bl_mynnedmf_driver.F90 .; cp ./MPAS/module_bl_mynnedmf_common.F90 .; $(MAKE) all)
 
+core_mynnsfc: core_physics_init
+	(cd physics_noaa/MYNN-SFC; cp ./MPAS/Makefile .; cp ./MPAS/module_sf_mynnsfc_driver.F90 .; cp ./MPAS/module_sf_mynnsfc_common.F90 .; $(MAKE) all)
+
 core_physics_wrf: core_physics_init core_physics_mmm core_UGWP core_mynnedmf
 	(cd physics_wrf; $(MAKE) all COREDEF="$(COREDEF)")
 
@@ -76,7 +79,7 @@ core_physics_noahmp:
 
 core_physics_init: $(OBJS_init)
 
-core_physics: core_physics_wrf core_physics_noahmp core_mynnedmf
+core_physics: core_physics_wrf core_physics_noahmp core_mynnedmf core_mynnsfc
 	($(MAKE) phys_interface COREDEF="$(COREDEF)")
 	ar -ru libphys.a $(OBJS_init) $(OBJS)
 	($(MAKE) -C ./physics_mmm -f Makefile.mpas physics_mmm_lib)
@@ -258,6 +261,7 @@ clean:
 	( cd physics_noahmp/utility; $(MAKE) clean )
 	( if [ -d physics_noaa/UGWP ]; then cd physics_noaa/UGWP; $(MAKE) clean; fi )
 	( if [ -d physics_noaa/MYNN-EDMF ]; then cd physics_noaa/MYNN-EDMF; $(MAKE) clean; fi )
+	( if [ -d physics_noaa/MYNN-SFC ]; then cd physics_noaa/MYNN-SFC; $(MAKE) clean; fi )
 	@# Certain systems with intel compilers generate *.i files
 	@# This removes them during the clean process
 	$(RM) *.i
@@ -268,5 +272,5 @@ ifeq "$(GEN_F90)" "true"
 	$(CPP) $(CPPFLAGS) $(COREDEF) $(HYDROSTATIC) $(CPPINCLUDES) $< > $*.f90
 	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES) -I./physics_mmm -I./physics_wrf -I./physics_noahmp -I./physics_noahmp/utility -I./physics_noahmp/drivers/mpas -I./physics_noahmp/src -I.. -I../../framework $(MPAS_ESMF_INC)
 else
-	$(FC) $(CPPFLAGS) $(COREDEF) $(HYDROSATIC) $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I./physics_mmm -I./physics_wrf -I./physics_noahmp -I./physics_noahmp/utility -I./physics_noahmp/drivers/mpas -I./physics_noahmp/src -I./physics_noaa/UGWP -I./physics_noaa/MYNN-EDMF -I.. -I../../framework $(MPAS_ESMF_INC)
+	$(FC) $(CPPFLAGS) $(COREDEF) $(HYDROSATIC) $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I./physics_mmm -I./physics_wrf -I./physics_noahmp -I./physics_noahmp/utility -I./physics_noahmp/drivers/mpas -I./physics_noahmp/src -I./physics_noaa/UGWP -I./physics_noaa/MYNN-EDMF -I./physics_noaa/MYNN-SFC -I.. -I../../framework $(MPAS_ESMF_INC)
 endif

--- a/src/core_atmosphere/physics/Makefile
+++ b/src/core_atmosphere/physics/Makefile
@@ -6,7 +6,7 @@ endif
 
 all:
 	./../tools/manage_externals/checkout_externals --externals ./../Externals.cfg
-	$(MAKE) lookup_tables core_physics_init core_physics_mmm core_UGWP core_physics_wrf core_physics_noahmp core_physics
+	$(MAKE) lookup_tables core_physics_init core_physics_mmm core_UGWP core_mynnedmf core_physics_wrf core_physics_noahmp core_physics
 
 dummy:
 	echo "****** compiling physics ******"
@@ -63,7 +63,10 @@ core_physics_mmm: core_physics_init
 core_UGWP: core_physics_init
 	(cd physics_noaa/UGWP; $(MAKE) all)
 
-core_physics_wrf: core_physics_init core_physics_mmm core_UGWP
+core_mynnedmf: core_physics_init
+	(cd physics_noaa/MYNN-EDMF; cp ./MPAS/Makefile .; cp ./MPAS/module_bl_mynnedmf_driver.F90 .; cp ./MPAS/module_bl_mynnedmf_common.F90 .; $(MAKE) all)
+
+core_physics_wrf: core_physics_init core_physics_mmm core_UGWP core_mynnedmf
 	(cd physics_wrf; $(MAKE) all COREDEF="$(COREDEF)")
 
 core_physics_noahmp:
@@ -254,6 +257,7 @@ clean:
 	( cd physics_noahmp/src; $(MAKE) clean )
 	( cd physics_noahmp/utility; $(MAKE) clean )
 	( if [ -d physics_noaa/UGWP ]; then cd physics_noaa/UGWP; $(MAKE) clean; fi )
+	( if [ -d physics_noaa/MYNN-EDMF ]; then cd physics_noaa/MYNN-EDMF; $(MAKE) clean; fi )
 	@# Certain systems with intel compilers generate *.i files
 	@# This removes them during the clean process
 	$(RM) *.i
@@ -264,5 +268,5 @@ ifeq "$(GEN_F90)" "true"
 	$(CPP) $(CPPFLAGS) $(COREDEF) $(HYDROSTATIC) $(CPPINCLUDES) $< > $*.f90
 	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES) -I./physics_mmm -I./physics_wrf -I./physics_noahmp -I./physics_noahmp/utility -I./physics_noahmp/drivers/mpas -I./physics_noahmp/src -I.. -I../../framework $(MPAS_ESMF_INC)
 else
-	$(FC) $(CPPFLAGS) $(COREDEF) $(HYDROSATIC) $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I./physics_mmm -I./physics_wrf -I./physics_noahmp -I./physics_noahmp/utility -I./physics_noahmp/drivers/mpas -I./physics_noahmp/src -I./physics_noaa/UGWP -I.. -I../../framework $(MPAS_ESMF_INC)
+	$(FC) $(CPPFLAGS) $(COREDEF) $(HYDROSATIC) $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I./physics_mmm -I./physics_wrf -I./physics_noahmp -I./physics_noahmp/utility -I./physics_noahmp/drivers/mpas -I./physics_noahmp/src -I./physics_noaa/UGWP -I./physics_noaa/MYNN-EDMF -I.. -I../../framework $(MPAS_ESMF_INC)
 endif

--- a/src/core_atmosphere/physics/Makefile
+++ b/src/core_atmosphere/physics/Makefile
@@ -64,10 +64,10 @@ core_UGWP: core_physics_init
 	(cd physics_noaa/UGWP; $(MAKE) all)
 
 core_mynnedmf: core_physics_init
-	(cd physics_noaa/MYNN-EDMF; cp ./MPAS/Makefile .; cp ./MPAS/module_bl_mynnedmf_driver.F90 .; cp ./MPAS/module_bl_mynnedmf_common.F90 .; $(MAKE) all)
+	(cd physics_noaa/MYNN-EDMF; cp ./MPAS/Makefile .; cp ./MPAS/module_bl_mynnedmf_driver.F90 .; cp ./MPAS/module_bl_mynnedmf_common.F90 .; $(MAKE) all COREDEF="$(COREDEF)")
 
 core_mynnsfc: core_physics_init
-	(cd physics_noaa/MYNN-SFC; cp ./MPAS/Makefile .; cp ./MPAS/module_sf_mynnsfc_driver.F90 .; cp ./MPAS/module_sf_mynnsfc_common.F90 .; $(MAKE) all)
+	(cd physics_noaa/MYNN-SFC; cp ./MPAS/Makefile .; cp ./MPAS/module_sf_mynnsfc_driver.F90 .; cp ./MPAS/module_sf_mynnsfc_common.F90 .; $(MAKE) all COREDEF="$(COREDEF)")
 
 core_physics_wrf: core_physics_init core_physics_mmm core_UGWP core_mynnedmf
 	(cd physics_wrf; $(MAKE) all COREDEF="$(COREDEF)")

--- a/src/core_atmosphere/physics/Makefile
+++ b/src/core_atmosphere/physics/Makefile
@@ -64,7 +64,7 @@ core_UGWP: core_physics_init
 	(cd physics_noaa/UGWP; $(MAKE) all)
 
 core_mynnedmf: core_physics_init
-	(cd physics_noaa/MYNN-EDMF/src; ln -s ./MPAS/Makefile .; ln -s ./MPAS/module_bl_mynnedmf_common.F90 .; $(MAKE) all COREDEF="$(COREDEF)")
+	(cd physics_noaa/MYNN-EDMF/src; ln -sf ./MPAS/Makefile Makefile; ln -sf ./MPAS/module_bl_mynnedmf_common.F90 module_bl_mynnedmf_common.F90; $(MAKE) all COREDEF="$(COREDEF)")
 
 core_mynnsfc: core_physics_init
 	(cd physics_noaa/MYNN-SFC; cp ./MPAS/Makefile .; cp ./MPAS/module_sf_mynnsfc_driver.F90 .; cp ./MPAS/module_sf_mynnsfc_common.F90 .; $(MAKE) all COREDEF="$(COREDEF)")

--- a/src/core_atmosphere/physics/Makefile
+++ b/src/core_atmosphere/physics/Makefile
@@ -76,7 +76,7 @@ core_physics_noahmp:
 
 core_physics_init: $(OBJS_init)
 
-core_physics: core_physics_wrf core_physics_noahmp
+core_physics: core_physics_wrf core_physics_noahmp core_mynnedmf
 	($(MAKE) phys_interface COREDEF="$(COREDEF)")
 	ar -ru libphys.a $(OBJS_init) $(OBJS)
 	($(MAKE) -C ./physics_mmm -f Makefile.mpas physics_mmm_lib)

--- a/src/core_atmosphere/physics/mpas_atmphys_control.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_control.F
@@ -199,8 +199,9 @@
  endif
 
 !pbl scheme:
- if(.not. (config_pbl_scheme .eq. 'off'     .or. &
-           config_pbl_scheme .eq. 'bl_mynn' .or. &
+ if(.not. (config_pbl_scheme .eq. 'off'         .or. &
+           config_pbl_scheme .eq. 'bl_mynn'     .or. &
+           config_pbl_scheme .eq. 'bl_mynnedmf' .or. &
            config_pbl_scheme .eq. 'bl_ysu')) then
 
     write(mpas_err_message,'(A,A20)') 'illegal value for pbl_scheme: ', &
@@ -243,10 +244,11 @@
  endif
 
 !cloud fraction for radiation schemes:
- if(.not. (config_radt_cld_scheme .eq. 'off'           .or. &
-           config_radt_cld_scheme .eq. 'cld_incidence' .or. &
-           config_radt_cld_scheme .eq. 'cld_fraction'  .or. &
-           config_radt_cld_scheme .eq. 'cld_fraction_thompson')) then
+ if(.not. (config_radt_cld_scheme .eq. 'off'                   .or. &
+           config_radt_cld_scheme .eq. 'cld_incidence'         .or. &
+           config_radt_cld_scheme .eq. 'cld_fraction'          .or. &
+           config_radt_cld_scheme .eq. 'cld_fraction_thompson' .or. &
+           config_radt_cld_scheme .eq. 'cld_fraction_mynn')) then
 
     write(mpas_err_message,'(A,A20)') 'illegal value for calculation of cloud fraction: ', &
           trim(config_radt_cld_scheme)
@@ -266,10 +268,19 @@
     config_radt_cld_scheme = "cld_incidence"
 
  endif
+ if(.not. (config_pbl_scheme .eq. 'bl_mynn'     .or.   &
+           config_pbl_scheme .eq. 'bl_mynnedmf') .and. &
+          (config_radt_cld_scheme .eq. 'cld_fraction_mynn')) then
+          write(mpas_err_message,'(A,A20)') 'illegal cloud fraction option for pbl_scheme: ', &
+                trim(config_pbl_scheme)
+          call physics_error_fatal(mpas_err_message)
 
+ endif
+      
 !surface-layer scheme:
  if(.not. (config_sfclayer_scheme .eq. 'off'              .or. &
            config_sfclayer_scheme .eq. 'sf_mynn'          .or. &
+           config_sfclayer_scheme .eq. 'sf_mynnsfclay'    .or. &
            config_sfclayer_scheme .eq. 'sf_monin_obukhov' .or. &
            config_sfclayer_scheme .eq. 'sf_monin_obukhov_rev')) then
  
@@ -279,6 +290,8 @@
  else
     if(config_pbl_scheme == 'bl_mynn') then
        config_sfclayer_scheme = 'sf_mynn'
+    elseif(config_pbl_scheme == 'bl_mynnedmf') then
+       config_sfclayer_scheme = 'sf_mynnsfclay'
     elseif(config_pbl_scheme == 'bl_ysu') then
        if(config_sfclayer_scheme /= 'sf_monin_obukhov' .and. &
           config_sfclayer_scheme /= 'sf_monin_obukhov_rev') then

--- a/src/core_atmosphere/physics/mpas_atmphys_driver.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver.F
@@ -213,10 +213,10 @@
 
     !call to cloud scheme:
     if(l_radtlw .or. l_radtsw) then
-       call allocate_cloudiness
+       call allocate_cloudiness(block%configs)
 !$OMP PARALLEL DO
        do thread=1,nThreads
-          call driver_cloudiness(block%configs,mesh,diag_physics,sfc_input, &
+          call driver_cloudiness(itimestep,block%configs,mesh,diag_physics,sfc_input, &
                                  cellSolveThreadStart(thread),cellSolveThreadEnd(thread))
        end do
 !$OMP END PARALLEL DO
@@ -260,7 +260,7 @@
 
     !deallocate all radiation arrays:
     if(config_radt_sw_scheme.ne.'off' .or. config_radt_lw_scheme.ne.'off') &
-       call deallocate_cloudiness
+       call deallocate_cloudiness(block%configs)
     if(config_radt_sw_scheme.ne.'off') call deallocate_radiation_sw(block%configs)
     if(config_radt_lw_scheme.ne.'off') call deallocate_radiation_lw(block%configs)
 

--- a/src/core_atmosphere/physics/mpas_atmphys_driver.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver.F
@@ -321,7 +321,7 @@
        call allocate_pbl(block%configs)
 !$OMP PARALLEL DO
        do thread=1,nThreads
-          call driver_pbl(itimestep,block%configs,mesh,sfc_input,diag_physics,tend_physics, &
+          call driver_pbl(itimestep,block%configs,state,mesh,sfc_input,diag_physics,tend_physics, &
                           cellSolveThreadStart(thread),cellSolveThreadEnd(thread))
        end do
 !$OMP END PARALLEL DO

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_cloudiness.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_cloudiness.F
@@ -61,9 +61,16 @@
 
 
 !=================================================================================================================
- subroutine allocate_cloudiness
+ subroutine allocate_cloudiness(configs)
 !=================================================================================================================
 
+!input arguments:
+ type(mpas_pool_type),intent(in):: configs
+!local pointer:
+ character(len=StrKIND),pointer:: radt_cld_scheme
+
+ call mpas_pool_get_config(configs,'config_radt_cld_scheme',radt_cld_scheme)
+      
  if(.not.allocated(dx_p)     ) allocate(dx_p(ims:ime,jms:jme)             ) 
  if(.not.allocated(xland_p)  ) allocate(xland_p(ims:ime,jms:jme)          )
  if(.not.allocated(cldfrac_p)) allocate(cldfrac_p(ims:ime,kms:kme,jms:jme))
@@ -72,12 +79,28 @@
  if(.not.allocated(qirad_p)  ) allocate(qirad_p(ims:ime,kms:kme,jms:jme)  )
  if(.not.allocated(qsrad_p)  ) allocate(qsrad_p(ims:ime,kms:kme,jms:jme)  )
 
+ cld_fraction_select: select case (trim(radt_cld_scheme))
+
+    case("cld_fraction_mynn")
+       if(.not.allocated(qibl_p)) allocate(qibl_p(ims:ime,kms:kme,jms:jme))
+       if(.not.allocated(qcbl_p)) allocate(qcbl_p(ims:ime,kms:kme,jms:jme))
+    case default
+
+ end select cld_fraction_select
+      
  end subroutine allocate_cloudiness
 
 !=================================================================================================================
- subroutine deallocate_cloudiness
+ subroutine deallocate_cloudiness(configs)
 !=================================================================================================================
 
+!input arguments:
+ type(mpas_pool_type),intent(in):: configs
+!local pointer:
+ character(len=StrKIND),pointer:: radt_cld_scheme
+
+ call mpas_pool_get_config(configs,'config_radt_cld_scheme',radt_cld_scheme)
+      
  if(allocated(dx_p)     ) deallocate(dx_p     )
  if(allocated(xland_p)  ) deallocate(xland_p  )
  if(allocated(cldfrac_p)) deallocate(cldfrac_p)
@@ -86,15 +109,25 @@
  if(allocated(qirad_p)  ) deallocate(qirad_p  )
  if(allocated(qsrad_p)  ) deallocate(qsrad_p  )
 
+  cld_fraction_select: select case (trim(radt_cld_scheme))
+
+    case("cld_fraction_mynn")
+       if(allocated(qibl_p)) deallocate(qibl_p)
+       if(allocated(qcbl_p)) deallocate(qcbl_p)
+    case default
+
+ end select cld_fraction_select
+      
  end subroutine deallocate_cloudiness
 
 !=================================================================================================================
- subroutine cloudiness_from_MPAS(configs,mesh,diag_physics,sfc_input,its,ite)
+ subroutine cloudiness_from_MPAS(itimestep,configs,mesh,diag_physics,sfc_input,its,ite)
 !=================================================================================================================
 
 !input arguments:
  integer,intent(in):: its,ite
-
+ integer,intent(in):: itimestep
+      
 !input and inout arguments:
  type(mpas_pool_type),intent(in)   :: configs
  type(mpas_pool_type),intent(in)   :: mesh
@@ -110,6 +143,10 @@
  real(kind=RKIND),dimension(:),pointer:: areaCell,meshDensity
  real(kind=RKIND),dimension(:),pointer:: xland
 
+ real(kind=RKIND),dimension(:,:),pointer:: cldfrac_bl,qi_bl,qc_bl
+
+ character(len=StrKIND),pointer:: radt_cld_scheme
+
 !-----------------------------------------------------------------------------------------------------------------
 
  call mpas_pool_get_config(configs,'config_len_disp',len_disp)
@@ -118,7 +155,8 @@
  call mpas_pool_get_array(mesh,'meshDensity',meshDensity)
 
  call mpas_pool_get_array(sfc_input,'xland',xland)
-
+ call mpas_pool_get_config(configs,'config_radt_cld_scheme',radt_cld_scheme)
+      
  do j = jts,jte
     do i = its,ite
        dx_p(i,j)    = len_disp / meshDensity(i)**0.25
@@ -139,6 +177,49 @@
     enddo
     enddo
  enddo
+
+ cld_fraction_select: select case (trim(radt_cld_scheme))
+
+    case("cld_fraction_mynn")
+       call mpas_pool_get_array(diag_physics,'cldfrac_bl',cldfrac_bl)
+       call mpas_pool_get_array(diag_physics,'qi_bl',qi_bl)
+       call mpas_pool_get_array(diag_physics,'qc_bl',qc_bl)
+       if(itimestep > 0) then
+          do j = jts,jte
+          do k = kts,kte
+          do i = its,ite
+             if (cldfrac_bl(k,i) .gt. 0.001) then
+                cldfrac_p(i,k,j) = cldfrac_bl(k,i)
+             endif
+          enddo
+          enddo
+          enddo
+       else
+          do j = jts,jte
+          do k = kts,kte
+          do i = its,ite
+             if (qcrad_p(i,k,j) .gt. 1e-6 .or. &
+                 qirad_p(i,k,j) .gt. 1e-9 .or. &
+                 qsrad_p(i,k,j) .gt. 1e-8 ) then
+                cldfrac_p(i,k,j) = 1._RKIND
+             endif
+          enddo
+          enddo
+          enddo
+       endif
+
+       do j = jts,jte
+       do k = kts,kte
+       do i = its,ite
+          qcbl_p(i,k,j) = qc_bl(k,i)
+          qibl_p(i,k,j) = qi_bl(k,i)
+       enddo
+       enddo
+       enddo
+
+    case default
+
+ end select cld_fraction_select
 
  end subroutine cloudiness_from_MPAS
 
@@ -172,7 +253,7 @@
  end subroutine cloudiness_to_MPAS
 
 !=================================================================================================================
- subroutine driver_cloudiness(configs,mesh,diag_physics,sfc_input,its,ite)
+ subroutine driver_cloudiness(itimestep,configs,mesh,diag_physics,sfc_input,its,ite)
 !=================================================================================================================
 
 !input arguments:
@@ -181,7 +262,8 @@
  type(mpas_pool_type),intent(in)   :: sfc_input
 
  integer,intent(in):: its,ite
-
+ integer,intent(in):: itimestep
+      
 !inout arguments:
  type(mpas_pool_type),intent(inout):: diag_physics
 
@@ -197,7 +279,7 @@
  call mpas_pool_get_config(configs,'config_radt_cld_scheme',radt_cld_scheme)
 
 !copy MPAS arrays to local arrays:
- call cloudiness_from_MPAS(configs,mesh,diag_physics,sfc_input,its,ite)
+ call cloudiness_from_MPAS(itimestep,configs,mesh,diag_physics,sfc_input,its,ite)
 
  cld_fraction_select: select case (trim(radt_cld_scheme))
     case("cld_incidence")
@@ -222,6 +304,13 @@
                       )
       call mpas_timer_stop('cal_cldfra3')
 
+    case("cld_fraction_mynn")
+      call mpas_timer_start('cal_mynncld')
+      call cal_mynncld(cldfrac_p , qcrad_p   , qirad_p    , &
+                       qcbl_p    , qibl_p    ,              &
+                       its,  ite , jts , jte , kts , kte  )
+      call mpas_timer_stop('cal_mynncld')
+                       
     case default
 
  end select cld_fraction_select
@@ -369,6 +458,39 @@
 
  end subroutine calc_cldfraction
 
+!=================================================================================================================
+ subroutine cal_mynncld(cldfrac,qc,qi,qc_bl,qi_bl,its,ite,jts,jte,kts,kte)
+!=================================================================================================================
+
+!input arguments:
+ integer,intent(in):: its,ite,jts,jte,kts,kte
+ real(kind=RKIND),intent(inout),dimension(ims:ime,kms:kme,jms:jme):: qc,qi
+ real(kind=RKIND),intent(in),   dimension(ims:ime,kms:kme,jms:jme):: qc_bl,qi_bl
+ real(kind=RKIND),intent(in),   dimension(ims:ime,kms:kme,jms:jme):: cldfrac
+
+!local variables:
+ integer:: i,j,k
+
+ real(kind=RKIND),parameter:: qc_thresh  = 1.e-06
+ real(kind=RKIND),parameter:: qi_thresh  = 1.e-09
+ real(kind=RKIND),parameter:: cld_thresh = 1.e-03
+
+ do j = jts,jte
+ do k = kts,kte
+ do i = its,ite
+
+    if (qc(i,k,j) < qc_thresh .AND. cldfrac(i,k,j) > cld_thresh) THEN
+       qc(i,k,j)=qc(i,k,j) + qc_bl(i,k,j)
+    endif
+    if (qi(i,k,j) < qi_thresh .AND. cldfrac(i,k,j) > cld_thresh) THEN
+       qi(i,k,j)=qi(i,k,j) + qi_bl(i,k,j)
+    endif
+ enddo
+ enddo
+ enddo
+
+ end subroutine cal_mynncld
+      
 !=================================================================================================================
  end module mpas_atmphys_driver_cloudiness
 !=================================================================================================================

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
@@ -16,6 +16,7 @@
 
  use bl_mynn,only: bl_mynn_init
  use module_bl_mynn,only: mynn_bl_driver
+ use module_bl_mynnedmf_driver,only: mynnedmf_driver
  use module_bl_ysu
 
  implicit none
@@ -185,6 +186,59 @@
 
        !allocation of additional arrays:
        if(.not.allocated(pattern_spp_pbl)) allocate(pattern_spp_pbl(ims:ime,kms:kme,jms:jme))
+       
+    case("bl_mynnedmf") !GSL version
+       if(.not.allocated(dx_p)          ) allocate(dx_p(ims:ime,jms:jme)                )
+       if(.not.allocated(ch_p)          ) allocate(ch_p(ims:ime,jms:jme)                )
+       if(.not.allocated(qsfc_p)        ) allocate(qsfc_p(ims:ime,jms:jme)              )
+       if(.not.allocated(tsk_p)         ) allocate(tsk_p(ims:ime,jms:jme)               )
+       if(.not.allocated(maxwidthbl_p)  ) allocate(maxwidthbl_p(ims:ime,jms:jme)        )
+       if(.not.allocated(maxmfbl_p)     ) allocate(maxmfbl_p(ims:ime,jms:jme)           )
+       if(.not.allocated(zbl_plume_p)   ) allocate(zbl_plume_p(ims:ime,jms:jme)         )
+       if(.not.allocated(excessh_p)     ) allocate(excessh_p(ims:ime,jms:jme)           )
+       if(.not.allocated(excessq_p)     ) allocate(excessq_p(ims:ime,jms:jme)           ) 
+       if(.not.allocated(maxwidth_dd_p) ) allocate(maxwidth_dd_p(ims:ime,jms:jme)       )
+       if(.not.allocated(maxmf_dd_p)    ) allocate(maxmf_dd_p(ims:ime,jms:jme)          )
+       if(.not.allocated(maxtkeprod_dd_p))allocate(maxtkeprod_dd_p(ims:ime,jms:jme)     )
+       if(.not.allocated(cldtop_cooling_p))allocate(cldtop_cooling_p(ims:ime,jms:jme)   )
+       if(.not.allocated(ent_eff_p)     ) allocate(ent_eff_p(ims:ime,jms:jme)           )
+       
+       if(.not.allocated(cov_p)         ) allocate(cov_p(ims:ime,kms:kme,jms:jme)       )
+       if(.not.allocated(qke_p)         ) allocate(qke_p(ims:ime,kms:kme,jms:jme)       )
+       if(.not.allocated(qsq_p)         ) allocate(qsq_p(ims:ime,kms:kme,jms:jme)       )
+       if(.not.allocated(tsq_p)         ) allocate(tsq_p(ims:ime,kms:kme,jms:jme)       )
+       if(.not.allocated(qkeadv_p)      ) allocate(qkeadv_p(ims:ime,kms:kme,jms:jme)    )
+       if(.not.allocated(elpbl_p)       ) allocate(elpbl_p(ims:ime,kms:kme,jms:jme)     )
+       if(.not.allocated(sh3d_p)        ) allocate(sh3d_p(ims:ime,kms:kme,jms:jme)      )
+       if(.not.allocated(sm3d_p)        ) allocate(sm3d_p(ims:ime,kms:kme,jms:jme)      )
+       if(.not.allocated(dqke_p)        ) allocate(dqke_p(ims:ime,kms:kme,jms:jme)      )
+       if(.not.allocated(qbuoy_p)       ) allocate(qbuoy_p(ims:ime,kms:kme,jms:jme)     )
+       if(.not.allocated(qdiss_p)       ) allocate(qdiss_p(ims:ime,kms:kme,jms:jme)     )
+       if(.not.allocated(qshear_p)      ) allocate(qshear_p(ims:ime,kms:kme,jms:jme)    )
+       if(.not.allocated(qwt_p)         ) allocate(qwt_p(ims:ime,kms:kme,jms:jme)       )
+       if(.not.allocated(qcbl_p)        ) allocate(qcbl_p(ims:ime,kms:kme,jms:jme)      )
+       if(.not.allocated(qibl_p)        ) allocate(qibl_p(ims:ime,kms:kme,jms:jme)      )
+       if(.not.allocated(cldfrabl_p)    ) allocate(cldfrabl_p(ims:ime,kms:kme,jms:jme)  )
+       if(.not.allocated(edmfa_p)       ) allocate(edmfa_p(ims:ime,kms:kme,jms:jme)     )
+       if(.not.allocated(edmfw_p)       ) allocate(edmfw_p(ims:ime,kms:kme,jms:jme)     )
+       if(.not.allocated(edmfqt_p)      ) allocate(edmfqt_p(ims:ime,kms:kme,jms:jme)    )
+       if(.not.allocated(edmfthl_p)     ) allocate(edmfthl_p(ims:ime,kms:kme,jms:jme)   )
+       if(.not.allocated(edmfent_p)     ) allocate(edmfent_p(ims:ime,kms:kme,jms:jme)   )
+       if(.not.allocated(edmfqc_p)      ) allocate(edmfqc_p(ims:ime,kms:kme,jms:jme)    )
+       if(.not.allocated(subthl_p)      ) allocate(subthl_p(ims:ime,kms:kme,jms:jme)    )
+       if(.not.allocated(subqv_p)       ) allocate(subqv_p(ims:ime,kms:kme,jms:jme)     )
+       if(.not.allocated(detthl_p)      ) allocate(detthl_p(ims:ime,kms:kme,jms:jme)    )
+       if(.not.allocated(detqv_p)       ) allocate(detqv_p(ims:ime,kms:kme,jms:jme)     )
+
+       !additional tendencies:
+       if(.not.allocated(rqsblten_p)    ) allocate(rqsblten_p(ims:ime,kms:kme,jms:jme)  )
+       if(.not.allocated(rncblten_p)    ) allocate(rncblten_p(ims:ime,kms:kme,jms:jme)  )
+       if(.not.allocated(rniblten_p)    ) allocate(rniblten_p(ims:ime,kms:kme,jms:jme)  )
+       if(.not.allocated(rnifablten_p)  ) allocate(rnifablten_p(ims:ime,kms:kme,jms:jme))
+       if(.not.allocated(rnwfablten_p)  ) allocate(rnwfablten_p(ims:ime,kms:kme,jms:jme))
+
+       !allocation of additional arrays:
+       if(.not.allocated(pattern_spp_pbl)) allocate(pattern_spp_pbl(ims:ime,kms:kme,jms:jme))
 
     case default
 
@@ -295,6 +349,59 @@
 
        !deallocation of additional arrays:
        if(allocated(pattern_spp_pbl)) deallocate(pattern_spp_pbl)
+       
+    case("bl_mynnedmf")
+       if(allocated(dx_p)            ) deallocate(dx_p            )
+       if(allocated(ch_p)            ) deallocate(ch_p            )
+       if(allocated(qsfc_p)          ) deallocate(qsfc_p          )
+       if(allocated(tsk_p)           ) deallocate(tsk_p           )
+       if(allocated(maxwidthbl_p)    ) deallocate(maxwidthbl_p    )
+       if(allocated(maxmfbl_p)       ) deallocate(maxmfbl_p       )
+       if(allocated(zbl_plume_p)     ) deallocate(zbl_plume_p     )
+       if(allocated(excessh_p)       ) deallocate(excessh_p       )                                                                                                         
+       if(allocated(excessq_p)       ) deallocate(excessq_p       )
+       if(allocated(maxwidth_dd_p)   ) deallocate(maxwidth_dd_p   )
+       if(allocated(maxmf_dd_p)      ) deallocate(maxmf_dd_p      )
+       if(allocated(maxtkeprod_dd_p) ) deallocate(maxtkeprod_dd_p )
+       if(allocated(cldtop_cooling_p)) deallocate(cldtop_cooling_p)
+       if(allocated(ent_eff_p)       ) deallocate(ent_eff_p       )
+       
+       if(allocated(cov_p)       ) deallocate(cov_p       )
+       if(allocated(qke_p)       ) deallocate(qke_p       )
+       if(allocated(qsq_p)       ) deallocate(qsq_p       )
+       if(allocated(tsq_p)       ) deallocate(tsq_p       )
+       if(allocated(qkeadv_p)    ) deallocate(qkeadv_p    )
+       if(allocated(elpbl_p)     ) deallocate(elpbl_p     )
+       if(allocated(sh3d_p)      ) deallocate(sh3d_p      )
+       if(allocated(sm3d_p)      ) deallocate(sm3d_p      )
+       if(allocated(dqke_p)      ) deallocate(dqke_p      )
+       if(allocated(qbuoy_p)     ) deallocate(qbuoy_p     )
+       if(allocated(qdiss_p)     ) deallocate(qdiss_p     )
+       if(allocated(qshear_p)    ) deallocate(qshear_p    )
+       if(allocated(qwt_p)       ) deallocate(qwt_p       )
+       if(allocated(qcbl_p)      ) deallocate(qcbl_p      )
+       if(allocated(qibl_p)      ) deallocate(qibl_p      )
+       if(allocated(cldfrabl_p)  ) deallocate(cldfrabl_p  )
+       if(allocated(edmfa_p)     ) deallocate(edmfa_p     )
+       if(allocated(edmfw_p)     ) deallocate(edmfw_p     )
+       if(allocated(edmfqt_p)    ) deallocate(edmfqt_p    )
+       if(allocated(edmfthl_p)   ) deallocate(edmfthl_p   )
+       if(allocated(edmfent_p)   ) deallocate(edmfent_p   )
+       if(allocated(edmfqc_p)    ) deallocate(edmfqc_p    )
+       if(allocated(subthl_p)    ) deallocate(subthl_p    )
+       if(allocated(subqv_p)     ) deallocate(subqv_p     )
+       if(allocated(detthl_p)    ) deallocate(detthl_p    )
+       if(allocated(detqv_p)     ) deallocate(detqv_p     )
+
+       !additional tendencies:
+       if(allocated(rqsblten_p)  ) deallocate(rqsblten_p  )
+       if(allocated(rncblten_p)  ) deallocate(rncblten_p  )
+       if(allocated(rniblten_p)  ) deallocate(rniblten_p  )
+       if(allocated(rnifablten_p)) deallocate(rnifablten_p)
+       if(allocated(rnwfablten_p)) deallocate(rnwfablten_p)
+
+       !deallocation of additional arrays:
+       if(allocated(pattern_spp_pbl)) deallocate(pattern_spp_pbl)
 
     case default
 
@@ -303,7 +410,7 @@
  end subroutine deallocate_pbl
 
 !=================================================================================================================
- subroutine pbl_from_MPAS(configs,mesh,sfc_input,diag_physics,tend_physics,its,ite)
+ subroutine pbl_from_MPAS(configs,state,mesh,sfc_input,diag_physics,tend_physics,its,ite)
 !=================================================================================================================
 
 !input arguments:
@@ -312,6 +419,7 @@
  type(mpas_pool_type),intent(in):: diag_physics
  type(mpas_pool_type),intent(in):: sfc_input
  type(mpas_pool_type),intent(in):: tend_physics
+ type(mpas_pool_type),intent(in):: state
 
  integer,intent(in):: its,ite
 
@@ -331,6 +439,7 @@
 
 !local pointers for MYNN scheme:
  real(kind=RKIND),pointer:: len_disp
+ integer,pointer:: config_mynn_tkebudget,config_mynn_edmf_output
  real(kind=RKIND),dimension(:),pointer  :: meshDensity
  real(kind=RKIND),dimension(:),pointer  :: ch,qsfc,rmol,skintemp
  real(kind=RKIND),dimension(:,:),pointer:: cov,qke,qsq,tsq,sh3d,sm3d,tke_pbl,qke_adv,el_pbl
@@ -504,6 +613,123 @@
           zbl_plume_p(i,j)  = 0
        enddo
        enddo
+       
+    case("bl_mynnedmf")
+       call mpas_pool_get_config(configs,'config_len_disp',len_disp)
+       call mpas_pool_get_config(configs,'config_mynn_edmf_output',config_mynn_edmf_output)
+       call mpas_pool_get_config(configs,'config_mynn_tkebudget',config_mynn_tkebudget)
+       call mpas_pool_get_array(mesh,'meshDensity',meshDensity)
+
+       call mpas_pool_get_array(sfc_input,'skintemp',skintemp)
+       call mpas_pool_get_array(diag_physics,'ch'        ,ch        )
+       call mpas_pool_get_array(diag_physics,'qsfc'      ,qsfc      )
+       call mpas_pool_get_array(diag_physics,'el_pbl'    ,el_pbl    )
+       call mpas_pool_get_array(diag_physics,'cov'       ,cov       )
+       call mpas_pool_get_array(diag_physics,'qke'       ,qke       )
+       call mpas_pool_get_array(diag_physics,'qke_adv'   ,qke_adv   )
+       call mpas_pool_get_array(diag_physics,'qsq'       ,qsq       )
+       call mpas_pool_get_array(diag_physics,'tsq'       ,tsq       )
+       call mpas_pool_get_array(diag_physics,'sh3d'      ,sh3d      )
+       call mpas_pool_get_array(diag_physics,'sm3d'      ,sm3d      )
+       call mpas_pool_get_array(diag_physics,'cldfrac_bl',cldfrac_bl)
+       call mpas_pool_get_array(diag_physics,'qc_bl'     ,qc_bl     )
+       call mpas_pool_get_array(diag_physics,'qi_bl'     ,qi_bl     )
+       if(config_mynn_edmf_output == 1) then
+          call mpas_pool_get_array(diag_physics,'edmf_a'    ,edmf_a    )
+          call mpas_pool_get_array(diag_physics,'edmf_ent'  ,edmf_ent  )
+          call mpas_pool_get_array(diag_physics,'edmf_qc'   ,edmf_qc   )
+          call mpas_pool_get_array(diag_physics,'edmf_qt'   ,edmf_qt   )
+          call mpas_pool_get_array(diag_physics,'edmf_thl'  ,edmf_thl  )
+          call mpas_pool_get_array(diag_physics,'edmf_w'    ,edmf_w    )
+          call mpas_pool_get_array(diag_physics,'sub_thl'   ,sub_thl   )
+          call mpas_pool_get_array(diag_physics,'sub_qv'    ,sub_qv    )
+          call mpas_pool_get_array(diag_physics,'det_thl'   ,det_thl   )
+          call mpas_pool_get_array(diag_physics,'det_qv'    ,det_qv    )
+       endif
+          
+       do j = jts,jte
+       do i = its,ite
+          dx_p(i,j)   = len_disp / meshDensity(i)**0.25
+          ch_p(i,j)   = ch(i)
+          qsfc_p(i,j) = qsfc(i)
+          tsk_p(i,j)  = skintemp(i)
+       enddo
+       enddo
+
+       do j = jts,jte
+       do k = kts,kte
+       do i = its,ite
+          elpbl_p(i,k,j)    = el_pbl(k,i)
+          cov_p(i,k,j)      = cov(k,i)
+          qke_p(i,k,j)      = qke(k,i)
+          qsq_p(i,k,j)      = qsq(k,i)
+          tsq_p(i,k,j)      = tsq(k,i)
+          qkeadv_p(i,k,j)   = qke_adv(k,i)
+          sh3d_p(i,k,j)     = sh3d(k,i)
+          sm3d_p(i,k,j)     = sm3d(k,i)
+          cldfrabl_p(i,k,j) = cldfrac_bl(k,i)
+          qcbl_p(i,k,j)     = qc_bl(k,i)
+          qibl_p(i,k,j)     = qi_bl(k,i)
+
+          rqsblten_p(i,k,j)   = 0._RKIND
+          rncblten_p(i,k,j)   = 0._RKIND
+          rniblten_p(i,k,j)   = 0._RKIND
+          rnifablten_p(i,k,j) = 0._RKIND
+          rnwfablten_p(i,k,j) = 0._RKIND
+
+          pattern_spp_pbl(i,k,j) = 0._RKIND
+
+       enddo
+       enddo
+       enddo
+
+       if(config_mynn_edmf_output == 1)then
+         do j = jts,jte
+         do k = kts,kte
+         do i = its,ite
+            edmfa_p(i,k,j)    = edmf_a(k,i)
+            edmfent_p(i,k,j)  = edmf_ent(k,i)
+            edmfqc_p(i,k,j)   = edmf_qc(k,i)
+            edmfqt_p(i,k,j)   = edmf_qt(k,i)
+            edmfthl_p(i,k,j)  = edmf_thl(k,i)
+            edmfw_p(i,k,j)    = edmf_w(k,i)
+            subthl_p(i,k,j)   = sub_thl(k,i)
+            subqv_p(i,k,j)    = sub_qv(k,i)
+            detthl_p(i,k,j)   = det_thl(k,i)
+            detqv_p(i,k,j)    = det_qv(k,i)
+         enddo
+         enddo
+         enddo
+       endif
+
+       if(config_mynn_tkebudget == 1)then
+         do j = jts,jte
+         do k = kts,kte
+         do i = its,ite
+            dqke_p(i,k,j)     = 0._RKIND
+            qbuoy_p(i,k,j)    = 0._RKIND
+            qdiss_p(i,k,j)    = 0._RKIND
+            qshear_p(i,k,j)   = 0._RKIND
+            qwt_p(i,k,j)      = 0._RKIND
+         enddo
+         enddo
+         enddo
+       endif
+      
+       do j = jts,jte
+       do i = its,ite
+          maxwidthbl_p(i,j)    = 0._RKIND
+          maxmfbl_p(i,j)       = 0._RKIND
+          zbl_plume_p(i,j)     = 0._RKIND
+          excessh_p(i,j)       = 0._RKIND
+          excessq_p(i,j)       = 0._RKIND
+          maxwidth_dd_p(i,j)   = 0._RKIND
+          maxmf_dd_p(i,j)      = 0._RKIND
+          maxtkeprod_dd_p(i,j) = 0._RKIND
+          cldtop_cooling_p(i,j)= 0._RKIND
+          ent_eff_p(i,j)       = 0._RKIND
+       enddo
+       enddo
 
     case default
 
@@ -529,7 +755,7 @@
  end subroutine pbl_from_MPAS
 
 !=================================================================================================================
- subroutine pbl_to_MPAS(configs,diag_physics,tend_physics,its,ite)
+ subroutine pbl_to_MPAS(configs,state,diag_physics,tend_physics,its,ite)
 !=================================================================================================================
 
 !input arguments:
@@ -538,6 +764,7 @@
 !inout arguments:
  type(mpas_pool_type),intent(inout):: diag_physics
  type(mpas_pool_type),intent(inout):: tend_physics
+ type(mpas_pool_type),intent(inout):: state
 
  integer,intent(in):: its,ite
 
@@ -556,9 +783,12 @@
 
 !local pointers for YSU scheme:
  real(kind=RKIND),dimension(:,:),pointer:: exch_h
-
-!local pointers for MYNN scheme:
  real(kind=RKIND),dimension(:),pointer  :: delta,wstar
+      
+!local pointers for MYNN scheme:
+ integer,pointer:: config_mynn_tkebudget,config_mynn_edmf_output
+ real(kind=RKIND),dimension(:),pointer  :: maxmf,maxwidth,ztop_plume,excess_h,excess_q
+ real(kind=RKIND),dimension(:),pointer  :: maxmf_dd,maxwidth_dd,maxtkeprod_dd,cldtop_cooling,ent_eff
  real(kind=RKIND),dimension(:,:),pointer:: cov,qke,qsq,tsq,sh3d,sm3d,tke_pbl,qke_adv,el_pbl,dqke,qbuoy, &
                                            qdiss,qshear,qwt
  real(kind=RKIND),dimension(:,:),pointer:: cldfrac_bl,qc_bl,qi_bl
@@ -716,7 +946,143 @@
              enddo
           enddo
        endif
+       
+      case("bl_mynnedmf")
+       call mpas_pool_get_config(configs,'config_mynn_edmf_output',config_mynn_edmf_output)
+       call mpas_pool_get_config(configs,'config_mynn_tkebudget',config_mynn_tkebudget)
+       call mpas_pool_get_array(diag_physics,'maxmf'         ,maxmf         )
+       call mpas_pool_get_array(diag_physics,'maxwidth'      ,maxwidth      )
+       call mpas_pool_get_array(diag_physics,'ztop_plume'    ,ztop_plume    )
+       call mpas_pool_get_array(diag_physics,'excess_h'      ,excess_h      )
+       call mpas_pool_get_array(diag_physics,'excess_q'      ,excess_q      )
+       call mpas_pool_get_array(diag_physics,'maxmf_dd'      ,maxmf_dd      )
+       call mpas_pool_get_array(diag_physics,'maxwidth_dd'   ,maxwidth_dd   )
+       call mpas_pool_get_array(diag_physics,'maxtkeprod_dd' ,maxtkeprod_dd )
+       call mpas_pool_get_array(diag_physics,'cldtop_cooling',cldtop_cooling)
+       call mpas_pool_get_array(diag_physics,'ent_eff'       ,ent_eff       )
+       call mpas_pool_get_array(diag_physics,'el_pbl'        ,el_pbl        )
+       call mpas_pool_get_array(diag_physics,'cov'           ,cov           )
+       call mpas_pool_get_array(diag_physics,'qke'           ,qke           )
+       call mpas_pool_get_array(diag_physics,'qke_adv'       ,qke_adv       )
+       call mpas_pool_get_array(diag_physics,'qsq'           ,qsq           )
+       call mpas_pool_get_array(diag_physics,'tsq'           ,tsq           )
+       call mpas_pool_get_array(diag_physics,'sh3d'          ,sh3d          )
+       call mpas_pool_get_array(diag_physics,'sm3d'          ,sm3d          )
+       if(config_mynn_tkebudget == 1) then
+          call mpas_pool_get_array(diag_physics,'dqke'       ,dqke          )
+          call mpas_pool_get_array(diag_physics,'qbuoy'      ,qbuoy         )
+          call mpas_pool_get_array(diag_physics,'qdiss'      ,qdiss         )
+          call mpas_pool_get_array(diag_physics,'qshear'     ,qshear        )
+          call mpas_pool_get_array(diag_physics,'qwt'        ,qwt           )
+       endif
+       call mpas_pool_get_array(diag_physics,'cldfrac_bl'    ,cldfrac_bl    )
+       call mpas_pool_get_array(diag_physics,'qc_bl'         ,qc_bl         )
+       call mpas_pool_get_array(diag_physics,'qi_bl'         ,qi_bl         )
+       if(config_mynn_edmf_output == 1) then
+          call mpas_pool_get_array(diag_physics,'edmf_a'     ,edmf_a        )
+          call mpas_pool_get_array(diag_physics,'edmf_ent'   ,edmf_ent      )
+          call mpas_pool_get_array(diag_physics,'edmf_qc'    ,edmf_qc       )
+          call mpas_pool_get_array(diag_physics,'edmf_qt'    ,edmf_qt       )
+          call mpas_pool_get_array(diag_physics,'edmf_thl'   ,edmf_thl      )
+          call mpas_pool_get_array(diag_physics,'edmf_w'     ,edmf_w        )
+          call mpas_pool_get_array(diag_physics,'sub_thl'    ,sub_thl       )
+          call mpas_pool_get_array(diag_physics,'sub_qv'     ,sub_qv        )
+          call mpas_pool_get_array(diag_physics,'det_thl'    ,det_thl       )
+          call mpas_pool_get_array(diag_physics,'det_qv'     ,det_qv        )
+       endif
+       call mpas_pool_get_array(tend_physics,'rqsblten'      ,rqsblten      )
 
+       do j = jts,jte
+       do i = its,ite
+          maxmf(i)         = maxmfbl_p(i,j)
+          maxwidth(i)      = maxwidthbl_p(i,j)
+          ztop_plume(i)    = zbl_plume_p(i,j)
+          excess_h(i)      = excessh_p(i,j)
+          excess_q(i)      = excessq_p(i,j)
+          maxmf_dd(i)      = maxmf_dd_p(i,j)
+          maxwidth_dd(i)   = maxwidth_dd_p(i,j)
+          maxtkeprod_dd(i) = maxtkeprod_dd_p(i,j)
+          cldtop_cooling(i)= cldtop_cooling_p(i,j)
+          ent_eff(i)       = ent_eff_p(i,j)
+       enddo
+       enddo
+
+       do j = jts,jte
+       do k = kts,kte
+       do i = its,ite
+          el_pbl(k,i)     = elpbl_p(i,k,j)
+          cov(k,i)        = cov_p(i,k,j)
+          qke(k,i)        = qke_p(i,k,j)
+          qsq(k,i)        = qsq_p(i,k,j)
+          tsq(k,i)        = tsq_p(i,k,j)
+          sh3d(k,i)       = sh3d_p(i,k,j)
+          sm3d(k,i)       = sm3d_p(i,k,j)
+          qke_adv(k,i)    = qkeadv_p(i,k,j)
+          cldfrac_bl(k,i) = cldfrabl_p(i,k,j)
+          qc_bl(k,i)      = qcbl_p(i,k,j)
+          qi_bl(k,i)      = qibl_p(i,k,j)
+          rqsblten(k,i)   = rqsblten_p(i,k,j)
+       enddo
+       enddo
+       enddo
+
+       if(config_mynn_edmf_output == 1)then
+          do j = jts,jte
+          do k = kts,kte
+          do i = its,ite
+             edmf_a(k,i)     = edmfa_p(i,k,j)
+             edmf_ent(k,i)   = edmfent_p(i,k,j)
+             edmf_qc(k,i)    = edmfqc_p(i,k,j)
+             edmf_qt(k,i)    = edmfqt_p(i,k,j)
+             edmf_thl(k,i)   = edmfthl_p(i,k,j)
+             edmf_w(k,i)     = edmfw_p(i,k,j)
+             sub_thl(k,i)    = subthl_p(i,k,j)
+             sub_qv(k,i)     = subqv_p(i,k,j)
+             det_thl(k,i)    = detthl_p(i,k,j)
+             det_qv(k,i)     = detqv_p(i,k,j)
+          enddo
+          enddo
+          enddo
+       endif
+       if(config_mynn_tkebudget == 1)then
+          do j = jts,jte
+          do k = kts,kte
+          do i = its,ite
+             dqke(k,i)       = dqke_p(i,k,j)
+             qbuoy(k,i)      = qbuoy_p(i,k,j)
+             qdiss(k,i)      = qdiss_p(i,k,j)
+             qshear(k,i)     = qshear_p(i,k,j)
+             qwt(k,i)        = qwt_p(i,k,j)
+          enddo
+          enddo
+          enddo
+       endif
+       
+       if(f_ni) then
+          call mpas_pool_get_array(tend_physics,'rniblten',rniblten)
+          do j = jts,jte
+             do k = kts,kte
+                do i = its,ite
+                   rniblten(k,i) = rniblten_p(i,k,j)
+                enddo
+             enddo
+          enddo
+       endif
+       if(f_nc .and. f_nifa .and. f_nwfa) then
+          call mpas_pool_get_array(tend_physics,'rncblten'  ,rncblten  )
+          call mpas_pool_get_array(tend_physics,'rnifablten',rnifablten)
+          call mpas_pool_get_array(tend_physics,'rnwfablten',rnwfablten)
+          do j = jts,jte
+             do k = kts,kte
+                do i = its,ite
+                   rncblten(k,i)   = rncblten_p(i,k,j)
+                   rnifablten(k,i) = rnifablten_p(i,k,j)
+                   rnwfablten(k,i) = rnwfablten_p(i,k,j)
+                enddo
+             enddo
+          enddo
+       endif
+       
     case default
 
  end select pbl_select
@@ -754,12 +1120,13 @@
  end subroutine init_pbl
 
 !=================================================================================================================
- subroutine driver_pbl(itimestep,configs,mesh,sfc_input,diag_physics,tend_physics,its,ite)
+ subroutine driver_pbl(itimestep,configs,state,mesh,sfc_input,diag_physics,tend_physics,its,ite)
 !=================================================================================================================
 
 !input arguments:
  type(mpas_pool_type),intent(in):: configs
  type(mpas_pool_type),intent(in):: mesh
+ type(mpas_pool_type),intent(inout):: state
 
  integer,intent(in):: its,ite
  integer,intent(in):: itimestep
@@ -788,12 +1155,27 @@
                    bl_mynn_edmf_tke,    &
                    bl_mynn_edmf_output, &
                    bl_mynn_mixscalars,  &
+                   bl_mynn_mixaerosols, &
+                   bl_mynn_mixnumcon,   &
                    bl_mynn_cloudmix,    &
                    bl_mynn_mixqt,       &
-                   bl_mynn_tkebudget
+                   bl_mynn_ess,         &
+                   bl_mynn_tkebudget,   &
+                   icloud_bl,           &
+                   spp_pbl
 
  real(kind=RKIND),pointer:: bl_mynn_closure
 
+!temporary smoke arrays needed for mynn-edmf (leave unallocated)
+ logical,parameter::mix_chem=.false.
+ logical,parameter::enh_mix=.false.
+ integer,parameter::num_chem=1
+ real, allocatable :: chem_p(:,:,:,:)
+ real, allocatable :: tend_chem_settle_p(:,:,:,:)
+ real, allocatable :: ddvel_p(:,:,:)
+ real, allocatable :: frp_out_p(:,:)
+ real, allocatable :: aero_emis_for_enhmix_p(:,:)
+      
 !local variables:
  integer:: initflag
  integer:: i,k,j
@@ -815,7 +1197,7 @@
  call mpas_pool_get_config(configs,'config_pbl_scheme'  ,pbl_scheme         )
 
 !copy MPAS arrays to local arrays:
- call pbl_from_MPAS(configs,mesh,sfc_input,diag_physics,tend_physics,its,ite)
+ call pbl_from_MPAS(configs,state,mesh,sfc_input,diag_physics,tend_physics,its,ite)
 
  initflag = 1
  if(config_do_restart .or. itimestep > 1) initflag = 0
@@ -957,8 +1339,140 @@
                   its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte ,                 &
                   errmsg = errmsg , errflg = errflg                                                       &
                           )
-       call mpas_timer_stop('bl_mynn')
-!      call mpas_log_write('--- exit subroutine mynn_bl_driver:')
+      call mpas_timer_stop('bl_mynn')
+!     call mpas_log_write('--- exit subroutine mynn_bl_driver:')
+!     call mpas_log_write(' ')
+       
+    case("bl_mynnedmf")
+       call mpas_pool_get_config(configs,'config_mynn_cloudpdf'   ,bl_mynn_cloudpdf   )
+       call mpas_pool_get_config(configs,'config_mynn_mixlength'  ,bl_mynn_mixlength  )
+       call mpas_pool_get_config(configs,'config_mynn_stfunc'     ,bl_mynn_stfunc     )
+       call mpas_pool_get_config(configs,'config_mynn_topdown'    ,bl_mynn_topdown    )
+       call mpas_pool_get_config(configs,'config_mynn_scaleaware' ,bl_mynn_scaleaware )
+       call mpas_pool_get_config(configs,'config_mynn_dheat_opt'  ,bl_mynn_dheat_opt  )
+       call mpas_pool_get_config(configs,'config_mynn_edmf'       ,bl_mynn_edmf       )
+       call mpas_pool_get_config(configs,'config_mynn_edmf_dd'    ,bl_mynn_edmf_dd    )
+       call mpas_pool_get_config(configs,'config_mynn_edmf_mom'   ,bl_mynn_edmf_mom   )
+       call mpas_pool_get_config(configs,'config_mynn_edmf_tke'   ,bl_mynn_edmf_tke   )
+       call mpas_pool_get_config(configs,'config_mynn_edmf_output',bl_mynn_edmf_output)
+       call mpas_pool_get_config(configs,'config_mynn_closure'    ,bl_mynn_closure    )
+       call mpas_pool_get_config(configs,'config_mynn_mixscalars' ,bl_mynn_mixscalars )
+       call mpas_pool_get_config(configs,'config_mynn_mixaerosols',bl_mynn_mixaerosols)
+       call mpas_pool_get_config(configs,'config_mynn_mixnumcon'  ,bl_mynn_mixnumcon  )
+       call mpas_pool_get_config(configs,'config_mynn_mixclouds'  ,bl_mynn_cloudmix   )
+       call mpas_pool_get_config(configs,'config_mynn_mixqt'      ,bl_mynn_mixqt      )
+       call mpas_pool_get_config(configs,'config_mynn_ess'        ,bl_mynn_ess        )
+       call mpas_pool_get_config(configs,'config_mynn_tkeadvect'  ,bl_mynn_tkeadvect  )
+       call mpas_pool_get_config(configs,'config_mynn_tkebudget'  ,bl_mynn_tkebudget  )
+       call mpas_pool_get_config(configs,'config_icloud_bl'       ,icloud_bl          )
+       call mpas_pool_get_config(configs,'config_spp_pbl'         ,spp_pbl            )
+
+!      call mpas_log_write(' ')
+!      call mpas_log_write('--- enter subroutine mynn_bl_driver:')
+!      call mpas_log_write('--- config_mynn_cloudpdf    = $i',intArgs=(/bl_mynn_cloudpdf/))
+!      call mpas_log_write('--- config_mynn_mixlength   = $i',intArgs=(/bl_mynn_mixlength/))
+!      call mpas_log_write('--- config_mynn_stfunc      = $i',intArgs=(/bl_mynn_stfunc/))
+!      call mpas_log_write('--- config_mynn_topdown     = $i',intArgs=(/bl_mynn_topdown/))
+!      call mpas_log_write('--- config_mynn_scaleaware  = $i',intArgs=(/bl_mynn_scaleaware/))
+!      call mpas_log_write('--- config_mynn_dheat_opt   = $i',intArgs=(/bl_mynn_dheat_opt/))
+!      call mpas_log_write('--- config_mynn_edmf        = $i',intArgs=(/bl_mynn_edmf/))
+!      call mpas_log_write('--- config_mynn_edmf_dd     = $i',intArgs=(/bl_mynn_edmf_dd/))
+!      call mpas_log_write('--- config_mynn_edmf_mom    = $i',intArgs=(/bl_mynn_edmf_mom/))
+!      call mpas_log_write('--- config_mynn_edmf_tke    = $i',intArgs=(/bl_mynn_edmf_tke/))
+!      call mpas_log_write('--- config_mynn_edmf_output = $i',intArgs=(/bl_mynn_edmf_output/))
+!      call mpas_log_write('--- config_mynn_mixscalars  = $i',intArgs=(/bl_mynn_mixscalars/))
+!      call mpas_log_write('--- config_mynn_mixclouds   = $i',intArgs=(/bl_mynn_cloudmix/))
+!      call mpas_log_write('--- config_mynn_mixqt       = $i',intArgs=(/bl_mynn_mixqt/))
+!      call mpas_log_write('--- config_mynn_tkeadvect   = $l',logicArgs=(/bl_mynn_tkeadvect/))
+!      call mpas_log_write('--- config_mynn_tkebudget   = $i',intArgs=(/bl_mynn_tkebudget/))
+!      call mpas_log_write('--- config_mynn_closure     = $r',realArgs=(/bl_mynn_closure/))
+!      call mpas_log_write(' ')
+!      call mpas_log_write('--- f_qc   = $l',logicArgs=(/f_qc/)  )
+!      call mpas_log_write('--- f_qi   = $l',logicArgs=(/f_qi/)  )
+!      call mpas_log_write('--- f_qs   = $l',logicArgs=(/f_qs/)  )
+!      call mpas_log_write('--- f_qoz  = $l',logicArgs=(/f_qoz/) )
+!      call mpas_log_write('--- f_nc   = $l',logicArgs=(/f_nc/)  )
+!      call mpas_log_write('--- f_ni   = $l',logicArgs=(/f_ni/)  )
+!      call mpas_log_write('--- f_nifa = $l',logicArgs=(/f_nifa/))
+!      call mpas_log_write('--- f_nwfa = $l',logicArgs=(/f_nwfa/))
+!      call mpas_log_write('--- f_nbca = $l',logicArgs=(/f_nbca/))
+
+!       if (do_chemistry) mix_chem = .true.
+
+       call mpas_timer_start('bl_mynnedmf')
+       call mynnedmf_driver( &
+                  f_qc       = f_qc         , f_qi         = f_qi           , f_qs          = f_qs             , &
+                  f_qoz      = f_qoz        , f_nc         = f_nc           , f_ni          = f_ni             , &
+                  f_nifa     = f_nifa       , f_nwfa       = f_nwfa         , f_nbca        = f_nbca           , &
+                  icloud_bl  = icloud_bl    , delt         = dt_pbl         , dx            = dx_p             , &
+                  xland      = xland_p      , ps           = psfc_p         , ts            = tsk_p            , &
+                  qsfc       = qsfc_p       , ust          = ust_p          , ch            = ch_p             , &
+                  hfx        = hfx_p        , qfx          = qfx_p          ,                                    &
+                  wspd       = wspd_p       , znt          = znt_p          , uoce          = uoce_p           , &
+                  voce       = voce_p       , dz           = dz_p           , u             = u_p              , &
+                  v          = v_p          , w            = w_p            , th            = th_p             , &
+                  tt         = t_p          , p            = pres_p         , exner         = pi_p             , &
+                  rho        = rho_p        , qv           = qv_p           , qc            = qc_p             , &
+                  qi         = qi_p         , qs           = qs_p           , ni            = ni_p             , &
+                  nc         = nc_p         , nifa         = nifa_p         , nwfa          = nwfa_p           , &
+                  rthraten   = rthraten_p   , pblh         = hpbl_p         , kpbl          = kpbl_p           , &
+                  cldfra_bl  = cldfrabl_p   , qc_bl        = qcbl_p         , qi_bl         = qibl_p           , &
+                  maxwidth   = maxwidthbl_p , maxmf        = maxmfbl_p      , ztop_plume    = zbl_plume_p      , &
+                  excess_h   = excessh_p    , excess_q     = excessq_p      , maxwidth_dd   = maxwidth_dd_p    , &
+                  maxmf_dd   = maxmf_dd_p   , maxtkeprod   = maxtkeprod_dd_p, cldtop_cooling= cldtop_cooling_p , &
+                  ent_eff    = ent_eff_p    ,                                                                    &
+                  qke        = qke_p        , qke_adv      = qkeadv_p       ,                                    &
+                  tsq        = tsq_p        , qsq          = qsq_p          , cov           = cov_p            , &
+                  el_pbl     = elpbl_p      , rublten      = rublten_p      , rvblten       = rvblten_p        , &
+                  rthblten   = rthblten_p   , rqvblten     = rqvblten_p     , rqcblten      = rqcblten_p       , &
+                  rqiblten   = rqiblten_p   , rqsblten     = rqsblten_p     , rniblten      = rniblten_p       , &
+                  rncblten   = rncblten_p   , rnwfablten   = rnwfablten_p   , rnifablten    = rnifablten_p     , &
+                  edmf_a     = edmfa_p      , edmf_w       = edmfw_p        , edmf_qt       = edmfqt_p         , &
+                  edmf_thl   = edmfthl_p    , edmf_ent     = edmfent_p      , edmf_qc       = edmfqc_p         , &
+                  sub_thl    = subthl_p     , sub_sqv      = subqv_p        , det_thl       = detthl_p         , &
+                  det_sqv    = detqv_p      , exch_h       = kzh_p          , exch_m        = kzm_p            , &
+                  dqke       = dqke_p       , qwt          = qwt_p          , qshear        = qshear_p         , &
+                  qbuoy      = qbuoy_p      , qdiss        = qdiss_p        , sh3d          = sh3d_p           , &
+                  sm3d       = sm3d_p       , spp_pbl      = spp_pbl        , pattern_spp   = pattern_spp_pbl  , &
+                  do_restart         = config_do_restart   ,                                              &
+                  do_DAcycling       = config_do_DAcycling ,                                              &
+                  initflag           = initflag            ,                                              &
+                  bl_mynn_tkeadvect  = bl_mynn_tkeadvect   ,                                              &
+                  bl_mynn_tkebudget  = bl_mynn_tkebudget   ,                                              &
+                  bl_mynn_cloudpdf   = bl_mynn_cloudpdf    ,                                              &
+                  bl_mynn_mixlength  = bl_mynn_mixlength   ,                                              &
+                  bl_mynn_closure    = bl_mynn_closure     ,                                              &
+                  bl_mynn_stfunc     = bl_mynn_stfunc      ,                                              &
+                  bl_mynn_topdown    = bl_mynn_topdown     ,                                              &
+                  bl_mynn_scaleaware = bl_mynn_scaleaware  ,                                              &
+                  bl_mynn_dheat_opt  = bl_mynn_dheat_opt   ,                                              &
+                  bl_mynn_edmf       = bl_mynn_edmf        ,                                              &
+                  bl_mynn_edmf_dd    = bl_mynn_edmf_dd     ,                                              &
+                  bl_mynn_edmf_mom   = bl_mynn_edmf_mom    ,                                              &
+                  bl_mynn_edmf_tke   = bl_mynn_edmf_tke    ,                                              &
+                  bl_mynn_output     = bl_mynn_edmf_output ,                                              &
+                  bl_mynn_mixscalars = bl_mynn_mixscalars  ,                                              &
+                  bl_mynn_mixaerosols= bl_mynn_mixaerosols ,                                              &
+                  bl_mynn_mixnumcon  = bl_mynn_mixnumcon   ,                                              &
+                  bl_mynn_cloudmix   = bl_mynn_cloudmix    ,                                              &
+                  bl_mynn_mixqt      = bl_mynn_mixqt       ,                                              &
+                  bl_mynn_ess        = bl_mynn_ess         ,                                              &
+                  mix_chem           = mix_chem            ,                                              &
+                  nchem              = num_chem            ,                                              &
+                  ndvel              = num_chem            ,                                              &
+                  chem3d             = chem_p              ,                                              &
+                  vd3d               = ddvel_p             ,                                              &
+                  settle3d           = tend_chem_settle_p  ,                                              &
+                  enh_mix            = enh_mix             ,                                              &
+                  frp_mean           = frp_out_p           ,                                              &
+                  emis_ant_no        = aero_emis_for_enhmix_p ,                                           &
+                  ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde ,                 &
+                  ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,                 &
+                  its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte ,                 &
+                  errmsg = errmsg , errflg = errflg                                                       &
+                          )
+       call mpas_timer_stop('bl_mynnedmf')
+!      call mpas_log_write('--- exit subroutine mynnedmf_driver:')
 !      call mpas_log_write(' ')
 
     case default
@@ -966,7 +1480,7 @@
  end select pbl_select
 
 !copy local arrays to MPAS grid:
- call pbl_to_MPAS(configs,diag_physics,tend_physics,its,ite)
+ call pbl_to_MPAS(configs,state,diag_physics,tend_physics,its,ite)
 
 !call mpas_log_write('--- end subroutine driver_pbl.')
 

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
@@ -1346,10 +1346,6 @@
     case("bl_mynnedmf")
        call mpas_pool_get_config(configs,'config_mynn_cloudpdf'   ,bl_mynn_cloudpdf   )
        call mpas_pool_get_config(configs,'config_mynn_mixlength'  ,bl_mynn_mixlength  )
-       call mpas_pool_get_config(configs,'config_mynn_stfunc'     ,bl_mynn_stfunc     )
-       call mpas_pool_get_config(configs,'config_mynn_topdown'    ,bl_mynn_topdown    )
-       call mpas_pool_get_config(configs,'config_mynn_scaleaware' ,bl_mynn_scaleaware )
-       call mpas_pool_get_config(configs,'config_mynn_dheat_opt'  ,bl_mynn_dheat_opt  )
        call mpas_pool_get_config(configs,'config_mynn_edmf'       ,bl_mynn_edmf       )
        call mpas_pool_get_config(configs,'config_mynn_edmf_dd'    ,bl_mynn_edmf_dd    )
        call mpas_pool_get_config(configs,'config_mynn_edmf_mom'   ,bl_mynn_edmf_mom   )
@@ -1371,10 +1367,6 @@
 !      call mpas_log_write('--- enter subroutine mynn_bl_driver:')
 !      call mpas_log_write('--- config_mynn_cloudpdf    = $i',intArgs=(/bl_mynn_cloudpdf/))
 !      call mpas_log_write('--- config_mynn_mixlength   = $i',intArgs=(/bl_mynn_mixlength/))
-!      call mpas_log_write('--- config_mynn_stfunc      = $i',intArgs=(/bl_mynn_stfunc/))
-!      call mpas_log_write('--- config_mynn_topdown     = $i',intArgs=(/bl_mynn_topdown/))
-!      call mpas_log_write('--- config_mynn_scaleaware  = $i',intArgs=(/bl_mynn_scaleaware/))
-!      call mpas_log_write('--- config_mynn_dheat_opt   = $i',intArgs=(/bl_mynn_dheat_opt/))
 !      call mpas_log_write('--- config_mynn_edmf        = $i',intArgs=(/bl_mynn_edmf/))
 !      call mpas_log_write('--- config_mynn_edmf_dd     = $i',intArgs=(/bl_mynn_edmf_dd/))
 !      call mpas_log_write('--- config_mynn_edmf_mom    = $i',intArgs=(/bl_mynn_edmf_mom/))
@@ -1442,10 +1434,6 @@
                   bl_mynn_cloudpdf   = bl_mynn_cloudpdf    ,                                              &
                   bl_mynn_mixlength  = bl_mynn_mixlength   ,                                              &
                   bl_mynn_closure    = bl_mynn_closure     ,                                              &
-                  bl_mynn_stfunc     = bl_mynn_stfunc      ,                                              &
-                  bl_mynn_topdown    = bl_mynn_topdown     ,                                              &
-                  bl_mynn_scaleaware = bl_mynn_scaleaware  ,                                              &
-                  bl_mynn_dheat_opt  = bl_mynn_dheat_opt   ,                                              &
                   bl_mynn_edmf       = bl_mynn_edmf        ,                                              &
                   bl_mynn_edmf_dd    = bl_mynn_edmf_dd     ,                                              &
                   bl_mynn_edmf_mom   = bl_mynn_edmf_mom    ,                                              &

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
@@ -1160,9 +1160,7 @@
                    bl_mynn_cloudmix,    &
                    bl_mynn_mixqt,       &
                    bl_mynn_ess,         &
-                   bl_mynn_tkebudget,   &
-                   icloud_bl,           &
-                   spp_pbl
+                   bl_mynn_tkebudget
 
  real(kind=RKIND),pointer:: bl_mynn_closure
 
@@ -1360,8 +1358,7 @@
        call mpas_pool_get_config(configs,'config_mynn_ess'        ,bl_mynn_ess        )
        call mpas_pool_get_config(configs,'config_mynn_tkeadvect'  ,bl_mynn_tkeadvect  )
        call mpas_pool_get_config(configs,'config_mynn_tkebudget'  ,bl_mynn_tkebudget  )
-       call mpas_pool_get_config(configs,'config_icloud_bl'       ,icloud_bl          )
-       call mpas_pool_get_config(configs,'config_spp_pbl'         ,spp_pbl            )
+!       call mpas_pool_get_config(configs,'config_spp_pbl'         ,spp_pbl            )
 
 !      call mpas_log_write(' ')
 !      call mpas_log_write('--- enter subroutine mynn_bl_driver:')
@@ -1396,7 +1393,7 @@
                   f_qc       = f_qc         , f_qi         = f_qi           , f_qs          = f_qs             , &
                   f_qoz      = f_qoz        , f_nc         = f_nc           , f_ni          = f_ni             , &
                   f_nifa     = f_nifa       , f_nwfa       = f_nwfa         , f_nbca        = f_nbca           , &
-                  icloud_bl  = icloud_bl    , delt         = dt_pbl         , dx            = dx_p             , &
+                  delt       = dt_pbl       , dx           = dx_p           ,                                    &
                   xland      = xland_p      , ps           = psfc_p         , ts            = tsk_p            , &
                   qsfc       = qsfc_p       , ust          = ust_p          , ch            = ch_p             , &
                   hfx        = hfx_p        , qfx          = qfx_p          ,                                    &

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
@@ -1391,8 +1391,8 @@
        call mpas_timer_start('bl_mynnedmf')
        call mynnedmf_driver( &
                   f_qc       = f_qc         , f_qi         = f_qi           , f_qs          = f_qs             , &
-                  f_qoz      = f_qoz        , f_nc         = f_nc           , f_ni          = f_ni             , &
-                  f_nifa     = f_nifa       , f_nwfa       = f_nwfa         , f_nbca        = f_nbca           , &
+                  f_qoz      = f_qoz        , f_qnc        = f_nc           , f_qni         = f_ni             , &
+                  f_qnifa    = f_nifa       , f_qnwfa      = f_nwfa         , f_qnbca       = f_nbca           , &
                   delt       = dt_pbl       , dx           = dx_p           ,                                    &
                   xland      = xland_p      , ps           = psfc_p         , ts            = tsk_p            , &
                   qsfc       = qsfc_p       , ust          = ust_p          , ch            = ch_p             , &
@@ -1400,10 +1400,11 @@
                   wspd       = wspd_p       , znt          = znt_p          , uoce          = uoce_p           , &
                   voce       = voce_p       , dz           = dz_p           , u             = u_p              , &
                   v          = v_p          , w            = w_p            , th            = th_p             , &
-                  tt         = t_p          , p            = pres_p         , exner         = pi_p             , &
-                  rho        = rho_p        , qv           = qv_p           , qc            = qc_p             , &
-                  qi         = qi_p         , qs           = qs_p           , ni            = ni_p             , &
-                  nc         = nc_p         , nifa         = nifa_p         , nwfa          = nwfa_p           , &
+                  tk         = t_p          , p            = pres_p         , pint          = pres2_hyd_p      , &
+                  exner      = pi_p         , rho          = rho_p          ,                                    &
+                  qv         = qv_p         , qc           = qc_p           ,                                    &
+                  qi         = qi_p         , qs           = qs_p           , qni           = ni_p             , &
+                  qnc        = nc_p         , qnifa        = nifa_p         , qnwfa         = nwfa_p           , &
                   rthraten   = rthraten_p   , pblh         = hpbl_p         , kpbl          = kpbl_p           , &
                   cldfra_bl  = cldfrabl_p   , qc_bl        = qcbl_p         , qi_bl         = qibl_p           , &
                   maxwidth   = maxwidthbl_p , maxmf        = maxmfbl_p      , ztop_plume    = zbl_plume_p      , &
@@ -1414,8 +1415,8 @@
                   tsq        = tsq_p        , qsq          = qsq_p          , cov           = cov_p            , &
                   el_pbl     = elpbl_p      , rublten      = rublten_p      , rvblten       = rvblten_p        , &
                   rthblten   = rthblten_p   , rqvblten     = rqvblten_p     , rqcblten      = rqcblten_p       , &
-                  rqiblten   = rqiblten_p   , rqsblten     = rqsblten_p     , rniblten      = rniblten_p       , &
-                  rncblten   = rncblten_p   , rnwfablten   = rnwfablten_p   , rnifablten    = rnifablten_p     , &
+                  rqiblten   = rqiblten_p   , rqsblten     = rqsblten_p     , rqniblten     = rniblten_p       , &
+                  rqncblten  = rncblten_p   , rqnwfablten  = rnwfablten_p   , rqnifablten   = rnifablten_p     , &
                   edmf_a     = edmfa_p      , edmf_w       = edmfw_p        , edmf_qt       = edmfqt_p         , &
                   edmf_thl   = edmfthl_p    , edmf_ent     = edmfent_p      , edmf_qc       = edmfqc_p         , &
                   sub_thl    = subthl_p     , sub_sqv      = subqv_p        , det_thl       = detthl_p         , &
@@ -1423,11 +1424,11 @@
                   dqke       = dqke_p       , qwt          = qwt_p          , qshear        = qshear_p         , &
                   qbuoy      = qbuoy_p      , qdiss        = qdiss_p        , sh3d          = sh3d_p           , &
                   sm3d       = sm3d_p       , spp_pbl      = spp_pbl        , pattern_spp   = pattern_spp_pbl  , &
-                  do_restart         = config_do_restart   ,                                              &
-                  do_DAcycling       = config_do_DAcycling ,                                              &
+                  restart            = config_do_restart   ,                                              &
+                  cycling            = config_do_DAcycling ,                                              &
                   initflag           = initflag            ,                                              &
                   bl_mynn_tkeadvect  = bl_mynn_tkeadvect   ,                                              &
-                  bl_mynn_tkebudget  = bl_mynn_tkebudget   ,                                              &
+                  tke_budget         = bl_mynn_tkebudget   ,                                              &
                   bl_mynn_cloudpdf   = bl_mynn_cloudpdf    ,                                              &
                   bl_mynn_mixlength  = bl_mynn_mixlength   ,                                              &
                   bl_mynn_closure    = bl_mynn_closure     ,                                              &

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
@@ -634,7 +634,7 @@
        call mpas_pool_get_array(diag_physics,'cldfrac_bl',cldfrac_bl)
        call mpas_pool_get_array(diag_physics,'qc_bl'     ,qc_bl     )
        call mpas_pool_get_array(diag_physics,'qi_bl'     ,qi_bl     )
-       if(config_mynn_edmf_output == 1) then
+       if(config_mynn_edmf_output > 0) then
           call mpas_pool_get_array(diag_physics,'edmf_a'    ,edmf_a    )
           call mpas_pool_get_array(diag_physics,'edmf_ent'  ,edmf_ent  )
           call mpas_pool_get_array(diag_physics,'edmf_qc'   ,edmf_qc   )
@@ -683,7 +683,7 @@
        enddo
        enddo
 
-       if(config_mynn_edmf_output == 1)then
+       if(config_mynn_edmf_output > 0)then
          do j = jts,jte
          do k = kts,kte
          do i = its,ite
@@ -978,7 +978,7 @@
        call mpas_pool_get_array(diag_physics,'cldfrac_bl'    ,cldfrac_bl    )
        call mpas_pool_get_array(diag_physics,'qc_bl'         ,qc_bl         )
        call mpas_pool_get_array(diag_physics,'qi_bl'         ,qi_bl         )
-       if(config_mynn_edmf_output == 1) then
+       if(config_mynn_edmf_output > 0) then
           call mpas_pool_get_array(diag_physics,'edmf_a'     ,edmf_a        )
           call mpas_pool_get_array(diag_physics,'edmf_ent'   ,edmf_ent      )
           call mpas_pool_get_array(diag_physics,'edmf_qc'    ,edmf_qc       )
@@ -1026,7 +1026,7 @@
        enddo
        enddo
 
-       if(config_mynn_edmf_output == 1)then
+       if(config_mynn_edmf_output > 0)then
           do j = jts,jte
           do k = kts,kte
           do i = its,ite

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_sfclayer.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_sfclayer.F
@@ -357,6 +357,7 @@
     case("sf_mynnsfclay")
        if(allocated(snowh_p)) deallocate(snowh_p)
        if(allocated(ch_p)   ) deallocate(ch_p   )
+       if(allocated(cqs_p)  ) deallocate(cqs_p  )
        if(allocated(qcg_p)  ) deallocate(qcg_p  )
        if(config_frac_seaice) then
           if(allocated(ch_sea)) deallocate(ch_sea)

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_sfclayer.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_sfclayer.F
@@ -15,6 +15,7 @@
  use mpas_atmphys_vars
 
  use module_sf_mynn,only: sfclay_mynn
+ use module_sf_mynnsfc_driver,only: mynnsfc_driver,mynnsfc_init
  use module_sf_sfclay
  use module_sf_sfclayrev,only: sfclayrev
  use sf_mynn,only: sf_mynn_init
@@ -146,6 +147,7 @@
  if(.not.allocated(xland_p) ) allocate(xland_p(ims:ime,jms:jme) )
  if(.not.allocated(zol_p)   ) allocate(zol_p(ims:ime,jms:jme)   )
  if(.not.allocated(znt_p)   ) allocate(znt_p(ims:ime,jms:jme)   )
+ if(.not.allocated(xice_p)  ) allocate(xice_p(ims:ime,jms:jme)  )
 
  if(config_frac_seaice) then
     if(.not.allocated(sst_p)      ) allocate(sst_p(ims:ime,jms:jme)      )
@@ -220,6 +222,16 @@
           if(.not.allocated(ch_sea)) allocate(ch_sea(ims:ime,jms:jme))
        endif
 
+   case("sf_mynnsfclay")
+       if(.not.allocated(snowh_p)) allocate(snowh_p(ims:ime,jms:jme))
+       if(.not.allocated(ch_p)   ) allocate(ch_p(ims:ime,jms:jme)   )
+       if(.not.allocated(cqs_p)  ) allocate(cqs_p(ims:ime,jms:jme)  )
+       if(.not.allocated(qcg_p)  ) allocate(qcg_p(ims:ime,jms:jme)  )
+       if(config_frac_seaice) then
+          if(.not.allocated(ch_sea) ) allocate(ch_sea(ims:ime,jms:jme) )
+          if(.not.allocated(cqs_sea)) allocate(cqs_sea(ims:ime,jms:jme))
+       endif
+
     case default
 
  end select sfclayer_select
@@ -279,10 +291,10 @@
  if(allocated(xland_p) ) deallocate(xland_p )
  if(allocated(zol_p)   ) deallocate(zol_p   )
  if(allocated(znt_p)   ) deallocate(znt_p   )
-
+ if(allocated(xice_p)  ) deallocate(xice_p  )
+      
  if(config_frac_seaice) then
     if(allocated(sst_p)      ) deallocate(sst_p      )
-    if(allocated(xice_p)     ) deallocate(xice_p     )
 
     if(allocated(br_sea)     ) deallocate(br_sea     )
     if(allocated(flhc_p)     ) deallocate(flhc_sea   )
@@ -342,6 +354,14 @@
           if(allocated(ch_sea)) deallocate(ch_sea)
        endif
 
+    case("sf_mynnsfclay")
+       if(allocated(snowh_p)) deallocate(snowh_p)
+       if(allocated(ch_p)   ) deallocate(ch_p   )
+       if(allocated(qcg_p)  ) deallocate(qcg_p  )
+       if(config_frac_seaice) then
+          if(allocated(ch_sea)) deallocate(ch_sea)
+       endif
+       
     case default
 
  end select sfclayer_select
@@ -374,6 +394,7 @@
  real(kind=RKIND),dimension(:),pointer:: br,cpm,chs,chs2,cqs2,flhc,flqc,gz1oz0,hfx,qfx,  &
                                          qgh,qsfc,lh,mol,psim,psih,regime,rmol,ust,ustm, &
                                          wspd,znt,zol
+ real(kind=RKIND),dimension(:),pointer:: cqs
 
 !local pointers specific to monin_obukhov:
  real(kind=RKIND),dimension(:),pointer:: fh,fm
@@ -393,7 +414,8 @@
  call mpas_pool_get_array(diag_physics,'mavail'  ,mavail  )
  call mpas_pool_get_array(sfc_input   ,'skintemp',skintemp)
  call mpas_pool_get_array(sfc_input   ,'xland'   ,xland   )
-
+ call mpas_pool_get_array(sfc_input   ,'xice'    ,xice    )
+      
 !inout variables:
  call mpas_pool_get_array(diag_physics,'br'      ,br      )
  call mpas_pool_get_array(diag_physics,'cpm'     ,cpm     )
@@ -427,7 +449,8 @@
     mavail_p(i,j) = mavail(i)
     tsk_p(i,j)    = skintemp(i)
     xland_p(i,j)  = xland(i)
-
+    xice_p(i,j)   = xice(i)
+      
     !inout variables:
     br_p(i,j)     = br(i)
     cpm_p(i,j)    = cpm(i)
@@ -470,11 +493,9 @@
 
  if(config_frac_seaice) then
     call mpas_pool_get_array(sfc_input,'sst' ,sst)
-    call mpas_pool_get_array(sfc_input,'xice',xice)
     do j = jts,jte
     do i = its,ite
        sst_p(i,j)      = sst(i)
-       xice_p(i,j)     = xice(i)
 
        !input variables:
        mavail_sea(i,j) = mavail(i)
@@ -519,6 +540,7 @@
        !overwrite some local variables for sea-ice cells:
        if(xice_p(i,j).ge.xice_threshold .and. xice_p(i,j).le.1._RKIND) then
           xland_sea(i,j)  = 2._RKIND
+          xland_p(i,j)    = 1._RKIND
           mavail_sea(i,j) = 1._RKIND
           znt_sea(i,j)    = 0.0001_RKIND
           tsk_sea(i,j)    = max(sst_p(i,j),271.4_RKIND)
@@ -585,6 +607,27 @@
        enddo
        enddo
 
+    case("sf_mynnsfclay")
+       !input variables:
+       call mpas_pool_get_array(sfc_input   ,'snowh',snowh)
+       !inout variables:
+       call mpas_pool_get_array(diag_physics,'ch' ,ch )
+       call mpas_pool_get_array(diag_physics,'cqs',cqs)
+
+       do j = jts,jte
+       do i = its,ite
+          !input variables:
+          snowh_p(i,j) = snowh(i)
+          !inout variables:
+          ch_p(i,j)    = ch(i)
+          cqs_p(i,j)   = cqs(i)
+          if(config_frac_seaice) then
+             ch_sea(i,j)  = ch(i)
+             cqs_sea(i,j) = cqs(i)
+          endif
+       enddo
+       enddo
+
     case default
 
  end select sfclayer_select
@@ -613,6 +656,7 @@
  real(kind=RKIND),dimension(:),pointer:: br,cpm,chs,chs2,cqs2,flhc,flqc,gz1oz0,hfx,qfx,  &
                                          qgh,qsfc,lh,mol,psim,psih,regime,rmol,ust,wspd, &
                                          znt,zol
+ real(kind=RKIND),dimension(:),pointer:: cqs
  real(kind=RKIND),dimension(:),pointer:: q2,t2m,th2m,u10,v10
  real(kind=RKIND),dimension(:),pointer:: cd,cda,ck,cka,ustm
  real(kind=RKIND),dimension(:),pointer:: xice
@@ -789,6 +833,27 @@
           enddo
        endif
 
+    case("sf_mynnsfclay")
+       call mpas_pool_get_array(diag_physics,'ch' ,ch )
+       call mpas_pool_get_array(diag_physics,'cqs',cqs)
+
+       do j = jts,jte
+       do i = its,ite
+          ch(i) = ch_p(i,j)
+          cqs(i)= cqs_p(i,j)
+       enddo
+       enddo
+       if(config_frac_seaice) then
+          call mpas_pool_get_array(sfc_input,'xice',xice)
+          do j = jts,jte
+          do i = its,ite
+             if(xice(i).ge.xice_threshold .and. xice(i).lt.1._RKIND) then
+                ch(i)  =  ch_p(i,j)*xice(i) + (1._RKIND-xice(i))*ch_sea(i,j)
+             endif
+          enddo
+          enddo
+       endif
+
     case default
 
  end select sfclayer_select
@@ -829,6 +894,9 @@
     case("sf_mynn")
        call sf_mynn_init(errmsg,errflg)
 
+    case("sf_mynnsfclay")
+       call mynnsfc_init(allowed_to_read,errmsg,errflg)
+       
     case default
 
  end select sfclayer_select
@@ -852,7 +920,10 @@
 
 !local pointers:
  logical,pointer:: config_do_restart,config_frac_seaice
+ logical,pointer:: config_do_DAcycling     
  character(len=StrKIND),pointer:: sfclayer_scheme
+ character(len=StrKIND),pointer:: lsm_scheme
+ integer,pointer:: sf_mynn_sfcflux_land,sf_mynn_sfcflux_water
  real(kind=RKIND),dimension(:),pointer:: areaCell
 
 !local variables:
@@ -874,7 +945,8 @@
  call mpas_pool_get_config(configs,'config_do_restart'     ,config_do_restart )
  call mpas_pool_get_config(configs,'config_frac_seaice'    ,config_frac_seaice)
  call mpas_pool_get_config(configs,'config_sfclayer_scheme',sfclayer_scheme   )
-
+ call mpas_pool_get_config(configs,'config_do_DAcycling'   ,config_do_DAcycling) 
+      
  call mpas_pool_get_array(mesh,'areaCell',areaCell)
 
 !copy all MPAS arrays to rectanguler grid:
@@ -883,7 +955,7 @@
  dx = sqrt(maxval(areaCell))
 
  initflag = 1
- if(config_do_restart .or. itimestep > 1) initflag = 0
+ if(config_do_restart .or. config_do_DAcycling .or. itimestep > 1) initflag = 0
 
  sfclayer_select: select case (trim(sfclayer_scheme))
 
@@ -1075,6 +1147,81 @@
                           )
        endif
        call mpas_timer_stop('sf_mynn')
+
+    case("sf_mynnsfclay")
+       call mpas_timer_start('sf_mynnsfclay')
+       call mpas_log_write('--- enter subroutine mynnsfc_driver:')
+       call mpas_pool_get_config(configs,'config_mynn_sfcflux_land' ,sf_mynn_sfcflux_land )
+       call mpas_pool_get_config(configs,'config_mynn_sfcflux_water',sf_mynn_sfcflux_water)
+       call mpas_pool_get_config(configs,'config_lsm_scheme'        ,lsm_scheme           )
+       call mynnsfc_driver( &
+                   p3d      = pres_hyd_p , th3d      = th_p     , t3d      = t_p         , &
+                   u3d      = u_p        , v3d       = v_p      , qv3d     = qv_p        , &
+                   rho3d    = rho_p      , dz8w      = dz_p     ,                          &
+                   chs      = chs_p      , chs2      = chs2_p   , psfcpa   = psfc_p      , &
+                   cqs      = cqs_p      , cqs2      = cqs2_p   , cpm      = cpm_p       , &
+                   znt      = znt_p      , qgh       = qgh_p                             , &
+                   ust      = ust_p      , pblh      = hpbl_p   , mavail   = mavail_p    , &
+                   zol      = zol_p      , mol       = mol_p    ,                          &
+                   psim     = psim_p     , psih      = psih_p   , xland    = xland_p     , &
+                   hfx      = hfx_p      , qfx       = qfx_p    , lh       = lh_p        , &
+                   tsk      = tsk_p      , flhc      = flhc_p   , flqc     = flqc_p      , &
+                   qsfc     = qsfc_p     , rmol      = rmol_p   ,                          &
+                   u10      = u10_p      , v10       = v10_p    , th2      = th2m_p      , &
+                   t2       = t2m_p      , q2        = q2_p     , snowh    = snowh_p     , &
+                   gz1oz0   = gz1oz0_p   , wspd      = wspd_p   , br       = br_p        , &
+                   isfflx   = isfflx     , dx        = dx_p     ,                          &
+                   ustm     = ustm_p     , ck        = ck_p     , cka      = cka_p       , &
+                   cd       = cd_p       , cda       = cda_p    , ch       = ch_p        , &
+                   xice     =xice_P      , xice_threshold       = xice_threshold         , &
+                   spp_pbl               = spp_pbl                                       , &
+                   sf_mynn_sfcflux_land  = sf_mynn_sfcflux_land                          , &
+                   sf_mynn_sfcflux_water = sf_mynn_sfcflux_water                         , &
+                   flagc_lsm             = lsm_scheme                                    , &
+                   itimestep= itimestep  , initflag  = initflag                          , &
+                   restart  = config_do_restart                                          , &
+                   cycling  = config_do_DAcycling                                        , &
+                   errmsg   = errmsg     , errflg    = errflg                            , &
+                   ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde , &
+                   ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme , &
+                   its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte   &
+                       )
+
+       if(config_frac_seaice) then
+          call mynnsfc_driver( &
+                      p3d      = pres_hyd_p , th3d      = th_p     , t3d      = t_p         , &
+                      u3d      = u_p        , v3d       = v_p      , qv3d     = qv_p        , &
+                      rho3d    = rho_p      , dz8w      = dz_p     ,                          &
+                      chs      = chs_sea    , chs2      = chs2_sea , psfcpa   = psfc_p      , &
+                      cqs      = cqs_sea    , cqs2      = cqs2_sea , cpm      = cpm_sea     , &
+                      znt      = znt_sea    , qgh       = qgh_sea                           , &
+                      ust      = ust_sea    , pblh      = hpbl_p   , mavail   = mavail_sea  , &
+                      zol      = zol_sea    , mol       = mol_sea  ,                          &
+                      psim     = psim_sea   , psih      = psih_sea , xland    = xland_sea   , &
+                      hfx      = hfx_sea    , qfx       = qfx_sea  , lh       = lh_sea      , &
+                      tsk      = tsk_sea    , flhc      = flhc_sea , flqc     = flqc_sea    , &
+                      qsfc     = qsfc_sea   , rmol      = rmol_sea ,                          &
+                      u10      = u10_sea    , v10       = v10_sea  , th2      = th2m_sea    , &
+                      t2       = t2m_sea    , q2        = q2_sea   , snowh    = snowh_p     , &
+                      gz1oz0   = gz1oz0_sea , wspd      = wspd_sea , br       = br_sea      , &
+                      isfflx   = isfflx     , dx        = dx_p     ,                          &
+                      ustm     = ustm_sea   , ck        = ck_sea   , cka      = cka_sea     , &
+                      cd       = cd_sea     , cda       = cda_sea  , ch       = ch_sea      , &
+                      xice     =xice_P      , xice_threshold       = xice_threshold         , & 
+                      spp_pbl               = spp_pbl                                       , &
+                      sf_mynn_sfcflux_land  = sf_mynn_sfcflux_land                          , &
+                      sf_mynn_sfcflux_water = sf_mynn_sfcflux_water     	            , &
+                      flagc_lsm    	    = lsm_scheme 	      	      	            , &
+                      itimestep= itimestep  , initflag  = initflag                          , &
+                      restart  = config_do_restart                                          , &
+                      cycling  = config_do_DAcycling                                        , &
+                      errmsg   = errmsg     , errflg    = errflg                            , &
+                      ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde , &
+                      ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme , &
+                      its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte   &
+                          )
+       endif
+       call mpas_timer_stop('sf_mynnsfclay')
 
     case default
 

--- a/src/core_atmosphere/physics/mpas_atmphys_interface.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_interface.F
@@ -143,6 +143,11 @@
        if(.not.allocated(nifa_p)) allocate(nifa_p(ims:ime,kms:kme,jms:jme))
        if(.not.allocated(nwfa_p)) allocate(nwfa_p(ims:ime,kms:kme,jms:jme))
 
+    case("bl_mynnedmf")
+       if(.not.allocated(nc_p)) allocate(nc_p(ims:ime,kms:kme,jms:jme))
+       if(.not.allocated(ni_p)) allocate(ni_p(ims:ime,kms:kme,jms:jme))
+       if(.not.allocated(nifa_p)) allocate(nifa_p(ims:ime,kms:kme,jms:jme))
+       if(.not.allocated(nwfa_p)) allocate(nwfa_p(ims:ime,kms:kme,jms:jme))
     case default
  end select pbl_select
 
@@ -218,6 +223,12 @@
        if(allocated(nifa_p)) deallocate(nifa_p)
        if(allocated(nwfa_p)) deallocate(nwfa_p)
 
+    case("bl_mynnedmf")
+       if(allocated(nc_p)) deallocate(nc_p)
+       if(allocated(ni_p)) deallocate(ni_p)
+       if(allocated(nifa_p)) deallocate(nifa_p)
+       if(allocated(nwfa_p)) deallocate(nwfa_p)
+       
     case default
  end select pbl_select
 
@@ -388,6 +399,52 @@
        enddo
        !initializes ni_p when running the options "mp_thompson" or "mp_thompson_aerosols":
        if(f_ni) then
+          nullify(ni)
+          call mpas_pool_get_dimension(state,'index_ni',index_ni)
+          ni => scalars(index_ni,:,:)
+          do j = jts,jte
+             do k = kts,kte
+                do i = its,ite
+                   ni_p(i,k,j) = max(0.,ni(k,i))
+                enddo
+             enddo
+          enddo
+       endif
+       !initializes nc_p, nifa_p, and nwfa_p when running the option "mp_thompson_aerosols":
+       if(f_nc .and. f_nifa .and. f_nwfa) then
+          nullify(nc)
+          nullify(nifa)
+          nullify(nwfa)
+          call mpas_pool_get_dimension(state,'index_nc',index_nc)
+          call mpas_pool_get_dimension(state,'index_nifa',index_nifa)
+          call mpas_pool_get_dimension(state,'index_nwfa',index_nwfa)
+          nc   => scalars(index_nc,:,:)
+          nifa => scalars(index_nifa,:,:)
+          nwfa => scalars(index_nwfa,:,:)
+          do j = jts,jte
+             do k = kts,kte
+                do i = its,ite
+                   nc_p(i,k,j)   = max(0.,nc(k,i))
+                   nifa_p(i,k,j) = max(0.,nifa(k,i))
+                   nwfa_p(i,k,j) = max(0.,nwfa(k,i))
+                enddo
+             enddo
+          enddo
+       endif
+
+    case("bl_mynnedmf")
+       do j = jts,jte
+          do k = kts,kte
+             do i = its,ite
+                nc_p(i,k,j)   = 0._RKIND
+                ni_p(i,k,j)   = 0._RKIND
+                nifa_p(i,k,j) = 0._RKIND
+                nwfa_p(i,k,j) = 0._RKIND
+             enddo
+          enddo
+       enddo
+       !initializes ni_p when running the options "mp_thompson" or "mp_thompson_aerosols":
+              if(f_ni) then
           nullify(ni)
           call mpas_pool_get_dimension(state,'index_ni',index_ni)
           ni => scalars(index_ni,:,:)

--- a/src/core_atmosphere/physics/mpas_atmphys_packages.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_packages.F
@@ -37,9 +37,11 @@
  character(len=StrKIND),pointer:: config_convection_scheme
  character(len=StrKIND),pointer:: config_pbl_scheme
  character(len=StrKIND),pointer:: config_lsm_scheme
+ integer,pointer:: config_mynn_tkebudget,config_mynn_edmf_output
  logical,pointer:: mp_kessler_in,mp_thompson_in,mp_thompson_aers_in,mp_wsm6_in
  logical,pointer:: cu_grell_freitas_in,cu_kain_fritsch_in,cu_ntiedtke_in
- logical,pointer:: bl_mynn_in,bl_ysu_in
+ logical,pointer:: bl_mynn_in,bl_mynnedmf_in,bl_ysu_in
+ logical,pointer:: bl_mynnedmf_tkebudget_in,bl_mynnedmf_output_in
  logical,pointer:: sf_noahmp_in
 
  integer :: ierr
@@ -143,14 +145,28 @@
 !--- initialization of all packages for parameterizations of surface layer and planetary boundary layer:
 
  call mpas_pool_get_config(configs,'config_pbl_scheme',config_pbl_scheme)
-
+ call mpas_pool_get_config(configs,'config_mynn_tkebudget',config_mynn_tkebudget)
+ call mpas_pool_get_config(configs,'config_mynn_edmf_output',config_mynn_edmf_output)
+      
  nullify(bl_mynn_in)
  call mpas_pool_get_package(packages,'bl_mynn_inActive',bl_mynn_in)
+
+ nullify(bl_mynnedmf_in)
+ call mpas_pool_get_package(packages,'bl_mynnedmf_inActive',bl_mynnedmf_in)
+
+ nullify(bl_mynnedmf_tkebudget_in)
+ call mpas_pool_get_package(packages,'bl_mynnedmf_tkebudget_inActive',bl_mynnedmf_tkebudget_in)
+
+ nullify(bl_mynnedmf_output_in)
+ call mpas_pool_get_package(packages,'bl_mynnedmf_output_inActive',bl_mynnedmf_output_in)
 
  nullify(bl_ysu_in)
  call mpas_pool_get_package(packages,'bl_ysu_inActive',bl_ysu_in)
 
  if(.not.associated(bl_mynn_in) .or. &
+    .not.associated(bl_mynnedmf_in) .or. &
+    .not.associated(bl_mynnedmf_output_in) .or. &
+    .not.associated(bl_mynnedmf_tkebudget_in) .or. &
     .not.associated(bl_ysu_in)) then
     call mpas_log_write('====================================================================================',messageType=MPAS_LOG_ERR)
     call mpas_log_write('* Error while setting up packages for planetary layer  options in atmosphere core.',  messageType=MPAS_LOG_ERR)
@@ -160,15 +176,25 @@
  endif
 
  bl_mynn_in = .false.
+ bl_mynnedmf_in = .false.
+ bl_mynnedmf_output_in = .false.
+ bl_mynnedmf_tkebudget_in = .false.
  bl_ysu_in  = .false.
 
  if(config_pbl_scheme=='bl_mynn') then
     bl_mynn_in = .true.
+ elseif(config_pbl_scheme == 'bl_mynnedmf') then
+    bl_mynnedmf_in = .true.
+    if(config_mynn_edmf_output ==1) bl_mynnedmf_output_in = .true.
+    if(config_mynn_tkebudget ==1) bl_mynnedmf_tkebudget_in = .true.
  elseif(config_pbl_scheme == 'bl_ysu') then
     bl_ysu_in = .true.
  endif
 
  call mpas_log_write('    bl_mynn_in              = $l', logicArgs=(/bl_mynn_in/))
+ call mpas_log_write('    bl_mynnedmf_in          = $l', logicArgs=(/bl_mynnedmf_in/))
+ call mpas_log_write('    bl_mynnedmf_output_in   = $l', logicArgs=(/bl_mynnedmf_output_in/))
+ call mpas_log_write('    bl_mynnedmf_tkebudget_in= $l', logicArgs=(/bl_mynnedmf_tkebudget_in/))
  call mpas_log_write('    bl_ysu_in               = $l', logicArgs=(/bl_ysu_in/))
  call mpas_log_write('')
 

--- a/src/core_atmosphere/physics/mpas_atmphys_todynamics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_todynamics.F
@@ -439,15 +439,15 @@
              enddo
           endif
 
-          if((trim(microp_scheme) == 'mp_tempo') .and. (config_tempo_aerosolaware)) then
-             do i = 1, nCellsSolve
-             do k = 1, nVertLevels
-                tend_scalars(index_nc,k,i) = tend_scalars(index_nc,k,i) + rncblten(k,i)*mass(k,i)
-                tend_scalars(index_nifa,k,i) = tend_scalars(index_nifa,k,i) + rnifablten(k,i)*mass(k,i)
-                tend_scalars(index_nwfa,k,i) = tend_scalars(index_nwfa,k,i) + rnwfablten(k,i)*mass(k,i)
-             enddo
-             enddo
-          endif
+          !if((trim(microp_scheme) == 'mp_tempo') .and. (config_tempo_aerosolaware)) then
+          !   do i = 1, nCellsSolve
+          !   do k = 1, nVertLevels
+          !      tend_scalars(index_nc,k,i) = tend_scalars(index_nc,k,i) + rncblten(k,i)*mass(k,i)
+          !      tend_scalars(index_nifa,k,i) = tend_scalars(index_nifa,k,i) + rnifablten(k,i)*mass(k,i)
+          !      tend_scalars(index_nwfa,k,i) = tend_scalars(index_nwfa,k,i) + rnwfablten(k,i)*mass(k,i)
+          !   enddo
+          !   enddo
+          !endif
           
        case default
     end select pbl_select

--- a/src/core_atmosphere/physics/mpas_atmphys_todynamics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_todynamics.F
@@ -421,6 +421,34 @@
              enddo
           endif
 
+       case('bl_mynnedmf')
+          do i = 1, nCellsSolve
+          do k = 1, nVertLevels
+             tend_scalars(index_qs,k,i) = tend_scalars(index_qs,k,i) + rqsblten(k,i)*mass(k,i)
+             tend_scalars(index_ni,k,i) = tend_scalars(index_ni,k,i) + rniblten(k,i)*mass(k,i)
+          enddo
+          enddo
+
+          if(trim(microp_scheme) == 'mp_thompson_aerosols') then
+             do i = 1, nCellsSolve
+             do k = 1, nVertLevels
+                tend_scalars(index_nc,k,i) = tend_scalars(index_nc,k,i) + rncblten(k,i)*mass(k,i)
+                tend_scalars(index_nifa,k,i) = tend_scalars(index_nifa,k,i) + rnifablten(k,i)*mass(k,i)
+                tend_scalars(index_nwfa,k,i) = tend_scalars(index_nwfa,k,i) + rnwfablten(k,i)*mass(k,i)
+             enddo
+             enddo
+          endif
+
+          if((trim(microp_scheme) == 'mp_tempo') .and. (config_tempo_aerosolaware)) then
+             do i = 1, nCellsSolve
+             do k = 1, nVertLevels
+                tend_scalars(index_nc,k,i) = tend_scalars(index_nc,k,i) + rncblten(k,i)*mass(k,i)
+                tend_scalars(index_nifa,k,i) = tend_scalars(index_nifa,k,i) + rnifablten(k,i)*mass(k,i)
+                tend_scalars(index_nwfa,k,i) = tend_scalars(index_nwfa,k,i) + rnwfablten(k,i)*mass(k,i)
+             enddo
+             enddo
+          endif
+          
        case default
     end select pbl_select
  endif

--- a/src/core_atmosphere/physics/mpas_atmphys_vars.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_vars.F
@@ -10,7 +10,7 @@
  use mpas_kind_types
 
  use NoahmpIOVarType
- 
+
  implicit none
  public
  save
@@ -162,7 +162,7 @@
  real(kind=RKIND),public:: dt_microp  !time-step for cloud microphysics parameterization.
  real(kind=RKIND),public:: dt_radtlw  !time-step for longwave radiation parameterization      [mns]
  real(kind=RKIND),public:: dt_radtsw  !time-step for shortwave radiation parameterization     [mns]
- 
+
  real(kind=RKIND),public:: xice_threshold
 
  real(kind=RKIND),dimension(:,:),allocatable:: &
@@ -182,7 +182,7 @@
 !... arrays related to u- and v-velocities interpolated to theta points:
     u_p,              &!u-velocity interpolated to theta points                               [m/s]
     v_p                !v-velocity interpolated to theta points                               [m/s]
-    
+
 !... arrays related to vertical sounding:
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
     zz_p,             &!
@@ -274,7 +274,7 @@
     graupelncv_p,     &!
     sr_p
 
- integer:: & 
+ integer:: &
     has_reqc,         &!
     has_reqi,         &!
     has_reqs
@@ -422,9 +422,16 @@
 
  real(kind=RKIND),dimension(:,:),allocatable:: &
     maxwidthbl_p,     &!max plume width                                                                        [m]
-    maxmfbl_p,        &!maximum mass flux for PBL shallow convection.
-    zbl_plume_p        !height of highest penetrating plume                                                    [m]
-
+    maxmfbl_p,        &!maximum mass flux for PBL shallow convection.                                        [m/s]
+    zbl_plume_p,      &!height of highest penetrating plume                                                    [m]
+    excessh_p,        &!maximum heat excess applied to plumes                                                  [K]
+    excessq_p,        &!maximum moisture excess applied to plumes                                          [kg/kg]
+    maxwidth_dd_p,    &!maximum downdraft plume width                                                          [m]
+    maxmf_dd_p,       &!maximum mass flux for downdrafts                                                     [m/s]
+    maxtkeprod_dd_p,  &!maximum tke prduction in column from downdrafts                                 [m2/s2/hr]
+    cldtop_cooling_p, &!maximum net cooling at boundary layer cloud top                                     [K/hr]
+    ent_eff_p          !entrainment efficiency
+      
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
     dqke_p,           &!
     qbuoy_p,          &!
@@ -564,6 +571,7 @@
     ck_p,             &!enthalpy exchange coeff at 10 meters                                                   [?]
     cka_p,            &!enthalpy exchange coeff at the lowest model level                                      [?]
     cqs2_p,           &!
+    cqs_p,            &!  
     gz1oz0_p,         &!log of z1 over z0                                                                      [-]
     flhc_p,           &!exchange coefficient for heat                                                          [-]
     flqc_p,           &!exchange coefficient for moisture                                                      [-]
@@ -839,7 +847,7 @@
 
  integer,public:: &
     num_soils          !number of soil layers                                                                  [-]
-    
+
  integer,dimension(:,:),allocatable:: &
     isltyp_p,         &!dominant soil type category                                                            [-]
     ivgtyp_p           !dominant vegetation category                                                           [-]
@@ -931,9 +939,9 @@
 !   is set to true. the arrays below have the same definition as the corresponding "_p" arrays:
 !=================================================================================================================
 
- real(kind=RKIND),dimension(:,:),allocatable:: br_sea,ch_sea,chs_sea,chs2_sea,cpm_sea,cqs2_sea,      &
-                                flhc_sea,flqc_sea,gz1oz0_sea,hfx_sea,lh_sea,mavail_sea,mol_sea,      &
-                                psih_sea,psim_sea,fh_sea,fm_sea,qfx_sea,qgh_sea,qsfc_sea,regime_sea, &
+ real(kind=RKIND),dimension(:,:),allocatable:: br_sea,ch_sea,chs_sea,chs2_sea,cpm_sea,cqs_sea,cqs2_sea,&
+                                flhc_sea,flqc_sea,gz1oz0_sea,hfx_sea,lh_sea,mavail_sea,mol_sea,        &
+                                psih_sea,psim_sea,fh_sea,fm_sea,qfx_sea,qgh_sea,qsfc_sea,regime_sea,   &
                                 rmol_sea,ust_sea,wspd_sea,znt_sea,zol_sea,tsk_sea,xland_sea
  real(kind=RKIND),dimension(:,:),allocatable:: t2m_sea,th2m_sea,q2_sea,u10_sea,v10_sea
  real(kind=RKIND),dimension(:,:),allocatable:: cd_sea,cda_sea,ck_sea,cka_sea,ustm_sea


### PR DESCRIPTION
This PR adds the official MYNN-EDMF and MYNN-SFC submodules to MPAS with via manage_externals. Some notes on the implementation are below:

1. The submodules were added simultaneously due to the common package (bl_mynnedmf_in) used for both schemes (following the previous implementations). 
2. Two additional packages are added to control the allocation of 10 optional 3d output arrays and 5 tke budget arrays.  
3. a new cloudiness option is added to handle the processing of the MYNN-EDMF subgrid clouds analogous to radiation driver in WRF.
4. The implementation was complicated by the earlier implementation of MYNN schemes, so renaming of key modules and subroutines was required to allow both submodules to work as alternatives to the other versions. The other schemes should still work but will hopefully be removed.


