### PR TITLE
Optimize ACC port of atm_compute_solve_diagnostics_work:7418

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -7416,13 +7416,12 @@ module atm_time_integration
          !
          r = config_apvm_upwinding * dt
          !$acc parallel default(present)
-         !$acc loop gang
+         !$acc loop gang worker vector collapse(2)
          do iEdge = edgeStart,edgeEnd
-            r1 = 1.0_RKIND * invDvEdge(iEdge)
-            r2 = 1.0_RKIND * invDcEdge(iEdge)
 !DIR$ IVDEP
-            !$acc loop vector
             do k = 1,nVertLevels
+               r1 = 1.0_RKIND * invDvEdge(iEdge)
+               r2 = 1.0_RKIND * invDcEdge(iEdge)
                gradPVt(k,iEdge) = (pv_vertex(k,verticesOnEdge(2,iEdge)) - pv_vertex(k,verticesOnEdge(1,iEdge))) * r1
                gradPVn(k,iEdge) = (pv_cell(k,cellsOnEdge(2,iEdge)) - pv_cell(k,cellsOnEdge(1,iEdge))) * r2
                pv_edge(k,iEdge) = pv_edge(k,iEdge) - r * (v(k,iEdge) * gradPVt(k,iEdge) + u(k,iEdge) * gradPVn(k,iEdge))

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -7399,7 +7399,7 @@ module atm_time_integration
 
 
 !$OMP BARRIER
-
+         call mpas_timer_start('atm_compute_solve_diag_7418')
          !
          ! Modify PV edge with upstream bias. 
          !
@@ -7429,7 +7429,7 @@ module atm_time_integration
             end do
          end do
          !$acc end parallel
-
+         call mpas_timer_stop('atm_compute_solve_diag_7418')
 
       end if  ! apvm upwinding
 


### PR DESCRIPTION
This PR introduces optimizations for the OpenACC port of atm_compute_solve_diagnostics_work:7418. The table below lists the timings for a real, global 30km experiment on A100 GPU with the nvhpc.

For nvhpc gpu runs, -gpu=math_uniform is introduced as a build flag to ensure optimizations are bit-identical, and the we report the numbers using NV_ACC_TIME=1. The GPU runs are on 1 Derecho GPU node, using 1 A100 via 1 MPI task.

The numbers reported for the CPU runs with gnu and intel compilers use the newly-added timers local to this region, and are averaged across three runs. The CPU runs use a single derecho CPU node each, fully subscribed to 128 MPI tasks.

Version | GPU kernel time (ms) | CPU timer - gnu  | CPU timer - intel25
-- | -- | -- | --
base | 6.59 | 0.00644 | 0.00765
1 | 2.457 | 0.00659 | 0.00733


TODO: Need to add @Pranay-Reddy-Kommera as the primary author for this commit. 

This work was completed in part at the NCAR/NLR/NOAA Open Hackathon, part of the Open Hackathons program. The authors would like to acknowledge OpenACC-Standard.org for their support.