### PR TITLE
Build option to download and build PT-SCOTCH automatically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -777,6 +777,34 @@ endif
 	LIBS += $(NCLIB)
 endif
 
+export SCOTCH ?= false
+ifeq "$(SCOTCH)" "true"
+	ifeq ($(wildcard $(SCOTCH_ROOT)), )
+		export SCOTCH_RELPATH=src/external/scotch
+		export SCOTCH_ROOT=${CURDIR}/${SCOTCH_RELPATH}/install
+		export SCOTCH_LIB_DIR=lib
+	else
+		ifneq ($(wildcard $(SCOTCH_ROOT)/lib/libptscotch.a), )
+			SCOTCH_LIB_DIR=lib64
+		else ifneq ($(wildcard $(SCOTCH_ROOT)/lib64/libptscotch.a), )
+			SCOTCH_LIB_DIR=lib64
+		else
+			$(error Could not find SCOTCH library in $(SCOTCH_ROOT)/lib or $(SCOTCH_ROOT)/lib64)
+		endif
+	endif
+	SCOTCH_INCLUDES += -I$(SCOTCH_ROOT)/include
+	SCOTCH_LIBS += -L$(SCOTCH_ROOT)/$(SCOTCH_LIB_DIR) -lptscotch -lscotch  -lptscotcherr -lm
+	SCOTCH_FLAGS = -DMPAS_SCOTCH
+	CPPINCLUDES += $(SCOTCH_INCLUDES)
+	LIBS += $(SCOTCH_LIBS)
+	override CPPFLAGS += $(SCOTCH_FLAGS)
+	SCOTCH_MESSAGE="MPAS was built with an external SCOTCH library using SCOTCH path"
+else ifeq "$(SCOTCH)" "false"
+	SCOTCH_MESSAGE="MPAS was built with the embedded SCOTCH library."
+else
+	$(error Invalid SCOTCH option: $(SCOTCH) - valid options "true", "false")
+endif
+
 ifneq "$(SCOTCH)" ""
 	SCOTCH_INCLUDES += -I$(SCOTCH)/include
 	SCOTCH_LIBS += -L$(SCOTCH)/lib64 -lptscotch -lscotch  -lptscotcherr -lm
@@ -1086,6 +1114,7 @@ rebuild_check:
 	OPENMP=$(OPENMP)\n$\
 	OPENMP_OFFLOAD=$(OPENMP_OFFLOAD)\n$\
 	OPENACC=$(OPENACC)\n$\
+	SCOTCH=$(SCOTCH)\n$\
 	TAU=$(TAU)\n$\
 	PICFLAG=$(PICFLAG)\n$\
 	TIMER_LIB=$(TIMER_LIB)\n$\
@@ -1442,11 +1471,22 @@ musica_fortran_test:
 	$(eval MUSICA_FORTRAN_VERSION := $(shell pkg-config --modversion musica-fortran))
 	$(if $(findstring 1,$(MUSICA_FORTRAN_TEST)), $(info Built a simple test program with MUSICA-Fortran version $(MUSICA_FORTRAN_VERSION)), )
 
-scotch_c_test:
+$(SCOTCH_ROOT)/$(SCOTCH_LIB_DIR)/libptscotch.a:
+	@#
+	@# Build the Scotch library if it is not already built
+	@#
+	$(info Building Scotch library...)
+	src/core_atmosphere/tools/manage_externals/checkout_externals --externals src/Externals.cfg;
+	cd ${SCOTCH_RELPATH} && mkdir -p build;
+	cd ${SCOTCH_RELPATH}/build && cmake .. -DCMAKE_INSTALL_PREFIX=$(SCOTCH_ROOT) -DCMAKE_INSTALL_LIBDIR=$(SCOTCH_LIB_DIR) -DCMAKE_BUILD_TYPE=Release;
+	cd ${SCOTCH_RELPATH}/build && make -j$(nproc);
+	cd ${SCOTCH_RELPATH}/build && make install;
+
+scotch_c_test: $(SCOTCH_ROOT)/$(SCOTCH_LIB_DIR)/libptscotch.a
 	@#
 	@# Create a C test program and try to build against the PT-SCOTCH library
 	@#
-	$(info Checking for a working Scotch library...)
+	$(info Checking for a working Scotch library in $(SCOTCH_ROOT)...)
 	$(eval SCOTCH_C_TEST := $(shell $\
 	    printf "#include <stdio.h>\n\
 			&#include \"mpi.h\"\n\
@@ -1529,7 +1569,7 @@ else
 MUSICA_MESSAGE = "MPAS was not linked with the MUSICA-Fortran library."
 endif
 
-ifneq "$(SCOTCH)" ""
+ifeq "$(SCOTCH)" "true"
 MAIN_DEPS += scotch_c_test
 SCOTCH_MESSAGE = "MPAS has been linked with the Scotch graph partitioning library."
 else

--- a/src/Externals.cfg
+++ b/src/Externals.cfg
@@ -1,0 +1,9 @@
+[SCOTCH]
+local_path = ./src/external/scotch
+protocol = git
+repo_url = https://gitlab.inria.fr/scotch/scotch.git
+tag = v7.0.11
+required = True
+
+[externals_description]
+schema_version = 1.0.0


### PR DESCRIPTION
Previously, using PT-SCOTCH for online graph partitioning with MPAS required the user to build and install it themselves and set SCOTCH=<path> environment variable before building MPAS. While this is a completely functional option, many users may prefer the convenience of an automatic fetch and build process. 


This PR adds an option to automatically fetch and build PT-SCOTCH under `src/external` during the MPAS build. The previously active `SCOTCH` variable is repurposed as  a `true or false` build option to toggle linking PT-SCOTCH library with the MPAS build. Previously, `SCOTCH` pointed to the PT-SCOTCH installation path. This is now available through the `SCOTCH_ROOT` variable. This allows the user to still link MPAS with custom PT-SCOTCH installations.

There are a few different build + link scenarios with these two variables


1. When `SCOTCH=false` or unspecified, the regular MPAS build process continues without attempting to build or link against PT-SCOTCH.

```
make gnu CORE=init_atmosphere
```

2. When `SCOTCH=true` and `SCOTCH_ROOT` is not set or unset, the build process automatically fetches and builds the PT-SCOTCH graph-partitioning library, followed by the build of the MPAS model, and then the PT-SCOTCH library is linked as a static library.

```
make gnu CORE=init_atmosphere SCOTCH=true
```

3. When `SCOTCH=true` and `SCOTCH_ROOT` points to the location of an existing PT-SCOTCH installation, the regular MPAS build process completes and then the PT-SCOTCH library is linked as a static library.

```
export SCOTCH_ROOT=/path/to/scotch/installation
make gnu CORE=init_atmosphere SCOTCH=true
```

4. When `SCOTCH=true` and `SCOTCH_ROOT` is set but does not point to the location of an existing PT-SCOTCH installation, the build process exits with an error. 


##
Notes:

- A new Externals.cfg is added under the src directory so that both the atmosphere and init_atmosphere CORES can use this external

- If the automatic PT-SCOTCH fetch and build is successful, it is installed under `src/external/scotch/install`. And the libraries under the `lib` subdirectory. However, in the case of a user-specified PT-SCOTCH installation, we search both `$(SCOTCH_ROOT)/lib` and `$(SCOTCH_ROOT)/lib64` subdirectories to find the relevant libraries.

- `SCOTCH=$(SCOTCH)` is added to the options tracked by `rebuild_check`, so switching SCOTCH on/off between builds is detected as an incompatible-option change (triggering the clean/rebuild prompt or AUTOCLEAN).

- Add a scotch cleanup step (rm -r build install) to the clean target so make clean removes the downloaded/built SCOTCH tree along with the other external libs.

###
Current limitations

- CMake (>= 3.10) is presently required in order to build PT-SCOTCH using the automatic fetch + build method. In addition, all the usual dependencies of PT-SCOTCH need to be present in the environment prior to the build.

- We presently support only the linking of static PT-SCOTCH libraries with MPAS. Shared libraries are currently not supported. 