### PR TITLE
Optimize ACC port of atm_advance_acoustic_step_work:3964

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -3961,6 +3961,7 @@ module atm_time_integration
          end do
          !$acc end parallel
       else
+         call mpas_timer_start('advance_acoustic_step_3964')
          !$acc parallel default(present)
          !$acc loop gang worker collapse(2)
          do iCell=cellStart,cellEnd
@@ -3969,6 +3970,7 @@ module atm_time_integration
             end do
          end do
          !$acc end parallel
+         call mpas_timer_stop('advance_acoustic_step_3964')
       end if
 
 !$OMP BARRIER

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -3963,7 +3963,7 @@ module atm_time_integration
       else
          call mpas_timer_start('advance_acoustic_step_3964')
          !$acc parallel default(present)
-         !$acc loop gang worker collapse(2)
+         !$acc loop gang worker vector collapse(2)
          do iCell=cellStart,cellEnd
             do k=1,nVertLevels
                rtheta_pp_old(k,iCell) = rtheta_pp(k,iCell)


### PR DESCRIPTION
This PR introduces optimizations for the OpenACC port of atm_advance_acoustic_step_work:3964. The table below lists the timings for a real, global 30km experiment on A100 GPU with the nvhpc.

For nvhpc gpu runs, -gpu=math_uniform is introduced as a build flag to ensure optimizations are bit-identical, and the we report the numbers using NV_ACC_TIME=1. The GPU runs are on 1 Derecho GPU node, using 1 A100 via 1 MPI task.

As the changes introduced aren't expected to affect CPU execution times, the CPU columns are skipped. 

Version | GPU kernel time (ms)
-- | --
base | 23.331
Add vector to loop statement | 0.258


The substantial speedup achieved in this PR is a result of utilizing all the threads available to each warp. 


This work was completed in part at the NCAR/NLR/NOAA Open Hackathon, part of the Open Hackathons program. The authors would like to acknowledge OpenACC-Standard.org for their support.