### PR TITLE
Cryptic soil layer indexing bug

### DIFF
--- a/src/core_atmosphere/physics/Registry_noahmp.xml
+++ b/src/core_atmosphere/physics/Registry_noahmp.xml
@@ -16,7 +16,7 @@
       <dim name="nSnowLevels" definition="3"
                 description="The number of snow layers used by the NOAHMP land-surface scheme"/>
 
-      <dim name="nzSnowLevels" definition="7"
+      <dim name="nzSnowLevels" definition="nSoilLevels+nSnowLevels"
                 description="The number of snow layer depths used by the NOAHMP land-surface scheme"/>
 
  </dims>

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_lsm_noahmp.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_lsm_noahmp.F
@@ -842,12 +842,8 @@
        snicexy(ns,i) = mpas_noahmp%snicexy(i,n)
        snliqxy(ns,i) = mpas_noahmp%snliqxy(i,n)
     enddo
-    do ns = 1,nsnow
+    do ns = 1,nzsnow
        n = ns - nsnow
-       zsnsoxy(ns,i) = mpas_noahmp%zsnsoxy(i,n)
-    enddo
-    do ns = nsnow+1,nzsnow
-       n = ns - nsoil + 1
        zsnsoxy(ns,i) = mpas_noahmp%zsnsoxy(i,n)
     enddo
  enddo


### PR DESCRIPTION
This fixes a rather cryptic bug, that occurs when the number of soil layers is not the default (4 layers) for Noah-MP, which results in the model not conserving water. 

**1. Soil layer indexing bug.** Noah-MP uses positive indices for soil layers, and negative indices for snowpack layers. In sub-routine `lsm_noahmp_toMPAS`, the code copies the depths from Noah-MP to a local structure (`zsnsoxy`) that assumes indices going from 1 to the number of combined snowpack and soil layers. However, the original code had one error in the conversion logic, which coincidentally worked for the specific case in which the number of soil layers is exactly the number of snowpack ayers plus 1. The proposed change follows the logic used elsewhere in the code and ensures the conversion always works.

**2. Hardcoded number of soil plus snow levels.** File `Registry_noahmp.xml` originally defines dimension `nzSnowLevels` (total number of soil plus snowpack layers) as 7. This works when using the default number of soil layers, but causes segmentation violations otherwise. 
