### PR TITLE
Optimize ACC port of atm_compute_solve_diagnostics_work:7134

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -7145,10 +7145,9 @@ module atm_time_integration
 !  the first openmp barrier below is set so that ke_edge is computed
 !  it would be good to move this somewhere else?
 
-         efac = dcEdge(iEdge)*dvEdge(iEdge)
          !$acc loop vector
          do k=1,nVertLevels
-            ke_edge(k,iEdge) = efac*u(k,iEdge)**2
+            ke_edge(k,iEdge) = dcEdge(iEdge)*dvEdge(iEdge)*u(k,iEdge)**2
          end do
 
       end do

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -7127,12 +7127,12 @@ module atm_time_integration
       logical :: reconstruct_v
 
 
-
+      call mpas_timer_start('atm_comp_solve_diag_7134')
       !
       ! Compute height on cell edges at velocity locations
       !
       !$acc parallel default(present)
-      !$acc loop gang
+      !$acc loop gang worker
       do iEdge=edgeStart,edgeEnd
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
@@ -7156,7 +7156,7 @@ module atm_time_integration
       !
       ! Compute circulation and relative vorticity at each vertex
       !
-      !$acc loop gang
+      !$acc loop gang worker
       do iVertex=vertexStart,vertexEnd
          !$acc loop vector
          do k=1,nVertLevels
@@ -7183,7 +7183,7 @@ module atm_time_integration
       !
       ! Compute the divergence at each cell center
       !
-      !$acc loop gang
+      !$acc loop gang worker
       do iCell=cellStart,cellEnd
          !$acc loop vector
          do k=1,nVertLevels
@@ -7206,7 +7206,7 @@ module atm_time_integration
          end do
       end do
       !$acc end parallel
-
+      call mpas_timer_stop('atm_comp_solve_diag_7134')
 
 !$OMP BARRIER
 

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -7162,13 +7162,15 @@ module atm_time_integration
          do k=1,nVertLevels
             vorticity(k,iVertex) = 0.0_RKIND
          end do
-         !$acc loop seq
-         do i=1,vertexDegree
-            iEdge = edgesOnVertex(i,iVertex)
-            s = edgesOnVertex_sign(i,iVertex) * dcEdge(iEdge)
 !DIR$ IVDEP
-            !$acc loop vector
-            do k=1,nVertLevels
+         !$acc loop vector
+         do k=1,nVertLevels
+            !$acc loop seq
+            do i=1,vertexDegree
+               iEdge = edgesOnVertex(i,iVertex)
+               s = edgesOnVertex_sign(i,iVertex) * dcEdge(iEdge)
+
+            
                vorticity(k,iVertex) = vorticity(k,iVertex) + s * u(k,iEdge)
             end do
          end do


### PR DESCRIPTION
This PR introduces optimizations for the OpenACC port of atm_compute_solve_diagnostics_work:7134. The table below lists the timings for a real, global 30km experiment on A100 GPU with the nvhpc.

For nvhpc gpu runs, -gpu=math_uniform is introduced as a build flag to ensure optimizations are bit-identical, and the we report the numbers using NV_ACC_TIME=1. The GPU runs are on 1 Derecho GPU node, using 1 A100 via 1 MPI task.

The numbers reported for the CPU runs with gnu and intel compilers use the newly-added timers local to this region, and are averaged across three runs. The CPU runs use a single derecho CPU node each, fully subscribed to 128 MPI tasks.

Version | GPU kernel time (ms) | CPU timer - nvhpc | CPU timer - gnu | CPU timer - intel25
-- | -- | -- | -- | --
base | 15 | 0.00911 | 0.01012 | 0.00901
1 Add workers | 7.117 | 0.00911 | 0.01012 | 0.00901
2 Swap seq and vector loops | 6.696 | 0.00941 | 0.01084 | 0.00894
3 Move efac to within vector loop | 5.787 | 0.00997 | 0.01063 | 0.00905

This work was completed in part at the NCAR/NLR/NOAA Open Hackathon, part of the Open Hackathons program. The authors would like to acknowledge OpenACC-Standard.org for their support.