### PR TITLE
Fix OpenMP reproducibility

### DIFF
--- a/cmake/Functions/MPAS_Functions.cmake
+++ b/cmake/Functions/MPAS_Functions.cmake
@@ -92,7 +92,6 @@ function(mpas_fortran_target target)
     list(APPEND MPAS_FORTRAN_TARGET_COMPILE_DEFINITIONS _MPI=1)
     # Enable OpenMP support
     if(MPAS_OPENMP)
-        list(APPEND MPAS_FORTRAN_TARGET_COMPILE_DEFINITIONS MPAS_OPENMP=1)
         target_link_libraries(${target} PUBLIC OpenMP::OpenMP_Fortran)
     endif()
 

--- a/cmake/Functions/MPAS_Functions.cmake
+++ b/cmake/Functions/MPAS_Functions.cmake
@@ -92,6 +92,7 @@ function(mpas_fortran_target target)
     list(APPEND MPAS_FORTRAN_TARGET_COMPILE_DEFINITIONS _MPI=1)
     # Enable OpenMP support
     if(MPAS_OPENMP)
+        list(APPEND MPAS_FORTRAN_TARGET_COMPILE_DEFINITIONS MPAS_OPENMP=1)
         target_link_libraries(${target} PUBLIC OpenMP::OpenMP_Fortran)
     endif()
 

--- a/src/core_atmosphere/diagnostics/mpas_pv_diagnostics.F
+++ b/src/core_atmosphere/diagnostics/mpas_pv_diagnostics.F
@@ -1029,7 +1029,7 @@ module mpas_pv_diagnostics
          du_dz = calc_vertDeriv_one(val0, valm, z0-zm)
          !v
          val0 = dotProduct(velCell0, xyzLocal(:,2),3)
-         valm = dotProduct(velCellp, xyzLocal(:,2),3)
+         valm = dotProduct(velCellm, xyzLocal(:,2),3)
          dv_dz = calc_vertDeriv_one(val0, valm, z0-zm)
       else
          !u

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -4384,12 +4384,14 @@ module atm_time_integration
 
       ! Avoid FP errors caused by a potential division by zero below by
       ! initializing the "garbage cell" of rho_zz to a non-zero value
+!$omp single
       !$acc parallel default(present)
       !$acc loop gang vector
       do k=1,nVertLevels
          rho_zz(k,nCells+1) = 1.0
       end do
       !$acc end parallel
+!$omp end single
 
       ! compute new density everywhere so we can compute u from ru.
       ! we will also need it to compute theta_m below
@@ -5294,10 +5296,12 @@ module atm_time_integration
          end do
 
 #ifndef MPAS_OPENACC
+!$omp single
          do k=1,nVertLevels
             scalar_old(k,nCells+1) = 0.0_RKIND
             scalar_new(k,nCells+1) = 0.0_RKIND
          end do
+!$omp end single
 #endif
 
          !$acc end parallel

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -16,6 +16,10 @@
 
 module atm_time_integration
 
+#ifdef MPAS_OPENMP
+   use omp_lib
+#endif
+
    use mpas_pool_routines
    use mpas_kind_types
    use mpas_constants
@@ -3135,9 +3139,18 @@ module atm_time_integration
       call mpas_pool_get_array(state, 'scalars', scalars_2, 2)
 
 
-      !$acc kernels
-      theta_m_2(:,cellEnd+1) = 0.0_RKIND
-      !$acc end kernels
+#ifdef MPAS_OPENMP
+      ! Assign 0 to cellEnd+1 element only on the last thread, because on
+      ! all other threads cellEnd+1 is the same memory location
+      ! as cellStart on the following threads
+      if (omp_get_thread_num() == omp_get_num_threads() - 1) then
+#endif
+         !$acc kernels
+         theta_m_2(:,cellEnd+1) = 0.0_RKIND
+         !$acc end kernels
+#ifdef MPAS_OPENMP
+      end if
+#endif
 
       !$acc parallel default(present)
       !$acc loop gang worker
@@ -7728,11 +7741,20 @@ module atm_time_integration
       call mpas_pool_get_array(state, 'rho_zz', rho_zz_1, 1)
       call mpas_pool_get_array(state, 'rho_zz', rho_zz_2, 2)
 
-      ! Interim fix for the atm_compute_dyn_tend_work subroutine accessing uninitialized values
-      ! in garbage cells of theta_m
-      !$acc kernels
-      theta_m_1(:,cellEnd+1) = 0.0_RKIND
-      !$acc end kernels
+#ifdef MPAS_OPENMP
+      ! Assign 0 to cellEnd+1 element only on the last thread, because on
+      ! all other threads cellEnd+1 is the same memory location
+      ! as cellStart on the following threads
+      if (omp_get_thread_num() == omp_get_num_threads() - 1) then
+#endif
+         ! Interim fix for the atm_compute_dyn_tend_work subroutine accessing uninitialized values
+         ! in garbage cells of theta_m
+         !$acc kernels
+         theta_m_1(:,cellEnd+1) = 0.0_RKIND
+         !$acc end kernels
+#ifdef MPAS_OPENMP
+      end if
+#endif
 
       inv_dynamics_split = 1.0_RKIND / real(dynamics_split)
 

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -3435,6 +3435,7 @@ module atm_time_integration
       rcv = rgas/(cp-rgas)
       c2 = cp*rcv
 
+!$omp single
       !$acc parallel default(present)
       !$acc loop gang worker
 ! MGD bad to have all threads setting this variable?
@@ -3442,6 +3443,7 @@ module atm_time_integration
          cofrz(k) = rdzw(k)
       end do
       !$acc end parallel
+!$omp end single
 
       !$acc parallel default(present)
       !$acc loop gang worker private(b_tri,c_tri)

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_lsm.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_lsm.F
@@ -357,9 +357,11 @@
 
 !In Registry.xml, dzs is a function of nCells. In the Noah lsm scheme, dzs is independent
 !of cell locations:
+!$omp single
  do n = 1,num_soils
     dzs_p(n) = dzs(n,its)
  enddo
+!$omp end single
 
  do j = jts,jte
  do n = 1,num_soils

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
@@ -493,7 +493,7 @@
                 p2d(i,k)  = pres_hyd_p(i,k,j) / 100._RKIND
              enddo
              enddo
-             call vinterp_ozn(1,ncols,ncols,nlevs,p2d,pin_p,num_oznlevels,o3clim_p(1,1,j),o32d)
+             call vinterp_ozn(1,ncols,ncols,nlevs,p2d,pin_p,num_oznlevels,o3clim_p(its:ite,1:num_oznLevels,j),o32d)
              do i = its,ite
              do k = kts,kte
                 o3vmr(k,i) = o32d(i,k)

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
@@ -469,9 +469,11 @@
 
        if(config_o3climatology) then
           !ozone mixing ratio:
+!$omp single
           do k = 1, num_oznLevels
              pin_p(k) = pin(k)
           enddo
+!$omp end single
           do j = jts,jte
           do k = 1, num_oznLevels
              do i = its,ite
@@ -501,9 +503,11 @@
           if(allocated(p2d))  deallocate(p2d)
           if(allocated(o32d)) deallocate(o32d)
        else
+!$omp single
           do k = 1, num_oznLevels
              pin_p(k) = 0.0_RKIND
           enddo
+!$omp end single
           do j = jts,jte
           do k = 1, num_oznLevels
              do i = its,ite
@@ -571,9 +575,11 @@
        endif
 
        !ozone mixing ratio:
+!$omp single
        do k = 1, num_oznlevels
           pin_p(k) = pin(k)
        enddo
+!$omp end single
        do n = 1, num_months
           do j = jts,jte
           do k = 1, num_oznlevels

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
@@ -598,9 +598,11 @@
 
        !ozone volume mixing ratio:
        if(config_o3climatology) then
+!$omp single
           do k = 1, num_oznLevels
              pin_p(k) = pin(k)
           enddo
+!$omp end single
           do j = jts,jte
           do k = 1, num_oznLevels
              do i = its,ite
@@ -609,9 +611,11 @@
           enddo
           enddo
        else
+!$omp single
           do k = 1, num_oznLevels
              pin_p(k) = 0.0_RKIND
           enddo
+!$omp end single
           do j = jts,jte
           do k = 1, num_oznLevels
              do i = its,ite
@@ -672,9 +676,11 @@
           enddo
        endif
        !ozone mixing ratio:
+!$omp single
        do k = 1, num_oznlevels
           pin_p(k) = pin(k)
        enddo
+!$omp end single
        do n = 1, num_months
           do j = jts,jte
           do k = 1, num_oznlevels

--- a/src/core_atmosphere/physics/mpas_atmphys_sfc_diagnostics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_sfc_diagnostics.F
@@ -41,7 +41,6 @@
 !local variables and pointers:
  character(len=StrKIND),pointer:: lsm_scheme
 
- integer,pointer:: nCellsSolve
  integer:: i
 
  real(kind=RKIND),dimension(:),pointer:: psfc
@@ -57,8 +56,6 @@
 !call mpas_log_write('--- enter subroutine atmphys_sfc_diagnostics:')
 
  call mpas_pool_get_config(configs,'config_lsm_scheme',lsm_scheme)
-
- call mpas_pool_get_dimension(mesh,'nCellsSolve',nCellsSolve)
 
  call mpas_pool_get_array(diag,'surface_pressure',psfc)
 
@@ -77,7 +74,7 @@
 
  sf_select: select case(trim(lsm_scheme))
     case("sf_noah")
-       do i = 1,nCellsSolve
+       do i = its,ite
           rho = psfc(i)/(R_d*tsk(i))
           if(cqs2(i) .lt. 1.e-5) then
              q2(i) = qsfc(i)
@@ -95,7 +92,7 @@
     case("sf_noahmp")
        call mpas_pool_get_array(output_noahmp,'q2mxy',q2mxy)
        call mpas_pool_get_array(output_noahmp,'t2mxy',t2mxy)
-       do i = 1,nCellsSolve
+       do i = its,ite
           rho = psfc(i)/(R_d*tsk(i))
           if((xland(i)-1.5 .gt. 0._RKIND) .or. (xland(i)-1.5.le.0._RKIND .and. xice(i).ge.xice_threshold)) then
              if(cqs2(i) .lt. 1.e-5) then

--- a/src/core_atmosphere/physics/mpas_atmphys_vars.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_vars.F
@@ -382,6 +382,7 @@
                        !do not run urban physics, idiff is set to zero.
 
  integer:: ysu_pblmix
+!$omp threadprivate(ysu_pblmix)
 
  integer,dimension(:,:),allocatable:: &
     kpbl_p             !index of PBL top                                                                       [-]
@@ -670,6 +671,8 @@
  integer,parameter:: taer_asy_opt    = 3!input option for nwfa, nifa aerosol asymmetry factor.
 
  integer:: aer_opt                      !=[0,3]  : 0 for no aerosols, 3 for "water-" and "ice-friendly" aerosols.
+!$omp threadprivate(aer_opt)
+
  integer,dimension(:,:),allocatable:: &
                      taer_type_p        !=[1,2,3]: 1 for rural, 2 is urban and 3 is maritime in WRF. In MPAS,
                                         !aer_type is initialized as a function of landmask (=1 over land; =2 over

--- a/src/core_atmosphere/physics/physics_wrf/module_mp_thompson.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_mp_thompson.F
@@ -110,6 +110,7 @@
 !     REAL, PARAMETER, PRIVATE:: Nt_c = 100.E6
       REAL, PARAMETER, PRIVATE:: Nt_c_max = 1999.E6
       REAL, PRIVATE:: Nt_c
+      !$omp threadprivate(Nt_c)
 
 !..Declaration of constants for assumed CCN/IN aerosols when none in
 !.. the input data.  Look inside the init routine for modifications
@@ -127,6 +128,7 @@
       REAL, PARAMETER, PRIVATE:: mu_g = 0.0
       REAL, PARAMETER, PRIVATE:: mu_i = 0.0
       REAL, PRIVATE:: mu_c
+      !$omp threadprivate(mu_c)
 
 !..Sum of two gamma distrib for snow (Field et al. 2005).
 !.. N(D) = M2**4/M3**3 * [Kap0*exp(-M2*Lam0*D/M3)

--- a/src/core_atmosphere/physics/physics_wrf/module_sf_mynn.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_mynn.F
@@ -226,6 +226,8 @@
  real(kind=RKIND),dimension(its:ite):: u10_hv,v10_hv,th2_hv,t2_hv,q2_hv,wstar_hv,qstar_hv
  real(kind=RKIND),dimension(its:ite):: cd_hv,cda_hv,ck_hv,cka_hv,ustm_hv
 
+ real(kind=RKIND),dimension(its:ite,1:kte):: dz8w_hv,u3d_hv,v3d_hv,p3d_hv,t3d_hv,rho3d_hv,qv3d_hv,qc3d_hv,pattern_spp_pbl_hv
+
 !-----------------------------------------------------------------------------------------------------------------
 
  f_spp = .false.
@@ -244,9 +246,60 @@
        qstar_hv(i) = qstar(i,j)
     enddo
 
-    call sf_mynn_pre_run(its,ite,kte,itimestep,dz8w,u3d,v3d,p3d,t3d,rho3d,qv3d,qc3d,f_spp, &
-              pattern_spp_pbl,ust_hv,mol_hv,qsfc_hv,qstar_hv,dz8w1d,u1d,v1d,p1d,t1d,rho1d, &
-              qv1d,qc1d,rstoch1d,dz2w1d,u1d2,v1d2,errmsg,errflg)
+#if 1
+    dz8w_hv = dz8w(its:ite,1:kte,j)
+    u3d_hv = u3d(its:ite,1:kte,j)
+    v3d_hv = v3d(its:ite,1:kte,j)
+    p3d_hv = p3d(its:ite,1:kte,j)
+    t3d_hv = t3d(its:ite,1:kte,j)
+    rho3d_hv = rho3d(its:ite,1:kte,j)
+    qv3d_hv = qv3d(its:ite,1:kte,j)
+    qc3d_hv = qc3d(its:ite,1:kte,j)
+    if(f_spp) then
+    pattern_spp_pbl_hv = pattern_spp_pbl(its:ite,1:kte,j)
+    end if
+
+	 call sf_mynn_pre_run(its,ite,kte,itimestep, &
+              dz8w_hv,u3d_hv,v3d_hv,p3d_hv,t3d_hv,rho3d_hv,qv3d_hv,qc3d_hv, &
+              f_spp,pattern_spp_pbl_hv, &
+              ust_hv,mol_hv,qsfc_hv,qstar_hv, &
+              dz8w1d,u1d,v1d,p1d,t1d,rho1d,qv1d,qc1d,rstoch1d, &
+              dz2w1d,u1d2,v1d2,errmsg,errflg)
+#else
+    do i = its,ite
+       dz8w1d(i) = dz8w(i,1,j)
+       u1d(i)    = u3d(i,1,j)
+       v1d(i)    = v3d(i,1,j)
+       qv1d(i)   = qv3d(i,1,j)
+       qc1d(i)   = qc3d(i,1,j)
+       p1d(i)    = p3d(i,1,j)
+       t1d(i)    = t3d(i,1,j)
+       rho1d(i)  = rho3d(i,1,j)
+       !--- 2nd model level winds - for diags with high-resolution grids:
+		 dz2w1d(i) = dz8w(i,2,j)
+       u1d2(i)   = u3d(i,2,j)
+       v1d2(i)   = v3d(i,2,j)
+    enddo
+
+    if(f_spp) then
+       do i = its,ite
+          rstoch1d(i) = pattern_spp_pbl(i,1,j)
+       enddo
+    else
+       do i = its,ite
+          rstoch1d(i)=0._RKIND
+       enddo
+    endif
+
+    if(itimestep == 1) then
+       do i = its,ite
+          ust_hv(i)   = max(0.04*sqrt(u1d(i)*u1d(i) + v1d(i)*v1d(i)),0.001)
+          mol_hv(i)   = 0._RKIND
+          qsfc_hv(i)  = qv1d(i)/(1.+qv1d(i))
+          qstar_hv(i) = 0._RKIND
+       enddo
+    endif
+#endif
 
     !input arguments:
     do i = its,ite


### PR DESCRIPTION
Fix the reproducibility of model outputs when a threaded build runs on a different number of OpenMP threads.

I used thread sanitizer to find potential data races, which frequently cause model non-reproducibility. Not every data race results in non-reproducible output, for example, a data race where multiple threads write the same initial value to a shared memory location. I think those cases should be fixed as well to minimize the number of warnings the thread sanitizer reports.

I tested these code changes using Intel (2025.3.0) and GNU (11.5.0). To get reproducible results with optimized code (`-O3`) for the Intel compiler I had to use the `-fp-model precise` compiler flag, in addition to the flags currently specified in the CMake files. For the GNU compiler I had to use `-fno-tree-loop-vectorize`. I didn't add those flags to the CMake files because I haven't checked the performance impact. 

With the code changes included in this PR and the compiler flags mentioned above, I am getting reproducible outputs (history, diag and restart files, checked by running nccmp) when I use 'mesoscale_reference' physics. For 'convection_permitting' physics two additional changes are needed in physics_mmm:

```diff
diff --git a/bl_mynn.F90 b/bl_mynn.F90
index 783b996..c083888 100644
--- a/bl_mynn.F90
+++ b/bl_mynn.F90
@@ -312,7 +312,7 @@
  integer,intent(out):: &
     errflg        ! output error flag (-).
 
- real(kind=kind_phys),intent(out),dimension(:):: &
+ real(kind=kind_phys),intent(out),dimension(its:):: &
     maxwidth,   &!
     maxmf,      &!
     ztop_plume
```
and
```diff
diff --git a/cu_ntiedtke.F90 b/cu_ntiedtke.F90
index e1d266d..75367e5 100644
--- a/cu_ntiedtke.F90
+++ b/cu_ntiedtke.F90
@@ -13,6 +13,7 @@
  real(kind=kind_phys):: g
  real(kind=kind_phys):: rd
  real(kind=kind_phys):: rv
+ !$omp threadprivate(alf, als, alv, cpd, g, rd, rv)
 
  real(kind=kind_phys),parameter:: t13   = 1.0/3.0
  real(kind=kind_phys),parameter:: tmelt = 273.16
@@ -46,6 +47,7 @@
  real(kind=kind_phys):: ralfdcp
  real(kind=kind_phys):: vtmpc1
  real(kind=kind_phys):: zrg
+ !$omp threadprivate(rcpd, c2es, c5les, c5ies, r5alvcp, r5alscp, ralvdcp, ralsdcp, ralfdcp, vtmpc1, zrg)
 
  logical,parameter:: nonequil = .true.
  logical,parameter:: lmfpen   = .true.
```