### PR TITLE
Fix bug in registry-generated code to set up derived dimensions

### DIFF
--- a/src/tools/registry/gen_inc.c
+++ b/src/tools/registry/gen_inc.c
@@ -1087,6 +1087,8 @@ int parse_dimensions_from_registry(ezxml_t registry)/*{{{*/
 				fortprintf(fd, "         call mpas_pool_add_dimension(dimensionPool, '%s', %s)\n", dimname, dimname);
 
 				fortprintf(fd, "         deallocate(%s)\n", dimname);
+				fortprintf(fd, "         ! Now let %s point to pool memory so the dimension can be referenced later in this routine as needed\n", dimname);
+				fortprintf(fd, "         call mpas_pool_get_dimension(dimensionPool, '%s', %s)\n", dimname, dimname);
 				fortprintf(fd, "          else if ( %s == MPAS_MISSING_DIM ) then\n", dimname, dimname);
 				// Namelist defined dimension
 				if(strncmp(dimdef, "namelist:", 9) == 0){
@@ -1103,6 +1105,8 @@ int parse_dimensions_from_registry(ezxml_t registry)/*{{{*/
 				fortprintf(fd, "         %s = MPAS_MISSING_DIM\n", dimname);
 				fortprintf(fd, "         call mpas_pool_add_dimension(dimensionPool, '%s', %s)\n", dimname, dimname);
 				fortprintf(fd, "         deallocate(%s)\n", dimname);
+				fortprintf(fd, "         ! Now let %s point to pool memory so the dimension can be referenced later in this routine as needed\n", dimname);
+				fortprintf(fd, "         call mpas_pool_get_dimension(dimensionPool, '%s', %s)\n", dimname, dimname);
 				fortprintf(fd, "      end if\n\n");
 			}
 		}

--- a/src/tools/registry/gen_inc.c
+++ b/src/tools/registry/gen_inc.c
@@ -1063,7 +1063,7 @@ int parse_dimensions_from_registry(ezxml_t registry)/*{{{*/
 
 	fortprintf(fd, "\n");
 
-	fortprintf(fd, "call mpas_log_write('Assigning remaining dimensions from definitions in Registry.xml ...')\n");
+	fortprintf(fd, "      call mpas_log_write('Assigning remaining dimensions from definitions in Registry.xml ...')\n");
 
 	for (dims_xml = ezxml_child(registry, "dims"); dims_xml; dims_xml = dims_xml->next) {
 		for (dim_xml = ezxml_child(dims_xml, "dim"); dim_xml; dim_xml = dim_xml->next) {
@@ -1079,17 +1079,17 @@ int parse_dimensions_from_registry(ezxml_t registry)/*{{{*/
 				if(strncmp(dimdef, "namelist:", 9) == 0){
 					snprintf(option_name, 1024, "%s", (dimdef)+9);
 					fortprintf(fd, "         %s = %s\n", dimname, option_name);
-					fortprintf(fd, "call mpas_log_write('       %s = $i (%s)', intArgs=(/%s/))\n", dimname, option_name, option_name);
+					fortprintf(fd, "         call mpas_log_write('       %s = $i (%s)', intArgs=(/%s/))\n", dimname, option_name, option_name);
 				} else {
 					fortprintf(fd, "         %s = %s\n", dimname, dimdef);
-					fortprintf(fd, "call mpas_log_write('       %s = $i', intArgs=(/%s/))\n", dimname, dimdef);
+					fortprintf(fd, "         call mpas_log_write('       %s = $i', intArgs=(/%s/))\n", dimname, dimdef);
 				}
 				fortprintf(fd, "         call mpas_pool_add_dimension(dimensionPool, '%s', %s)\n", dimname, dimname);
 
 				fortprintf(fd, "         deallocate(%s)\n", dimname);
 				fortprintf(fd, "         ! Now let %s point to pool memory so the dimension can be referenced later in this routine as needed\n", dimname);
 				fortprintf(fd, "         call mpas_pool_get_dimension(dimensionPool, '%s', %s)\n", dimname, dimname);
-				fortprintf(fd, "          else if ( %s == MPAS_MISSING_DIM ) then\n", dimname, dimname);
+				fortprintf(fd, "      else if ( %s == MPAS_MISSING_DIM ) then\n", dimname, dimname);
 				// Namelist defined dimension
 				if(strncmp(dimdef, "namelist:", 9) == 0){
 					snprintf(option_name, 1024, "%s", (dimdef)+9);
@@ -1098,7 +1098,7 @@ int parse_dimensions_from_registry(ezxml_t registry)/*{{{*/
 					fortprintf(fd, "         %s = %s\n", dimname, dimdef);
 				}
 
-				fortprintf(fd, "          end if\n\n");
+				fortprintf(fd, "      end if\n\n");
 			} else {
 				fortprintf(fd, "      if ( .not. associated(%s) ) then\n", dimname);
 				fortprintf(fd, "         allocate(%s)\n", dimname);


### PR DESCRIPTION
This PR fixes a bug in registry-generated code for setting up derived dimensions.

Previous work (in PR #1451, commit ae45a181) introduced changes to eliminate memory leaks that occurred while setting up derived dimensions. The approach taken in that work involved deallocating dimensions after they were allocated and added to the dimension pool, since the pool assigns the value of the dimension to its own internal memory, and it is up to calling code to free any memory allocated for the dimension argument to `mpas_pool_add_dimension`. However, as an unintended side effect, any later derived dimensions that depended on a dimension whose value came from a namelist or other registry definiton would generate a segmentation fault after referencing an unassociated pointer to the now deallocated dimension.

For example, in the `init_atmosphere` core, the `nVertLevels` dimension is set based on the namelist option `config_nvertlevels`, and the `nVertLevelsP1` dimension is subsequently set to `nVertLevels+1`.

This PR fixes this issue by re-setting pointers to point to pool-owned memory after a dimension has been allocated, added to the dimension pool, and freed.