### PR TITLE
Reduce the constant used to create rain number concentration from cloud-water autoconversion

### DIFF
--- a/src/core_atmosphere/physics/physics_wrf/module_mp_thompson.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_mp_thompson.F
@@ -1981,7 +1981,7 @@
           tau  = 3.72/(rc(k)*taud)
           prr_wau(k) = zeta/tau
           prr_wau(k) = MIN(DBLE(rc(k)*odts), prr_wau(k))
-          pnr_wau(k) = prr_wau(k) / (am_r*nu_c*200.*D0r*D0r*D0r)         ! RAIN2M
+          pnr_wau(k) = prr_wau(k) / (am_r*nu_c*10.*D0r*D0r*D0r)         ! RAIN2M
           pnc_wau(k) = MIN(DBLE(nc(k)*odts), prr_wau(k)                 &
                      / (am_r*mvd_c(k)*mvd_c(k)*mvd_c(k)))                   ! Qc2M
          endif


### PR DESCRIPTION
Reduce the constant used to create rain number concentration from cloud-water autoconversion to be consistent with WRF for Thompson microphysics.

Here's the value used in WRF:
https://github.com/wrf-model/WRF/blob/06d4240ae989cc3e50af412bb472df3d9048783c/phys/module_mp_thompson.F#L2191

A value of 200 results in reduced warm-rain precipitation, particularly along the Pacific coast. Testing done by Trude Eidhammer. 