### PR TITLE
Optimize ACC port of atm_compute_dyn_tend_work:6652

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -6648,7 +6648,7 @@ module atm_time_integration
       !
       !  horizontal advection for w
       !
-
+      call mpas_timer_start('atm_dyn_tend_work_6652')
       !$acc parallel default(present)
       !$acc loop gang worker private(ru_edge_w, flux_arr)
       do iCell=cellSolveStart,cellSolveEnd    ! Technically updating fewer cells than before...
@@ -6696,7 +6696,7 @@ module atm_time_integration
          end do
       end do
       !$acc end parallel
-
+      call mpas_timer_stop('atm_dyn_tend_work_6652')
 #ifdef CURVATURE
       !$acc parallel default(present)
       !$acc loop gang worker

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -6674,12 +6674,23 @@ module atm_time_integration
             !$acc loop vector
             do k=2,nVertLevels
                flux_arr_local = 0.0_RKIND
-               !$acc loop seq
-               do j=1,nAdvCellsForEdge(iEdge)
-                  iAdvCell = advCellsForEdge(j,iEdge)
-                  scalar_weight = adv_coefs(j,iEdge) + sign(1.0_RKIND,ru_edge_w(k)) * adv_coefs_3rd(j,iEdge)
-                  flux_arr_local = flux_arr_local + scalar_weight * w(k,iAdvCell)
-               end do
+
+               select case(nAdvCellsForEdge(iEdge))
+               case (10)
+                  !$acc loop seq
+                  do j=1,nAdvCellsForEdge(iEdge)
+                     iAdvCell = advCellsForEdge(j,iEdge)
+                     scalar_weight = adv_coefs(j,iEdge) + sign(1.0_RKIND,ru_edge_w(k)) * adv_coefs_3rd(j,iEdge)
+                     flux_arr_local = flux_arr_local + scalar_weight * w(k,iAdvCell)
+                  end do
+               case default
+                  !$acc loop seq
+                  do j=1,nAdvCellsForEdge(iEdge)
+                     iAdvCell = advCellsForEdge(j,iEdge)
+                     scalar_weight = adv_coefs(j,iEdge) + sign(1.0_RKIND,ru_edge_w(k)) * adv_coefs_3rd(j,iEdge)
+                     flux_arr_local = flux_arr_local + scalar_weight * w(k,iAdvCell)
+                  end do
+               end select
                tend_w(k,iCell) = tend_w(k,iCell) - edgesOnCell_sign(i,iCell) * ru_edge_w(k)*flux_arr_local
             end do
 

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -6294,7 +6294,7 @@ module atm_time_integration
 
       real (kind=RKIND), dimension( nVertLevels ) :: rayleigh_damp_coef
 
-      real (kind=RKIND) :: flux3, flux4
+      real (kind=RKIND) :: flux3, flux4, flux_arr_local
       real (kind=RKIND) :: q_im2, q_im1, q_i, q_ip1, ua, coef3
 
       logical, parameter :: perturbation_coriolis = .true.
@@ -6650,7 +6650,7 @@ module atm_time_integration
       !
       call mpas_timer_start('atm_dyn_tend_work_6652')
       !$acc parallel default(present)
-      !$acc loop gang worker private(ru_edge_w, flux_arr)
+      !$acc loop gang worker private(ru_edge_w)
       do iCell=cellSolveStart,cellSolveEnd    ! Technically updating fewer cells than before...
 
          !$acc loop vector
@@ -6669,28 +6669,18 @@ module atm_time_integration
                ru_edge_w(k) = fzm(k)*ru(k,iEdge) + fzp(k)*ru(k-1,iEdge)
             end do
 
-            !$acc loop vector
-            do k=1,nVertLevels
-               flux_arr(k) = 0.0_RKIND
-            end do
-
             ! flux_arr stores the value of w at the cell edge used in the horizontal transport
 
-            !$acc loop seq
-            do j=1,nAdvCellsForEdge(iEdge)
-               iAdvCell = advCellsForEdge(j,iEdge)
-
-               !$acc loop vector
-               do k=2,nVertLevels
-                  scalar_weight = adv_coefs(j,iEdge) + sign(1.0_RKIND,ru_edge_w(k)) * adv_coefs_3rd(j,iEdge)
-                  flux_arr(k) = flux_arr(k) + scalar_weight * w(k,iAdvCell)
-               end do
-            end do
-
-!DIR$ IVDEP
             !$acc loop vector
             do k=2,nVertLevels
-               tend_w(k,iCell) = tend_w(k,iCell) - edgesOnCell_sign(i,iCell) * ru_edge_w(k)*flux_arr(k)
+               flux_arr_local = 0.0_RKIND
+               !$acc loop seq
+               do j=1,nAdvCellsForEdge(iEdge)
+                  iAdvCell = advCellsForEdge(j,iEdge)
+                  scalar_weight = adv_coefs(j,iEdge) + sign(1.0_RKIND,ru_edge_w(k)) * adv_coefs_3rd(j,iEdge)
+                  flux_arr_local = flux_arr_local + scalar_weight * w(k,iAdvCell)
+               end do
+               tend_w(k,iCell) = tend_w(k,iCell) - edgesOnCell_sign(i,iCell) * ru_edge_w(k)*flux_arr_local
             end do
 
          end do


### PR DESCRIPTION
This PR introduces optimizations for the OpenACC port of atm_compute_dyn_tend_work:6652. The table below lists the timings for a real, global 30km experiment on A100 GPU with the nvhpc.

For nvhpc gpu runs, -gpu=math_uniform is introduced as a build flag to ensure optimizations are bit-identical, and the we report the numbers using NV_ACC_TIME=1. The GPU runs are on 1 Derecho GPU node, using 1 A100 via 1 MPI task.

The numbers reported for the CPU runs with gnu and intel compilers use the newly-added timers local to this region, and are averaged across three runs. The CPU runs use a single derecho CPU node each, fully subscribed to 128 MPI tasks.

Version | GPU kernel time (ms) |   | CPU timer - gnu |   | CPU timer - intel25
-- | -- | -- | -- | -- | --
base | 14.317 |   | 0.01217 |   | 0.011043
1 | 8 |   | 0.02375 |   | 0.018293
2 | 6.904 |   | 0.01844 |   | 0.014157


This PR is not ready to be merged yet. Any improvements to this will also be applicable to atm_compute_dyn_tend_work:6812

This work was completed in part at the NCAR/NLR/NOAA Open Hackathon, part of the Open Hackathons program. The authors would like to acknowledge OpenACC-Standard.org for their support.