### PR TITLE
Add a dm_info object to the argument list of core mpas_setup_packages_function

### DIFF
--- a/src/core_atmosphere/mpas_atm_core_interface.F
+++ b/src/core_atmosphere/mpas_atm_core_interface.F
@@ -99,7 +99,7 @@ module atm_core_interface
    !>  not allocated until after this routine has been called.
    !
    !-----------------------------------------------------------------------
-   function atm_setup_packages(configs, streamInfo, packages, iocontext) result(ierr)
+   function atm_setup_packages(configs, streamInfo, packages, iocontext, dminfo) result(ierr)
 
       use mpas_dmpar
       use mpas_derived_types, only : mpas_pool_type, mpas_io_context_type, MPAS_streamInfo_type
@@ -116,6 +116,7 @@ module atm_core_interface
       type (MPAS_streamInfo_type), intent(inout) :: streamInfo
       type (mpas_pool_type), intent(inout) :: packages
       type (mpas_io_context_type), intent(inout) :: iocontext
+      type (dm_info), intent(in) :: dminfo
       integer :: ierr
 
       logical, pointer :: iauActive

--- a/src/core_init_atmosphere/mpas_init_atm_core_interface.F
+++ b/src/core_init_atmosphere/mpas_init_atm_core_interface.F
@@ -100,7 +100,7 @@ module init_atm_core_interface
    !>  not allocated until after this routine has been called.
    !
    !-----------------------------------------------------------------------
-   function init_atm_setup_packages(configs, streamInfo, packages, iocontext) result(ierr)
+   function init_atm_setup_packages(configs, streamInfo, packages, iocontext, dminfo) result(ierr)
 
       use mpas_derived_types, only : mpas_pool_type, mpas_io_context_type, MPAS_streamInfo_type
       use mpas_pool_routines, only : mpas_pool_get_config, mpas_pool_get_package
@@ -111,6 +111,7 @@ module init_atm_core_interface
       type (MPAS_streamInfo_type), intent(inout) :: streamInfo
       type (mpas_pool_type), intent(inout) :: packages
       type (mpas_io_context_type), intent(inout) :: iocontext
+      type (dm_info), intent(in) :: dminfo
       integer :: ierr
       logical :: lexist
 

--- a/src/core_landice/mode_forward/mpas_li_core_interface.F
+++ b/src/core_landice/mode_forward/mpas_li_core_interface.F
@@ -90,13 +90,14 @@ module li_core_interface
 !>   *not* allocated until after this routine is called.
 !
 !-----------------------------------------------------------------------
-   function li_setup_packages(configPool, streamInfo, packagePool, iocontext) result(ierr)
+   function li_setup_packages(configPool, streamInfo, packagePool, iocontext, dminfo) result(ierr)
 
       implicit none
       type (mpas_pool_type), intent(inout) :: configPool
       type (MPAS_streamInfo_type), intent(inout) :: streamInfo
       type (mpas_pool_type), intent(inout) :: packagePool
       type (mpas_io_context_type), intent(inout) :: iocontext
+      type (dm_info), intent(in) :: dminfo
       integer :: ierr
 
       ! Local variables

--- a/src/core_ocean/driver/mpas_ocn_core_interface.F
+++ b/src/core_ocean/driver/mpas_ocn_core_interface.F
@@ -95,7 +95,7 @@ module ocn_core_interface
    !>   *not* allocated until after this routine is called.
    !
    !-----------------------------------------------------------------------
-   function ocn_setup_packages(configPool, streamInfo, packagePool, iocontext) result(ierr)!{{{
+   function ocn_setup_packages(configPool, streamInfo, packagePool, iocontext, dminfo) result(ierr)!{{{
 
       use ocn_analysis_driver
 
@@ -103,6 +103,7 @@ module ocn_core_interface
       type (MPAS_streamInfo_type), intent(inout) :: streamInfo
       type (mpas_pool_type), intent(inout) :: packagePool
       type (mpas_io_context_type), intent(inout) :: iocontext
+      type (dm_info), intent(in) :: dminfo
 
       integer :: ierr
 

--- a/src/core_seaice/model_forward/mpas_seaice_core_interface.F
+++ b/src/core_seaice/model_forward/mpas_seaice_core_interface.F
@@ -88,7 +88,7 @@ module seaice_core_interface
    !>   *not* allocated until after this routine is called.
    !
    !-----------------------------------------------------------------------
-   function seaice_setup_packages(configPool, streamInfo, packagePool, iocontext) result(ierr)!{{{
+   function seaice_setup_packages(configPool, streamInfo, packagePool, iocontext, dminfo) result(ierr)!{{{
 
       use mpas_derived_types
 
@@ -98,6 +98,7 @@ module seaice_core_interface
       type (MPAS_streamInfo_type), intent(inout) :: streamInfo
       type (mpas_pool_type), intent(inout) :: packagePool
       type (mpas_io_context_type), intent(inout) :: iocontext
+      type (dm_info), intent(in) :: dminfo
 
       integer :: ierr
 

--- a/src/core_sw/mpas_sw_core_interface.F
+++ b/src/core_sw/mpas_sw_core_interface.F
@@ -89,7 +89,7 @@ module sw_core_interface
    !>   *not* allocated until after this routine is called.
    !
    !-----------------------------------------------------------------------
-   function sw_setup_packages(configPool, streamInfo, packagePool, iocontext) result(ierr)!{{{
+   function sw_setup_packages(configPool, streamInfo, packagePool, iocontext, dminfo) result(ierr)!{{{
 
       use mpas_derived_types
 
@@ -99,6 +99,7 @@ module sw_core_interface
       type (MPAS_streamInfo_type), intent(inout) :: streamInfo
       type (mpas_pool_type), intent(inout) :: packagePool
       type (mpas_io_context_type), intent(inout) :: iocontext
+      type (dm_info), intent(in) :: dminfo
       integer :: ierr
 
       ierr = 0

--- a/src/core_test/mpas_test_core_interface.F
+++ b/src/core_test/mpas_test_core_interface.F
@@ -89,7 +89,7 @@ module test_core_interface
    !>   *not* allocated until after this routine is called.
    !
    !-----------------------------------------------------------------------
-   function test_setup_packages(configPool, streamInfo, packagePool, iocontext) result(ierr)!{{{
+   function test_setup_packages(configPool, streamInfo, packagePool, iocontext, dminfo) result(ierr)!{{{
 
       use mpas_derived_types
 
@@ -99,6 +99,7 @@ module test_core_interface
       type (MPAS_streamInfo_type), intent(inout) :: streamInfo
       type (mpas_pool_type), intent(inout) :: packagePool
       type (mpas_io_context_type), intent(inout) :: iocontext
+      type (dm_info), intent(in) :: dminfo
       integer :: ierr
 
       ierr = 0

--- a/src/driver/mpas_subdriver.F
+++ b/src/driver/mpas_subdriver.F
@@ -275,7 +275,7 @@ module mpas_subdriver
       end if
 
       ierr = domain_ptr % core % setup_packages(domain_ptr % configs, domain_ptr % streamInfo, domain_ptr % packages, &
-                                                domain_ptr % iocontext)
+                                                domain_ptr % iocontext, domain_ptr % dminfo)
       if ( ierr /= 0 ) then
          call mpas_log_write('Package setup failed for core '//trim(domain_ptr % core % coreName), messageType=MPAS_LOG_CRIT)
       end if

--- a/src/framework/mpas_core_types.inc
+++ b/src/framework/mpas_core_types.inc
@@ -21,15 +21,17 @@
    end interface
 
    abstract interface
-      function mpas_setup_packages_function(configs, streamInfo, packages, iocontext) result(iErr)
+      function mpas_setup_packages_function(configs, streamInfo, packages, iocontext, dminfo) result(iErr)
          import mpas_pool_type
          import mpas_io_context_type
          import mpas_streaminfo_type
+         import dm_info
 
          type (mpas_pool_type), intent(inout) :: configs
          type (mpas_streaminfo_type), intent(inout) :: streamInfo
          type (mpas_pool_type), intent(inout) :: packages
          type (mpas_io_context_type), intent(inout) :: iocontext
+         type (dm_info), intent(in) :: dminfo
          integer :: iErr
       end function mpas_setup_packages_function
    end interface


### PR DESCRIPTION
This PR adds a `dm_info` object to the argument list of the `mpas_setup_packages_function` core interface function. Adding a `dm_info` object allows a core's package setup function to make use of MPI when setting up packages. For example, a core may read data from a file only on MPI rank 0 and broadcast the resulting values to other MPI ranks rather than having each MPI rank independently open and read the file.

In addition to updating the `mpas_setup_packages_function` abstract interface in `mpas_core_types.inc` with an additional `dminfo` argument, this PR updates the call to `domain_ptr % core % setup_packages` in `mpas_init` to include the `dminfo` argument, and it also updates the `*_setup_packages` functions in each core's interface module.