### PR TITLE
Optimize ACC port of atm_divergence_damping_3d:4160

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -4158,18 +4158,17 @@ module atm_time_integration
 
       call mpas_timer_start('atm_divergence_damping_3d_4160')
       !$acc parallel default(present)
-      !$acc loop gang worker
+      !$acc loop gang worker vector collapse(2)
       do iEdge=edgeStart,edgeEnd ! MGD do we really just need edges touching owned cells?
+!DIR$ IVDEP
+         do k=1,nVertLevels
 
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
 
          ! update edges for block-owned cells
          if (cell1 <= nCellsSolve .or. cell2 <= nCellsSolve ) then
-
-!DIR$ IVDEP
-            !$acc loop vector
-            do k=1,nVertLevels
+            
 
 !!  unscaled 3d divergence damping
 !!               divCell1 = -(rtheta_pp(k,cell1)-rtheta_pp_old(k,cell1))*rdts
@@ -4183,8 +4182,9 @@ module atm_time_integration
                ru_p(k,iEdge) = ru_p(k,iEdge) + coef_divdamp*(divCell2-divCell1)*(1.0_RKIND - specZoneMaskEdge(iEdge)) &
                                                       /(theta_m(k,cell1)+theta_m(k,cell2))
 
-            end do
-         end if ! edges for block-owned cells
+
+            end if ! edges for block-owned cells
+         end do
       end do ! end loop over edges
       !$acc end parallel
       call mpas_timer_stop('atm_divergence_damping_3d_4160')

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -4156,7 +4156,7 @@ module atm_time_integration
       nCellsSolve = nCellsSolve_ptr
       nVertLevels = nVertLevels_ptr
 
-
+      call mpas_timer_start('atm_divergence_damping_3d_4160')
       !$acc parallel default(present)
       !$acc loop gang worker
       do iEdge=edgeStart,edgeEnd ! MGD do we really just need edges touching owned cells?
@@ -4187,7 +4187,7 @@ module atm_time_integration
          end if ! edges for block-owned cells
       end do ! end loop over edges
       !$acc end parallel
-
+      call mpas_timer_stop('atm_divergence_damping_3d_4160')
       
 
    end subroutine atm_divergence_damping_3d


### PR DESCRIPTION
This PR introduces optimizations for the OpenACC port of atm_divergence_damping_3d:4160. The table below lists the timings for a real, global 30km experiment on A100 GPU with the nvhpc.

For nvhpc gpu runs, -gpu=math_uniform is introduced as a build flag to ensure optimizations are bit-identical, and the we report the numbers using NV_ACC_TIME=1. The GPU runs are on 1 Derecho GPU node, using 1 A100 via 1 MPI task.

The numbers reported for the CPU runs with gnu and intel compilers use the newly-added timers local to this region, and are averaged across three runs. The CPU runs use a single derecho CPU node each, fully subscribed to 128 MPI tasks.

 Version | GPU kernel time (ms) |  CPU timer - gnu | CPU timer - intel25
 -- | -- | -- | --
 base | 3.573 | 0.00227 | 0.00248
  1 | 2.045 | 0.00228 | 0.00253

This work was completed in part at the NCAR/NLR/NOAA Open Hackathon, part of the Open Hackathons program. The authors would like to acknowledge OpenACC-Standard.org for their support.