### PR TITLE
Add a time-dependent function for CO2 (Update PR #1173)

### DIFF
--- a/src/core_atmosphere/physics/Makefile
+++ b/src/core_atmosphere/physics/Makefile
@@ -46,6 +46,7 @@ OBJS = \
 	mpas_atmphys_manager.o             \
 	mpas_atmphys_o3climatology.o       \
 	mpas_atmphys_packages.o            \
+	mpas_atmphys_radiation_utils.o     \
 	mpas_atmphys_rrtmg_lwinit.o        \
 	mpas_atmphys_rrtmg_swinit.o        \
 	mpas_atmphys_sfc_diagnostics.o     \
@@ -150,11 +151,14 @@ mpas_atmphys_driver_pbl.o: \
 	mpas_atmphys_constants.o \
 	mpas_atmphys_vars.o
 
+mpas_atmphys_radiation_utils.o: \
+	mpas_atmphys_constants.o
+
 mpas_atmphys_driver_radiation_lw.o: \
 	mpas_atmphys_camrad_init.o \
 	mpas_atmphys_constants.o \
-	mpas_atmphys_driver_radiation_sw.o \
 	mpas_atmphys_manager.o \
+	mpas_atmphys_radiation_utils.o     \
 	mpas_atmphys_rrtmg_lwinit.o \
 	mpas_atmphys_vars.o
 
@@ -162,6 +166,7 @@ mpas_atmphys_driver_radiation_sw.o: \
 	mpas_atmphys_camrad_init.o \
 	mpas_atmphys_constants.o \
 	mpas_atmphys_manager.o \
+	mpas_atmphys_radiation_utils.o     \
 	mpas_atmphys_rrtmg_swinit.o \
 	mpas_atmphys_vars.o
 

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
@@ -870,6 +870,7 @@
             rre_snow   = rresnow_p     , lwupt     = lwupt_p     , lwuptc   = lwuptc_p , &
             lwdnt      = lwdnt_p       , lwdntc    = lwdntc_p    , lwupb    = lwupb_p  , &
             lwupbc     = lwupbc_p      , lwdnb     = lwdnb_p     , lwdnbc   = lwdnbc_p , &
+            yr         = year          ,                                                 &
             ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde ,      &
             ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,      &
             its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte        &

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
@@ -17,6 +17,7 @@
  use mpas_atmphys_camrad_init
  use mpas_atmphys_rrtmg_lwinit
  use mpas_atmphys_vars
+ use mpas_atmphys_functions, only: co2_estimate
 
 !wrf physics:
  use module_ra_cam            
@@ -835,6 +836,7 @@
 !local variables:
  integer:: o3input
  real(kind=RKIND):: radt,xtime_m
+ real(kind=RKIND):: co2
 
 !-----------------------------------------------------------------------------------------------------------------
 !call mpas_log_write(' --- enter subroutine driver_radiation_lw: ')
@@ -851,6 +853,7 @@
     case ("rrtmg_lw")
        o3input = 0
        if(config_o3climatology) o3input = 2
+       co2 = co2_estimate(year,curr_julday)
 
        call mpas_timer_start('RRTMG_lw')
        call rrtmg_lwrad( &
@@ -870,7 +873,7 @@
             rre_snow   = rresnow_p     , lwupt     = lwupt_p     , lwuptc   = lwuptc_p , &
             lwdnt      = lwdnt_p       , lwdntc    = lwdntc_p    , lwupb    = lwupb_p  , &
             lwupbc     = lwupbc_p      , lwdnb     = lwdnb_p     , lwdnbc   = lwdnbc_p , &
-            yr         = year          ,                                                 &
+            co2        = co2           ,                                                 &
             ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde ,      &
             ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,      &
             its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte        &

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
@@ -11,13 +11,12 @@
  use mpas_pool_routines
  use mpas_timer,only: mpas_timer_start,mpas_timer_stop
 
- use mpas_atmphys_driver_radiation_sw, only: radconst
  use mpas_atmphys_constants
  use mpas_atmphys_manager, only: gmt,curr_julday,julday,year
  use mpas_atmphys_camrad_init
  use mpas_atmphys_rrtmg_lwinit
  use mpas_atmphys_vars
- use mpas_atmphys_functions, only: co2_estimate
+ use mpas_atmphys_radiation_utils, only: radconst
 
 !wrf physics:
  use module_ra_cam            
@@ -830,7 +829,6 @@
  integer:: o3input
  integer:: cldovrlp,idcor
  real(kind=RKIND):: radt,xtime_m
- real(kind=RKIND):: co2
 
 !-----------------------------------------------------------------------------------------------------------------
 !call mpas_log_write(' --- enter subroutine driver_radiation_lw: ')
@@ -843,12 +841,18 @@
 !copy MPAS arrays to local arrays:
  call radiation_lw_from_MPAS(xtime_s,configs,mesh,state,time_lev,diag_physics,atm_input,sfc_input,its,ite)
 
+! This should be OMP MASTER with barrier afterwards or OMP SINGLE, since declin and solcon
+! are global variables in mpas_atmphys_vars.F and race conditions may occur otherwise!
+!$OMP SINGLE
+!... calculates solar declination and co2 concentration:
+ call radconst(declin,solcon,curr_julday,degrad,dpd,co2_val,year)
+!$OMP END SINGLE
+
 !call to longwave radiation scheme:
  radiation_lw_select: select case (trim(radt_lw_scheme))
     case ("rrtmg_lw")
        o3input = 0
        if(config_o3climatology) o3input = 2
-       co2 = co2_estimate(year,curr_julday)
 
        !initialization of cloud overlap option:
        if(trim(radt_cld_overlap) == "none"              ) cldovrlp = 0
@@ -881,7 +885,7 @@
             rre_ice  = rreice_p    , rre_snow   = rresnow_p     , lwupt     = lwupt_p    , &
             lwuptc   = lwuptc_p    , lwdnt      = lwdnt_p       , lwdntc    = lwdntc_p   , &
             lwupb    = lwupb_p     , lwupbc     = lwupbc_p      , lwdnb     = lwdnb_p    , &
-            lwdnbc   = lwdnbc_p    , co2        = co2           ,                          &
+            lwdnbc   = lwdnbc_p    , co2        = co2_val       ,                          &
             ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde ,        &
             ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,        &
             its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte          &
@@ -890,13 +894,6 @@
 
     case ("cam_lw")
        xtime_m = xtime_s/60.
-
-! This should be OMP MASTER with barrier afterwards or OMP SINGLE, since declin and solcon
-! are global variables in mpas_atmphys_vars.F and race conditions may occur otherwise!
-!$OMP SINGLE
-       !... calculates solar declination:
-       call radconst(declin,solcon,curr_julday,degrad,dpd)
-!$OMP END SINGLE
 
 !... convert the radiation time_step to minutes:
        radt = dt_radtlw/60.

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
@@ -16,7 +16,7 @@
  use mpas_atmphys_camrad_init
  use mpas_atmphys_rrtmg_lwinit
  use mpas_atmphys_vars
- use mpas_atmphys_radiation_utils, only: radconst
+ use mpas_atmphys_radiation_utils, only: radconst, co2_estimate
 
 !wrf physics:
  use module_ra_cam            
@@ -844,8 +844,10 @@
 ! This should be OMP MASTER with barrier afterwards or OMP SINGLE, since declin and solcon
 ! are global variables in mpas_atmphys_vars.F and race conditions may occur otherwise!
 !$OMP SINGLE
-!... calculates solar declination and co2 concentration:
- call radconst(declin,solcon,curr_julday,degrad,dpd,co2_val,year)
+!... calculates solar declination:
+ call radconst(declin,solcon,curr_julday,degrad,dpd)
+!... estimates co2 concentration using a function of year: 
+ co2_val = co2_estimate(year,curr_julday) 
 !$OMP END SINGLE
 
 !call to longwave radiation scheme:

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
@@ -16,6 +16,7 @@
  use mpas_atmphys_camrad_init
  use mpas_atmphys_rrtmg_swinit
  use mpas_atmphys_vars
+ use mpas_atmphys_functions, only: co2_estimate
  
 !wrf physics:
  use module_ra_cam
@@ -733,6 +734,7 @@
 !local variables:
  integer:: o3input
  real(kind=RKIND):: radt,xtime_m
+ real(kind=RKIND):: co2
 
 !-----------------------------------------------------------------------------------------------------------------
 !call mpas_log_write(' --- enter subroutine driver_radiation_sw: $i',intArgs=(/itimestep/))
@@ -770,6 +772,7 @@
     case ("rrtmg_sw")
        o3input = 0
        if(config_o3climatology) o3input = 2
+       co2 = co2_estimate(year,curr_julday)
 
        call mpas_timer_start('RRTMG_sw')
        call rrtmg_swrad( &
@@ -792,7 +795,7 @@
               swdnt      = swdnt_p      , swdntc     = swdntc_p      , swupb    = swupb_p  , &
               swupbc     = swupbc_p     , swdnb      = swdnb_p       , swdnbc   = swdnbc_p , &
               swddir     = swddir_p     , swddni     = swddni_p      , swddif   = swddif_p , &
-              yr         = year         ,                                                    &
+              co2        = co2          ,                                                    &
               ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde ,        &
               ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,        &
               its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte          &

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
@@ -792,6 +792,7 @@
               swdnt      = swdnt_p      , swdntc     = swdntc_p      , swupb    = swupb_p  , &
               swupbc     = swupbc_p     , swdnb      = swdnb_p       , swdnbc   = swdnbc_p , &
               swddir     = swddir_p     , swddni     = swddni_p      , swddif   = swddif_p , &
+              yr         = year         ,                                                    &
               ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde ,        &
               ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,        &
               its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte          &

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
@@ -16,7 +16,7 @@
  use mpas_atmphys_camrad_init
  use mpas_atmphys_rrtmg_swinit
  use mpas_atmphys_vars
- use mpas_atmphys_functions, only: co2_estimate
+ use mpas_atmphys_radiation_utils, only: radconst
  
 !wrf physics:
  use module_mp_thompson_aerosols
@@ -29,8 +29,7 @@
  public:: allocate_radiation_sw,   &
           deallocate_radiation_sw, &
           driver_radiation_sw,     &
-          init_radiation_sw,       &
-          radconst
+          init_radiation_sw
 
 !MPAS driver for parameterization of shortwave radiation codes.
 !Laura D. Fowler (send comments to laura@ucar.edu).
@@ -44,7 +43,6 @@
 ! driver_radiation_sw    : main driver (called from subroutine physics_driver).
 ! radiation_sw_from_MPAS : initialize local arrays.
 ! radiation_sw_to_MPAS   : copy local arrays to MPAS arrays.
-! radconst               : calculate solar declination,...
 !
 ! WRF physics called from driver_radiation_sw:
 ! --------------------------------------------
@@ -863,7 +861,6 @@
  integer:: o3input
  integer:: cldovrlp,idcor
  real(kind=RKIND):: radt,xtime_m
- real(kind=RKIND):: co2
 
 !-----------------------------------------------------------------------------------------------------------------
 !call mpas_log_write(' --- enter subroutine driver_radiation_sw: $i',intArgs=(/itimestep/))
@@ -881,9 +878,10 @@
 ! This should be OMP MASTER with barrier afterwards or OMP SINGLE, since declin and solcon
 ! are global variables in mpas_atmphys_vars.F and race conditions may occur otherwise!
 !$OMP SINGLE
-!... calculates solar declination:
+!... calculates solar declination and co2 concentration:
 !call radconst(declin,solcon,julday,degrad,dpd)
- call radconst(declin,solcon,curr_julday,degrad,dpd)
+ call radconst(declin,solcon,curr_julday,degrad,dpd,co2_val,year)
+!call mpas_log_write(' --- driver_radiation_sw after radconst')
 !call mpas_log_write('     ITIMESTEP   = $i', intArgs=(/itimestep/))
 !call mpas_log_write('     YEAR        = $i', intArgs=(/year/))
 !call mpas_log_write('     JULDAY      = $i', intArgs=(/julday/))
@@ -892,6 +890,7 @@
 !call mpas_log_write('     CURR_JULDAY = $r', realArgs=(/curr_julday/))
 !call mpas_log_write('     SOLCON      = $r', realArgs=(/solcon/))
 !call mpas_log_write('     DECLIN      = $r', realArgs=(/declin/))
+!call mpas_log_write('     CO2_VAL     = $r', realArgs=(/co2_val/))
 !$OMP END SINGLE
 
 !... convert the radiation time_step to minutes:
@@ -902,7 +901,6 @@
     case ("rrtmg_sw")
        o3input = 0
        if(config_o3climatology) o3input = 2
-       co2 = co2_estimate(year,curr_julday)
 
        !initialization of cloud overlap option:
        if(trim(radt_cld_overlap) == "none"              ) cldovrlp = 0
@@ -939,7 +937,7 @@
               swdnt      = swdnt_p       , swdntc   = swdntc_p    , swupb      = swupb_p      , &
               swupbc     = swupbc_p      , swdnb    = swdnb_p     , swdnbc     = swdnbc_p     , &
               swddir     = swddir_p      , swddni   = swddni_p    , swddif     = swddif_p     , &
-              co2        = co2           ,                                                      &
+              co2        = co2_val       ,                                                      &
               ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde ,           &
               ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,           &
               its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte             &
@@ -1006,50 +1004,6 @@
 !call mpas_log_write('--- end subroutine driver_radiation_sw.')
 
  end subroutine driver_radiation_sw
-
-!=================================================================================================================
- subroutine radconst(declin,solcon,julian,degrad,dpd)
-!=================================================================================================================
-
-!input arguments:
-!integer,intent(in):: julian
- real(kind=RKIND),intent(in):: julian
- real(kind=RKIND),intent(in):: degrad,dpd
-
-!output arguments:
- real(kind=RKIND),intent(out):: declin,solcon
-
-!local variables:
- real(kind=RKIND):: obecl,sinob,sxlong,arg,decdeg,djul,rjul,eccfac
-
-!-----------------------------------------------------------------------------------------------------------------
-
-   declin=0.
-   solcon=0.
-
-!obecl : obliquity = 23.5 degree.
-        
-   obecl=23.5*degrad
-   sinob=sin(obecl)
-        
-!calculate longitude of the sun from vernal equinox:        
-
-   if(julian.ge.80.)sxlong=dpd*(julian-80.)
-   if(julian.lt.80.)sxlong=dpd*(julian+285.)
-   sxlong=sxlong*degrad
-   arg=sinob*sin(sxlong)
-   declin=asin(arg)
-   decdeg=declin/degrad
-
-!solar constant eccentricity factor (paltridge and platt 1976)
-
-   djul=julian*360./365.
-   rjul=djul*degrad
-   eccfac=1.000110+0.034221*cos(rjul)+0.001280*sin(rjul)+0.000719*  &
-          cos(2*rjul)+0.000077*sin(2*rjul)
-   solcon=solcon_0*eccfac
-
- end subroutine radconst
 
 !=================================================================================================================
  end module mpas_atmphys_driver_radiation_sw

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
@@ -16,7 +16,7 @@
  use mpas_atmphys_camrad_init
  use mpas_atmphys_rrtmg_swinit
  use mpas_atmphys_vars
- use mpas_atmphys_radiation_utils, only: radconst
+ use mpas_atmphys_radiation_utils, only: radconst, co2_estimate
  
 !wrf physics:
  use module_mp_thompson_aerosols
@@ -878,9 +878,11 @@
 ! This should be OMP MASTER with barrier afterwards or OMP SINGLE, since declin and solcon
 ! are global variables in mpas_atmphys_vars.F and race conditions may occur otherwise!
 !$OMP SINGLE
-!... calculates solar declination and co2 concentration:
+!... calculates solar declination:
 !call radconst(declin,solcon,julday,degrad,dpd)
- call radconst(declin,solcon,curr_julday,degrad,dpd,co2_val,year)
+ call radconst(declin,solcon,curr_julday,degrad,dpd)
+!... estimates co2 concentration using a function of year:
+ co2_val = co2_estimate(year,curr_julday)
 !call mpas_log_write(' --- driver_radiation_sw after radconst')
 !call mpas_log_write('     ITIMESTEP   = $i', intArgs=(/itimestep/))
 !call mpas_log_write('     YEAR        = $i', intArgs=(/year/))

--- a/src/core_atmosphere/physics/mpas_atmphys_functions.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_functions.F
@@ -14,7 +14,7 @@
 
  implicit none
  private
- public:: gammln,gammp,wgamma,rslf,rsif
+ public:: gammln,gammp,wgamma,rslf,rsif,co2_estimate
 
 
  contains
@@ -215,6 +215,29 @@
 !     ESI = EXP(9.550426 - 5723.265/T + 3.53068*ALOG(T) - 0.00728332*T)
 
       END FUNCTION RSIF
+
+!+---+-----------------------------------------------------------------+
+! This function calculates CO2 from an equation in WRF by J. Dudhia
+!
+      real(kind=rkind) function co2_estimate(year,curr_julday)
+
+      implicit none
+      integer, intent(in) :: year
+      real, intent(in) :: curr_julday
+      real(kind=rkind) :: rdays,ryear
+      integer :: ny1, ny2, ny3
+
+      rdays = 365.
+      ny1 = mod(year,4)
+      ny2 = mod(year,100)
+      ny3 = mod(year,400)
+      if(ny1.eq.0.and.ny2.ne.0.or.ny3.eq.0) rdays = 366.
+      ryear = float(year)+curr_julday/rdays
+
+! Annual function for co2 from WRF v4.2
+      co2_estimate = (280. + 90.*exp(0.02*(ryear-2000.)))*1.e-6
+
+      end function co2_estimate
 
 !=================================================================================================================
  end module mpas_atmphys_functions

--- a/src/core_atmosphere/physics/mpas_atmphys_functions.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_functions.F
@@ -14,7 +14,7 @@
 
  implicit none
  private
- public:: gammln,gammp,wgamma,rslf,rsif,co2_estimate
+ public:: gammln,gammp,wgamma,rslf,rsif
 
 
  contains
@@ -215,29 +215,6 @@
 !     ESI = EXP(9.550426 - 5723.265/T + 3.53068*ALOG(T) - 0.00728332*T)
 
       END FUNCTION RSIF
-
-!+---+-----------------------------------------------------------------+
-! This function calculates CO2 from an equation in WRF by J. Dudhia
-!
-      real(kind=rkind) function co2_estimate(year,curr_julday)
-
-      implicit none
-      integer, intent(in) :: year
-      real, intent(in) :: curr_julday
-      real(kind=rkind) :: rdays,ryear
-      integer :: ny1, ny2, ny3
-
-      rdays = 365.
-      ny1 = mod(year,4)
-      ny2 = mod(year,100)
-      ny3 = mod(year,400)
-      if(ny1.eq.0.and.ny2.ne.0.or.ny3.eq.0) rdays = 366.
-      ryear = float(year)+curr_julday/rdays
-
-! Annual function for co2 from WRF v4.2
-      co2_estimate = (280. + 90.*exp(0.02*(ryear-2000.)))*1.e-6
-
-      end function co2_estimate
 
 !=================================================================================================================
  end module mpas_atmphys_functions

--- a/src/core_atmosphere/physics/mpas_atmphys_radiation_utils.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_radiation_utils.F
@@ -1,0 +1,107 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+!=================================================================================================================
+ module mpas_atmphys_radiation_utils
+
+ use mpas_kind_types, only : RKIND
+ use mpas_atmphys_constants, only : solcon_0
+ use mpas_log, only : mpas_log_write
+
+ implicit none
+ private
+ public:: radconst,     &
+          co2_estimate
+
+ contains
+
+!=================================================================================================================
+ subroutine radconst(declin,solcon,julian,degrad,dpd,co2,year)
+!=================================================================================================================
+!
+! computes solar declination
+! computes co2 concentration from WRF v4.2 (Jimy Dudhia)
+!
+!input arguments:
+ real(kind=RKIND),intent(in):: julian
+ real(kind=RKIND),intent(in):: degrad,dpd
+ integer, intent(in):: year
+
+!output arguments:
+ real(kind=RKIND),intent(out):: declin,solcon
+ real(kind=RKIND),intent(out):: co2
+
+!local variables:
+ real(kind=RKIND):: obecl,sinob,sxlong,arg,decdeg,djul,rjul,eccfac
+
+!-----------------------------------------------------------------------------------------------------------------
+
+ call mpas_log_write('--- enter subroutine radconst:')
+
+ declin=0.
+ solcon=0.
+
+!obecl : obliquity = 23.5 degree.
+
+ obecl=23.5*degrad
+ sinob=sin(obecl)
+
+!calculate longitude of the sun from vernal equinox:
+
+ if(julian.ge.80.)sxlong=dpd*(julian-80.)
+ if(julian.lt.80.)sxlong=dpd*(julian+285.)
+
+ sxlong=sxlong*degrad
+ arg=sinob*sin(sxlong)
+ declin=asin(arg)
+ decdeg=declin/degrad
+
+!solar constant eccentricity factor (paltridge and platt 1976)
+
+ djul=julian*360./365.
+ rjul=djul*degrad
+ eccfac=1.000110+0.034221*cos(rjul)+0.001280*sin(rjul)+0.000719*  &
+        cos(2*rjul)+0.000077*sin(2*rjul)
+ solcon=solcon_0*eccfac
+
+!estimate co2 concentration from an equation from WRF4.2
+
+ co2 = co2_estimate(year,julian)
+
+ end subroutine radconst
+
+!=================================================================================================================
+ real(kind=RKIND) function co2_estimate(year,julian)
+!=================================================================================================================
+
+! This function calculates CO2 from an equation in WRF by J. Dudhia
+
+ implicit none
+
+ integer, intent(in) :: year
+ real(kind=RKIND),intent(in):: julian
+
+ real(kind=RKIND) :: rdays,ryear
+ integer :: ny1, ny2, ny3
+
+!-----------------------------------------------------------------------------------------------------------------
+
+ rdays = 365._RKIND
+ ny1 = mod(year,4)
+ ny2 = mod(year,100)
+ ny3 = mod(year,400)
+ if( (ny1.eq.0 .and. ny2.ne.0) .or. ny3.eq.0 ) rdays = 366._RKIND
+ ryear = float(year)+julian/rdays
+
+! Annual function for co2 from WRF v4.2
+ co2_estimate = (280._RKIND + 90._RKIND*exp(0.02_RKIND*(ryear-2000._RKIND)))*1.e-6_RKIND
+
+ end function co2_estimate
+
+!=================================================================================================================
+ end module mpas_atmphys_radiation_utils
+!=================================================================================================================

--- a/src/core_atmosphere/physics/mpas_atmphys_radiation_utils.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_radiation_utils.F
@@ -20,20 +20,16 @@
  contains
 
 !=================================================================================================================
- subroutine radconst(declin,solcon,julian,degrad,dpd,co2,year)
+ subroutine radconst(declin,solcon,julian,degrad,dpd)
 !=================================================================================================================
-!
-! computes solar declination
-! computes co2 concentration from WRF v4.2 (Jimy Dudhia)
-!
+
 !input arguments:
+!integer,intent(in):: julian
  real(kind=RKIND),intent(in):: julian
  real(kind=RKIND),intent(in):: degrad,dpd
- integer, intent(in):: year
 
 !output arguments:
  real(kind=RKIND),intent(out):: declin,solcon
- real(kind=RKIND),intent(out):: co2
 
 !local variables:
  real(kind=RKIND):: obecl,sinob,sxlong,arg,decdeg,djul,rjul,eccfac
@@ -54,7 +50,6 @@
 
  if(julian.ge.80.)sxlong=dpd*(julian-80.)
  if(julian.lt.80.)sxlong=dpd*(julian+285.)
-
  sxlong=sxlong*degrad
  arg=sinob*sin(sxlong)
  declin=asin(arg)
@@ -68,10 +63,6 @@
         cos(2*rjul)+0.000077*sin(2*rjul)
  solcon=solcon_0*eccfac
 
-!estimate co2 concentration from an equation from WRF4.2
-
- co2 = co2_estimate(year,julian)
-
  end subroutine radconst
 
 !=================================================================================================================
@@ -79,6 +70,8 @@
 !=================================================================================================================
 
 ! This function calculates CO2 from an equation in WRF by J. Dudhia
+! The function is a smoothly increasing, time-dependent CO2 concentration function.
+! The function form is a close fit for past CO2 growth and extrapolates it for the future.
 
  implicit none
 

--- a/src/core_atmosphere/physics/mpas_atmphys_vars.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_vars.F
@@ -688,6 +688,13 @@
  real(kind=RKIND),dimension(:,:,:,:),allocatable:: asyaer_p   !aerosol asymmetry factor in RRTMG SW            [-]
 
 !=================================================================================================================
+!... variables and arrays related to parameterizations of long- and short-wave radiation, especially RRTMG:
+!=================================================================================================================
+
+ real(kind=RKIND):: &
+    co2_val            !co2 concentration                                                       [-]
+
+!=================================================================================================================
 !... variables and arrays related to parameterization of short-wave radiation:
 !=================================================================================================================
 

--- a/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_lw.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_lw.F
@@ -11482,6 +11482,7 @@ CONTAINS
                        lwupt,lwuptc,lwdnt,lwdntc,                 &
                        lwupb,lwupbc,lwdnb,lwdnbc,                 &
                        lwupflx, lwupflxc, lwdnflx, lwdnflxc,      &
+                       yr,                                        &
                        ids,ide, jds,jde, kds,kde,                 & 
                        ims,ime, jms,jme, kms,kme,                 &
                        its,ite, jts,jte, kts,kte                  &
@@ -11497,6 +11498,7 @@ CONTAINS
                       its,ite, jts,jte, kts,kte
  integer,intent(in):: icloud,has_reqc,has_reqi,has_reqs
  integer,intent(in),optional:: o3input
+ integer,intent(in):: yr
 
  real,intent(in),dimension(ims:ime,jms:jme):: emiss,tsk,snow,xice,xland
  real,intent(in),dimension(ims:ime,kms:kme,jms:jme):: t3d,p3d,pi3d
@@ -11565,7 +11567,7 @@ CONTAINS
 !--- set trace gas volume mixing ratios, 2005 values, IPCC (2007):
 !carbon dioxide (379 ppmv)
  real :: co2
- data co2 / 379.e-6 / 
+!data co2 / 379.e-6 / 
 !methane (1774 ppbv)
  real :: ch4
  data ch4 / 1774.e-9 / 
@@ -11639,6 +11641,9 @@ CONTAINS
              249.89,246.67,243.48,240.25,236.66,233.86/	
 
 !-----------------------------------------------------------------------------------------------------------------
+
+! Annual function for co2 in WRF v4.2
+ co2 = (280. + 90.*exp(0.02*(yr-2000)))*1.e-6
 
 !--- all fields are ordered vertically from bottom to top (pressures are in mb):
  ncol = 1

--- a/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_lw.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_lw.F
@@ -11482,7 +11482,7 @@ CONTAINS
                        lwupt,lwuptc,lwdnt,lwdntc,                 &
                        lwupb,lwupbc,lwdnb,lwdnbc,                 &
                        lwupflx, lwupflxc, lwdnflx, lwdnflxc,      &
-                       yr,                                        &
+                       co2,                                       &
                        ids,ide, jds,jde, kds,kde,                 & 
                        ims,ime, jms,jme, kms,kme,                 &
                        its,ite, jts,jte, kts,kte                  &
@@ -11498,7 +11498,6 @@ CONTAINS
                       its,ite, jts,jte, kts,kte
  integer,intent(in):: icloud,has_reqc,has_reqi,has_reqs
  integer,intent(in),optional:: o3input
- integer,intent(in):: yr
 
  real,intent(in),dimension(ims:ime,jms:jme):: emiss,tsk,snow,xice,xland
  real,intent(in),dimension(ims:ime,kms:kme,jms:jme):: t3d,p3d,pi3d
@@ -11641,9 +11640,6 @@ CONTAINS
              249.89,246.67,243.48,240.25,236.66,233.86/	
 
 !-----------------------------------------------------------------------------------------------------------------
-
-! Annual function for co2 in WRF v4.2
- co2 = (280. + 90.*exp(0.02*(yr-2000)))*1.e-6
 
 !--- all fields are ordered vertically from bottom to top (pressures are in mb):
  ncol = 1

--- a/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_sw.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_sw.F
@@ -9877,6 +9877,7 @@ CONTAINS
                        swupb,swupbc,swdnb,swdnbc,                      &
                        swupflx, swupflxc, swdnflx, swdnflxc,           &
                        swddir,swddni,swddif,                           &
+                       yr,                                             &
                        ids,ide, jds,jde, kds,kde,                      & 
                        ims,ime, jms,jme, kms,kme,                      &
                        its,ite, jts,jte, kts,kte                       &
@@ -9891,7 +9892,7 @@ CONTAINS
                       ims,ime, jms,jme, kms,kme, &
                       its,ite, jts,jte, kts,kte
  integer,intent(in):: icloud,has_reqc,has_reqi,has_reqs
- integer,intent(in):: julday
+ integer,intent(in):: julday,yr
  integer,intent(in),optional:: o3input
 
  real,intent(in):: radt,degrad,xtime,declin,solcon,gmt
@@ -9973,7 +9974,7 @@ CONTAINS
 !--- set trace gas volume mixing ratios, 2005 values, IPCC (2007):
 !carbon dioxide (379 ppmv)
  real :: co2
- data co2 / 379.e-6 / 
+!data co2 / 379.e-6 / 
 !methane (1774 ppbv)
  real :: ch4
  data ch4 / 1774.e-9 / 
@@ -10004,6 +10005,9 @@ CONTAINS
   data amdo2 / 0.905190 /
 
 !-----------------------------------------------------------------------------------------------------------------
+
+! Annual function for co2 in WRF v4.2
+      co2 = (280. + 90.*exp(0.02*(yr-2000)))*1.e-6
 
 !--- all fields are ordered vertically from bottom to top (pressures are in mb):
  ncol = 1

--- a/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_sw.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_sw.F
@@ -9877,7 +9877,7 @@ CONTAINS
                        swupb,swupbc,swdnb,swdnbc,                      &
                        swupflx, swupflxc, swdnflx, swdnflxc,           &
                        swddir,swddni,swddif,                           &
-                       yr,                                             &
+                       co2,                                            &
                        ids,ide, jds,jde, kds,kde,                      & 
                        ims,ime, jms,jme, kms,kme,                      &
                        its,ite, jts,jte, kts,kte                       &
@@ -9892,7 +9892,7 @@ CONTAINS
                       ims,ime, jms,jme, kms,kme, &
                       its,ite, jts,jte, kts,kte
  integer,intent(in):: icloud,has_reqc,has_reqi,has_reqs
- integer,intent(in):: julday,yr
+ integer,intent(in):: julday
  integer,intent(in),optional:: o3input
 
  real,intent(in):: radt,degrad,xtime,declin,solcon,gmt
@@ -10005,9 +10005,6 @@ CONTAINS
   data amdo2 / 0.905190 /
 
 !-----------------------------------------------------------------------------------------------------------------
-
-! Annual function for co2 in WRF v4.2
-      co2 = (280. + 90.*exp(0.02*(yr-2000)))*1.e-6
 
 !--- all fields are ordered vertically from bottom to top (pressures are in mb):
  ncol = 1


### PR DESCRIPTION
This PR builds on #1173, which proposed a smoothly increasing, time-dependent CO2 concentration function. The function form is a close fit for past CO2 growth and extrapolates it for the future. 

This update introduces a new radiation utility module for subroutines or functions used by both LW and SW radiation schemes. 

Summary of changes: 
- rebase PR #1173 changes onto the current develop branch 
- add a new utility module (`mpas_atmphys_radiation_utils.F`)
- move `radconst` and `co2_estimate` into `mpas_atmphys_radiation_utils`
- rename `co2` to `co2_val` to avoid conflict with the non-1D `co2` array used by the CAM radiation scheme
- compute `co2_val` in `radconst` 
- call `radconst` before `rrtmg_lwrad` and `rrtmg_swrad` 
(Moving `radconst` from `mpas_atmphys_driver_radiation_sw.F90` to `mpas_atmphys_radiation_utils.F90`  removes the build dependency of LW on the SW module.)

A future update will implement reading GHG values from prescribed tables, following the WRF approach. The table year-dependent GHG is based on observed values for past years and official climate scenarios for future years. 