### PR TITLE
Optimize ACC port of atm_compute_solve_diagnostics_work:7313

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -7312,7 +7312,7 @@ module atm_time_integration
       if (reconstruct_v) then
         call mpas_timer_start('atm_compute_solve_diag_7313')
         !$acc parallel default(present)
-        !$acc loop gang
+        !$acc loop gang worker
         do iEdge = edgeStart,edgeEnd
           !$acc loop vector
           do k = 1,nVertLevels

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -7308,8 +7308,9 @@ module atm_time_integration
       if(present(rk_step)) then
         if(rk_step /= 3) reconstruct_v = .false.
       end if
-
+      
       if (reconstruct_v) then
+        call mpas_timer_start('atm_compute_solve_diag_7313')
         !$acc parallel default(present)
         !$acc loop gang
         do iEdge = edgeStart,edgeEnd
@@ -7328,6 +7329,7 @@ module atm_time_integration
           end do
         end do
         !$acc end parallel
+        call mpas_timer_stop('atm_compute_solve_diag_7313')
       end if
 
       !

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -7318,12 +7318,12 @@ module atm_time_integration
           do k = 1,nVertLevels
             v(k,iEdge) = 0.0_RKIND
           end do
-          !$acc loop seq
-          do i=1,nEdgesOnEdge(iEdge)
-            eoe = edgesOnEdge(i,iEdge)
 !DIR$ IVDEP
-            !$acc loop vector
-            do k = 1,nVertLevels
+          !$acc loop vector
+          do k = 1,nVertLevels
+            !$acc loop seq
+            do i=1,nEdgesOnEdge(iEdge)
+              eoe = edgesOnEdge(i,iEdge)
               v(k,iEdge) = v(k,iEdge) + weightsOnEdge(i,iEdge) * u(k, eoe)
             end do
           end do


### PR DESCRIPTION
This PR introduces optimizations for the OpenACC port of atm_compute_solve_diagnostics_work:7313. The table below lists the timings for a real, global 30km experiment on A100 GPU with the nvhpc.

For nvhpc gpu runs, -gpu=math_uniform is introduced as a build flag to ensure optimizations are bit-identical, and the we report the numbers using NV_ACC_TIME=1. The GPU runs are on 1 Derecho GPU node, using 1 A100 via 1 MPI task.

The numbers reported for the CPU runs with gnu and intel compilers use the newly-added timers local to this region, and are averaged across three runs. The CPU runs use a single derecho CPU node each, fully subscribed to 128 MPI tasks.

Version | GPU kernel time (ms) |   | CPU timer - gnu |   | CPU timer - intel25
-- | -- | -- | -- | -- | --
base | 17.534 |   | 0.007606 |   | 0.00624
1 - Add worker | 6.798 |   |   |   |  
2 - swap loop seq and vector | 3.656 |   |   |   |  

TODO: Need to redo/fill in CPU benchmarks add @Pranay-Reddy-Kommera as the primary author for this commit.

This work was completed in part at the NCAR/NLR/NOAA Open Hackathon, part of the Open Hackathons program. The authors would like to acknowledge OpenACC-Standard.org for their support.