### PR TITLE
Atmosphere/package eval order

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -485,9 +485,11 @@
                 <package name="les"
                          description="Variables and options associated with LES models"
                          active_when="trim(config_les_model) /= 'none'"/>
+#ifdef DO_PHYSICS
                 <package name="sfclayer"
                          description="Variables and options associated with surface layer physics"
                          active_when="trim(config_sfclayer_scheme) /= 'off'"/>
+#endif
         </packages>
 
 

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -487,7 +487,7 @@
                          active_when="trim(config_les_model) /= 'none'"/>
                 <package name="sfclayer"
                          description="Variables and options associated with surface layer physics"
-                         active_when="(trim(config_physics_suite) /= 'none' .and. trim(config_sfclayer_scheme) == 'suite') .or.  any(trim(config_sfclayer_scheme) == [ character(len=StrKind) :: 'sf_monin_obukhov', 'sf_monin_obukhov_rev', 'sf_mynn' ])"/>
+                         active_when="trim(config_sfclayer_scheme) /= 'off'"/>
         </packages>
 
 

--- a/src/core_atmosphere/mpas_atm_core_interface.F
+++ b/src/core_atmosphere/mpas_atm_core_interface.F
@@ -134,11 +134,6 @@ module atm_core_interface
       integer :: local_ierr
 
 
-      ierr = atm_setup_packages_when(configs, packages)
-      if (ierr /= 0) then
-         return
-      end if
-
       !
       ! Incremental analysis update
       !
@@ -258,6 +253,11 @@ module atm_core_interface
       end if
 
 #endif
+
+      ierr = atm_setup_packages_when(configs, packages)
+      if (ierr /= 0) then
+         return
+      end if
 
    end function atm_setup_packages
 


### PR DESCRIPTION
This PR incorporates several small modifications to the registry-defined package logic processing in the atmosphere core, especially concerning the `sfclayer` package, ultimately allowing for improved evaluation of physics namelist options in package logic.