### PR TITLE
Optimize ACC port of atm_advance_scalars_work:4857

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -4854,6 +4854,7 @@ module atm_time_integration
       !$acc enter data create(scalar_tend_column)
       MPAS_ACC_TIMER_STOP('atm_advance_scalars [ACC_data_xfer]')
 
+      MPAS_ACC_TIMER_START('atm_advance_scalars_4857')
       !$acc parallel wait
       !$acc loop gang worker private(scalar_tend_column, wdtn)
       do iCell=cellSolveStart,cellSolveEnd
@@ -4931,6 +4932,8 @@ module atm_time_integration
 
       end do
       !$acc end parallel
+
+      MPAS_ACC_TIMER_STOP('atm_advance_scalars_4857')
 
       MPAS_ACC_TIMER_START('atm_advance_scalars [ACC_data_xfer]')
       !$acc exit data delete(scalar_tend_column)

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -4871,20 +4871,19 @@ module atm_time_integration
             end do
             end do
 
-            !$acc loop seq
-            do i=1,nEdgesOnCell(iCell)
-               iEdge = edgesOnCell(i,iCell)
-
+            !$acc loop vector collapse(2)
+            do k=1,nVertLevels
+            do iScalar=1,num_scalars
                ! here we add the horizontal flux divergence into the scalar tendency.
                ! note that the scalar tendency is modified.
-               !$acc loop vector collapse(2)
-               do k=1,nVertLevels
-                  do iScalar=1,num_scalars
+               !$acc loop seq
+               do i=1,nEdgesOnCell(iCell)
+                  iEdge = edgesOnCell(i,iCell)
                         scalar_tend_column(iScalar,k) = scalar_tend_column(iScalar,k) &
                                - edgesOnCell_sign(i,iCell) * uhAvg(k,iEdge)*horiz_flux_arr(iScalar,k,iEdge)
-                  end do
+   
                end do
-
+            end do
             end do
 
             !$acc loop vector collapse(2)

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -4724,8 +4724,9 @@ module atm_time_integration
       logical :: local_advance_density
 
       real (kind=RKIND) :: weight_time_old, weight_time_new
-      real (kind=RKIND), dimension(num_scalars,nVertLevels) :: scalar_tend_column  ! local storage to accumulate tendency
+      !real (kind=RKIND), dimension(num_scalars,nVertLevels) :: scalar_tend_column  ! local storage to accumulate tendency
       real (kind=RKIND) :: u_direction, u_positive, u_negative
+      real (kind=RKIND) :: scalar_tend_column_tmp
 
       flux4(q_im2, q_im1, q_i, q_ip1, ua) =                     &
           ua*( 7.*(q_i + q_im1) - (q_ip1 + q_im2) )/12.0
@@ -4851,42 +4852,18 @@ module atm_time_integration
       !
 
       MPAS_ACC_TIMER_START('atm_advance_scalars [ACC_data_xfer]')
-      !$acc enter data create(scalar_tend_column)
+      !!$acc enter data create(scalar_tend_column)
       MPAS_ACC_TIMER_STOP('atm_advance_scalars [ACC_data_xfer]')
 
       call mpas_timer_start('atm_advance_scalars_4857')
       !$acc parallel wait
-      !$acc loop gang worker private(scalar_tend_column, wdtn)
+      !$acc loop gang worker private(wdtn)
       do iCell=cellSolveStart,cellSolveEnd
 
          if(bdyMaskCell(iCell) <= nRelaxZone) then  ! specified zone for regional_MPAS is not updated in this routine
-
-            !$acc loop vector collapse(2)
-            do k=1,nVertLevels
-            do iScalar=1,num_scalars
-               scalar_tend_column(iScalar,k) = 0.0_RKIND
-#ifndef DO_PHYSICS
-               scalar_tend_save(iScalar,k,iCell) = 0.0_RKIND  !  testing purposes - we have no sources or sinks
-#endif
-               ! here we add the horizontal flux divergence into the scalar tendency.
-               ! note that the scalar tendency is modified.
-               !$acc loop seq
-               do i=1,nEdgesOnCell(iCell)
-                  iEdge = edgesOnCell(i,iCell)
-                  scalar_tend_column(iScalar,k) = scalar_tend_column(iScalar,k) &
-                           - edgesOnCell_sign(i,iCell) * uhAvg(k,iEdge)*horiz_flux_arr(iScalar,k,iEdge)   
-               end do
-
-               scalar_tend_column(iScalar,k) = scalar_tend_column(iScalar,k) * invAreaCell(iCell) &
-                                             + scalar_tend_save(iScalar,k,iCell)
-            end do
-            end do
-
-
             !
             !  vertical flux divergence and update of the scalars
             !
-
             !$acc loop vector
             do iScalar=1,num_scalars
                wdtn(iScalar,1) = 0.0
@@ -4908,11 +4885,27 @@ module atm_time_integration
 
             !$acc loop vector collapse(2)
             do k=1,nVertLevels
-               do iScalar=1,num_scalars
-                  rho_zz_new_inv = 1.0_RKIND / (weight_time_old*rho_zz_old(k,iCell) + weight_time_new*rho_zz_new(k,iCell))
-                  scalar_new(iScalar,k,iCell) = (   scalar_old(iScalar,k,iCell)*rho_zz_old(k,iCell) &
-                        + dt*( scalar_tend_column(iScalar,k) -rdnw(k)*(wdtn(iScalar,k+1)-wdtn(iScalar,k)) ) ) * rho_zz_new_inv
+            do iScalar=1,num_scalars
+               scalar_tend_column_tmp = 0.0_RKIND
+#ifndef DO_PHYSICS
+               scalar_tend_save(iScalar,k,iCell) = 0.0_RKIND  !  testing purposes - we have no sources or sinks
+#endif
+               ! here we add the horizontal flux divergence into the scalar tendency.
+               ! note that the scalar tendency is modified.
+               !$acc loop seq
+               do i=1,nEdgesOnCell(iCell)
+                  iEdge = edgesOnCell(i,iCell)
+                  scalar_tend_column_tmp = scalar_tend_column_tmp &
+                           - edgesOnCell_sign(i,iCell) * uhAvg(k,iEdge)*horiz_flux_arr(iScalar,k,iEdge)   
                end do
+
+               scalar_tend_column_tmp = scalar_tend_column_tmp * invAreaCell(iCell) &
+                                             + scalar_tend_save(iScalar,k,iCell)
+
+               rho_zz_new_inv = 1.0_RKIND / (weight_time_old*rho_zz_old(k,iCell) + weight_time_new*rho_zz_new(k,iCell))
+               scalar_new(iScalar,k,iCell) = (   scalar_old(iScalar,k,iCell)*rho_zz_old(k,iCell) &
+                        + dt*( scalar_tend_column_tmp -rdnw(k)*(wdtn(iScalar,k+1)-wdtn(iScalar,k)) ) ) * rho_zz_new_inv
+            end do
             end do
 
          end if ! specified zone regional_MPAS test
@@ -4923,7 +4916,7 @@ module atm_time_integration
       call mpas_timer_stop('atm_advance_scalars_4857')
 
       MPAS_ACC_TIMER_START('atm_advance_scalars [ACC_data_xfer]')
-      !$acc exit data delete(scalar_tend_column)
+      !!$acc exit data delete(scalar_tend_column)
       MPAS_ACC_TIMER_STOP('atm_advance_scalars [ACC_data_xfer]')
 
    end subroutine atm_advance_scalars_work

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -4854,7 +4854,7 @@ module atm_time_integration
       !$acc enter data create(scalar_tend_column)
       MPAS_ACC_TIMER_STOP('atm_advance_scalars [ACC_data_xfer]')
 
-      MPAS_ACC_TIMER_START('atm_advance_scalars_4857')
+      call mpas_timer_start('atm_advance_scalars_4857')
       !$acc parallel wait
       !$acc loop gang worker private(scalar_tend_column, wdtn)
       do iCell=cellSolveStart,cellSolveEnd
@@ -4933,7 +4933,7 @@ module atm_time_integration
       end do
       !$acc end parallel
 
-      MPAS_ACC_TIMER_STOP('atm_advance_scalars_4857')
+      call mpas_timer_stop('atm_advance_scalars_4857')
 
       MPAS_ACC_TIMER_START('atm_advance_scalars [ACC_data_xfer]')
       !$acc exit data delete(scalar_tend_column)

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -4868,30 +4868,18 @@ module atm_time_integration
 #ifndef DO_PHYSICS
                scalar_tend_save(iScalar,k,iCell) = 0.0_RKIND  !  testing purposes - we have no sources or sinks
 #endif
-            end do
-            end do
-
-            !$acc loop vector collapse(2)
-            do k=1,nVertLevels
-            do iScalar=1,num_scalars
                ! here we add the horizontal flux divergence into the scalar tendency.
                ! note that the scalar tendency is modified.
                !$acc loop seq
                do i=1,nEdgesOnCell(iCell)
                   iEdge = edgesOnCell(i,iCell)
-                        scalar_tend_column(iScalar,k) = scalar_tend_column(iScalar,k) &
-                               - edgesOnCell_sign(i,iCell) * uhAvg(k,iEdge)*horiz_flux_arr(iScalar,k,iEdge)
-   
+                  scalar_tend_column(iScalar,k) = scalar_tend_column(iScalar,k) &
+                           - edgesOnCell_sign(i,iCell) * uhAvg(k,iEdge)*horiz_flux_arr(iScalar,k,iEdge)   
                end do
-            end do
-            end do
 
-            !$acc loop vector collapse(2)
-            do k=1,nVertLevels
-               do iScalar=1,num_scalars
-                     scalar_tend_column(iScalar,k) = scalar_tend_column(iScalar,k) * invAreaCell(iCell) &
-                                                   + scalar_tend_save(iScalar,k,iCell)
-               end do
+               scalar_tend_column(iScalar,k) = scalar_tend_column(iScalar,k) * invAreaCell(iCell) &
+                                             + scalar_tend_save(iScalar,k,iCell)
+            end do
             end do
 
 


### PR DESCRIPTION
This PR introduces optimizations for the OpenACC port of `atm_advance_scalars_work:4857` and is intended to serve as a template for other optimization PRs.

The table below lists the timings for a real, global 30km experiment on A100 GPU with nvhpc, and Derecho CPUs with several compiler suites. 

For nvhpc gpu runs, `-gpu=math_uniform` is introduced as a build flag to ensure optimizations are bit-identical, and the we report the numbers using `NV_ACC_TIME=1`. The GPU runs are on 1 Derecho GPU node, using 1 A100  via 1 MPI task.

The numbers reported for the CPU runs with gnu and intel compilers use the newly-added timers local to this region, and are averaged across three runs. The CPU runs use a single derecho CPU node each, fully subscribed to 128 MPI tasks.

Version | GPU kernel time (ms) | CPU timer - nvhpc | CPU timer - gnu | CPU timer - intel24 | CPU timer - intel25
-- | -- | -- | -- | -- | --
base | 36 | 0.0251 | 0.0246 | 0.0245 | 0.02338
1 swap the seq and vector collapse(2) loops | 26 | 0.02695 | 0.03141 | 0.02768 | 0.03124
2 and fuse all scalar_tend_column loops | 24 | 0.02694 | 0.03058 | 0.0273 | 0.03034
3 Rearrange loops so scalar_tend_column can be replaced by a scalar local to each gang | 18 | 0.02669 | 0.03136 | 0.03269 | 0.03094





This work was completed in part at the NCAR/NLR/NOAA Open Hackathon, part of the Open Hackathons program. The authors would like to acknowledge OpenACC-Standard.org for their support.