### PR TITLE
Optimize ACC port of atm_advance_scalars_work:4760

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -4772,16 +4772,16 @@ module atm_time_integration
                do k = 1,nVertLevels
                   do iScalar = 1,num_scalars
                      horiz_flux_arr(iScalar,k,iEdge) = &
-                          adv_coefs(1,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(1,iEdge)  * scalar_new(iScalar,k,advCellsForEdge(1,iEdge)) + &
-                          adv_coefs(2,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(2,iEdge)  * scalar_new(iScalar,k,advCellsForEdge(2,iEdge)) + &
-                          adv_coefs(3,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(3,iEdge)  * scalar_new(iScalar,k,advCellsForEdge(3,iEdge)) + &
-                          adv_coefs(4,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(4,iEdge)  * scalar_new(iScalar,k,advCellsForEdge(4,iEdge)) + &
-                          adv_coefs(5,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(5,iEdge)  * scalar_new(iScalar,k,advCellsForEdge(5,iEdge)) + &
-                          adv_coefs(6,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(6,iEdge)  * scalar_new(iScalar,k,advCellsForEdge(6,iEdge)) + &
-                          adv_coefs(7,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(7,iEdge)  * scalar_new(iScalar,k,advCellsForEdge(7,iEdge)) + &
-                          adv_coefs(8,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(8,iEdge)  * scalar_new(iScalar,k,advCellsForEdge(8,iEdge)) + &
-                          adv_coefs(9,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(9,iEdge)  * scalar_new(iScalar,k,advCellsForEdge(9,iEdge)) + &
-                          adv_coefs(10,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(10,iEdge) * scalar_new(iScalar,k,advCellsForEdge(10,iEdge))
+                          (adv_coefs(1,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(1,iEdge))  * scalar_new(iScalar,k,advCellsForEdge(1,iEdge)) + &
+                          (adv_coefs(2,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(2,iEdge))  * scalar_new(iScalar,k,advCellsForEdge(2,iEdge)) + &
+                          (adv_coefs(3,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(3,iEdge))  * scalar_new(iScalar,k,advCellsForEdge(3,iEdge)) + &
+                          (adv_coefs(4,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(4,iEdge))  * scalar_new(iScalar,k,advCellsForEdge(4,iEdge)) + &
+                          (adv_coefs(5,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(5,iEdge))  * scalar_new(iScalar,k,advCellsForEdge(5,iEdge)) + &
+                          (adv_coefs(6,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(6,iEdge))  * scalar_new(iScalar,k,advCellsForEdge(6,iEdge)) + &
+                          (adv_coefs(7,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(7,iEdge))  * scalar_new(iScalar,k,advCellsForEdge(7,iEdge)) + &
+                          (adv_coefs(8,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(8,iEdge))  * scalar_new(iScalar,k,advCellsForEdge(8,iEdge)) + &
+                          (adv_coefs(9,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(9,iEdge))  * scalar_new(iScalar,k,advCellsForEdge(9,iEdge)) + &
+                          (adv_coefs(10,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(10,iEdge)) * scalar_new(iScalar,k,advCellsForEdge(10,iEdge))
                   end do
                end do
 

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -4803,16 +4803,9 @@ module atm_time_integration
                do k=1,nVertLevels
                   do iScalar=1,num_scalars
                      horiz_flux_arr(iScalar,k,iEdge) = 0.0_RKIND
-                  end do
-               end do
-
-               !$acc loop seq
-               do j=1,nAdvCellsForEdge(iEdge)
-                  iAdvCell = advCellsForEdge(j,iEdge)
-
-                  !$acc loop vector collapse(2)
-                  do k=1,nVertLevels
-                     do iScalar=1,num_scalars
+                     !$acc loop seq
+                     do j=1,nAdvCellsForEdge(iEdge)
+                        iAdvCell = advCellsForEdge(j,iEdge)
                         scalar_weight = adv_coefs(j,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(j,iEdge)
                         horiz_flux_arr(iScalar,k,iEdge) = horiz_flux_arr(iScalar,k,iEdge) &
                                                         + scalar_weight * scalar_new(iScalar,k,iAdvCell)

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -4758,7 +4758,7 @@ module atm_time_integration
 
       call mpas_timer_start('atm_advance_scalars_4760')
       !$acc parallel async
-      !$acc loop gang worker private(scalar_weight2, ica)
+      !$acc loop gang worker private(scalar_weight2)
       do iEdge=edgeStart,edgeEnd
 
          if ((.not.config_apply_lbcs) &
@@ -4775,25 +4775,20 @@ module atm_time_integration
                   end do
                end do
 
-               !$acc loop vector
-               do j=1,10
-                  ica(j) = advCellsForEdge(j,iEdge)
-               end do
-
                !$acc loop vector collapse(2)
                do k = 1,nVertLevels
                   do iScalar = 1,num_scalars
                      horiz_flux_arr(iScalar,k,iEdge) = &
-                          scalar_weight2(k,1)  * scalar_new(iScalar,k,ica(1)) + &
-                          scalar_weight2(k,2)  * scalar_new(iScalar,k,ica(2)) + &
-                          scalar_weight2(k,3)  * scalar_new(iScalar,k,ica(3)) + &
-                          scalar_weight2(k,4)  * scalar_new(iScalar,k,ica(4)) + &
-                          scalar_weight2(k,5)  * scalar_new(iScalar,k,ica(5)) + &
-                          scalar_weight2(k,6)  * scalar_new(iScalar,k,ica(6)) + &
-                          scalar_weight2(k,7)  * scalar_new(iScalar,k,ica(7)) + &
-                          scalar_weight2(k,8)  * scalar_new(iScalar,k,ica(8)) + &
-                          scalar_weight2(k,9)  * scalar_new(iScalar,k,ica(9)) + &
-                          scalar_weight2(k,10) * scalar_new(iScalar,k,ica(10))
+                          scalar_weight2(k,1)  * scalar_new(iScalar,k,advCellsForEdge(1,iEdge)) + &
+                          scalar_weight2(k,2)  * scalar_new(iScalar,k,advCellsForEdge(2,iEdge)) + &
+                          scalar_weight2(k,3)  * scalar_new(iScalar,k,advCellsForEdge(3,iEdge)) + &
+                          scalar_weight2(k,4)  * scalar_new(iScalar,k,advCellsForEdge(4,iEdge)) + &
+                          scalar_weight2(k,5)  * scalar_new(iScalar,k,advCellsForEdge(5,iEdge)) + &
+                          scalar_weight2(k,6)  * scalar_new(iScalar,k,advCellsForEdge(6,iEdge)) + &
+                          scalar_weight2(k,7)  * scalar_new(iScalar,k,advCellsForEdge(7,iEdge)) + &
+                          scalar_weight2(k,8)  * scalar_new(iScalar,k,advCellsForEdge(8,iEdge)) + &
+                          scalar_weight2(k,9)  * scalar_new(iScalar,k,advCellsForEdge(9,iEdge)) + &
+                          scalar_weight2(k,10) * scalar_new(iScalar,k,advCellsForEdge(10,iEdge))
                   end do
                end do
 

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -4725,7 +4725,7 @@ module atm_time_integration
 
       real (kind=RKIND) :: weight_time_old, weight_time_new
       real (kind=RKIND), dimension(num_scalars,nVertLevels) :: scalar_tend_column  ! local storage to accumulate tendency
-      real (kind=RKIND) :: u_direction, u_positive, u_negative
+      real (kind=RKIND) :: u_direction, u_positive, u_negative, local_sign
 
       flux4(q_im2, q_im1, q_i, q_ip1, ua) =                     &
           ua*( 7.*(q_i + q_im1) - (q_ip1 + q_im2) )/12.0
@@ -4755,7 +4755,7 @@ module atm_time_integration
          if(rk_step == 3) weight_time_new = 1.
       end if
       weight_time_old = 1. - weight_time_new
-
+      local_sign = 1.0_RKIND
       call mpas_timer_start('atm_advance_scalars_4760')
       !$acc parallel async
       !$acc loop gang worker
@@ -4771,17 +4771,18 @@ module atm_time_integration
                !$acc loop vector collapse(2)
                do k = 1,nVertLevels
                   do iScalar = 1,num_scalars
+                     local_sign = sign(1.0_RKIND,uhAvg(k,iEdge))
                      horiz_flux_arr(iScalar,k,iEdge) = &
-                          (adv_coefs(1,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(1,iEdge))  * scalar_new(iScalar,k,advCellsForEdge(1,iEdge)) + &
-                          (adv_coefs(2,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(2,iEdge))  * scalar_new(iScalar,k,advCellsForEdge(2,iEdge)) + &
-                          (adv_coefs(3,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(3,iEdge))  * scalar_new(iScalar,k,advCellsForEdge(3,iEdge)) + &
-                          (adv_coefs(4,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(4,iEdge))  * scalar_new(iScalar,k,advCellsForEdge(4,iEdge)) + &
-                          (adv_coefs(5,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(5,iEdge))  * scalar_new(iScalar,k,advCellsForEdge(5,iEdge)) + &
-                          (adv_coefs(6,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(6,iEdge))  * scalar_new(iScalar,k,advCellsForEdge(6,iEdge)) + &
-                          (adv_coefs(7,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(7,iEdge))  * scalar_new(iScalar,k,advCellsForEdge(7,iEdge)) + &
-                          (adv_coefs(8,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(8,iEdge))  * scalar_new(iScalar,k,advCellsForEdge(8,iEdge)) + &
-                          (adv_coefs(9,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(9,iEdge))  * scalar_new(iScalar,k,advCellsForEdge(9,iEdge)) + &
-                          (adv_coefs(10,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(10,iEdge)) * scalar_new(iScalar,k,advCellsForEdge(10,iEdge))
+                          (adv_coefs(1,iEdge) + local_sign*adv_coefs_3rd(1,iEdge))  * scalar_new(iScalar,k,advCellsForEdge(1,iEdge)) + &
+                          (adv_coefs(2,iEdge) + local_sign*adv_coefs_3rd(2,iEdge))  * scalar_new(iScalar,k,advCellsForEdge(2,iEdge)) + &
+                          (adv_coefs(3,iEdge) + local_sign*adv_coefs_3rd(3,iEdge))  * scalar_new(iScalar,k,advCellsForEdge(3,iEdge)) + &
+                          (adv_coefs(4,iEdge) + local_sign*adv_coefs_3rd(4,iEdge))  * scalar_new(iScalar,k,advCellsForEdge(4,iEdge)) + &
+                          (adv_coefs(5,iEdge) + local_sign*adv_coefs_3rd(5,iEdge))  * scalar_new(iScalar,k,advCellsForEdge(5,iEdge)) + &
+                          (adv_coefs(6,iEdge) + local_sign*adv_coefs_3rd(6,iEdge))  * scalar_new(iScalar,k,advCellsForEdge(6,iEdge)) + &
+                          (adv_coefs(7,iEdge) + local_sign*adv_coefs_3rd(7,iEdge))  * scalar_new(iScalar,k,advCellsForEdge(7,iEdge)) + &
+                          (adv_coefs(8,iEdge) + local_sign*adv_coefs_3rd(8,iEdge))  * scalar_new(iScalar,k,advCellsForEdge(8,iEdge)) + &
+                          (adv_coefs(9,iEdge) + local_sign*adv_coefs_3rd(9,iEdge))  * scalar_new(iScalar,k,advCellsForEdge(9,iEdge)) + &
+                          (adv_coefs(10,iEdge) + local_sign*adv_coefs_3rd(10,iEdge)) * scalar_new(iScalar,k,advCellsForEdge(10,iEdge))
                   end do
                end do
 

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -4758,7 +4758,7 @@ module atm_time_integration
 
       call mpas_timer_start('atm_advance_scalars_4760')
       !$acc parallel async
-      !$acc loop gang worker private(scalar_weight2)
+      !$acc loop gang worker
       do iEdge=edgeStart,edgeEnd
 
          if ((.not.config_apply_lbcs) &
@@ -4769,26 +4769,19 @@ module atm_time_integration
             case(10)
 
                !$acc loop vector collapse(2)
-               do j=1,10
-                  do k=1,nVertLevels
-                     scalar_weight2(k,j) = adv_coefs(j,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(j,iEdge)
-                  end do
-               end do
-
-               !$acc loop vector collapse(2)
                do k = 1,nVertLevels
                   do iScalar = 1,num_scalars
                      horiz_flux_arr(iScalar,k,iEdge) = &
-                          scalar_weight2(k,1)  * scalar_new(iScalar,k,advCellsForEdge(1,iEdge)) + &
-                          scalar_weight2(k,2)  * scalar_new(iScalar,k,advCellsForEdge(2,iEdge)) + &
-                          scalar_weight2(k,3)  * scalar_new(iScalar,k,advCellsForEdge(3,iEdge)) + &
-                          scalar_weight2(k,4)  * scalar_new(iScalar,k,advCellsForEdge(4,iEdge)) + &
-                          scalar_weight2(k,5)  * scalar_new(iScalar,k,advCellsForEdge(5,iEdge)) + &
-                          scalar_weight2(k,6)  * scalar_new(iScalar,k,advCellsForEdge(6,iEdge)) + &
-                          scalar_weight2(k,7)  * scalar_new(iScalar,k,advCellsForEdge(7,iEdge)) + &
-                          scalar_weight2(k,8)  * scalar_new(iScalar,k,advCellsForEdge(8,iEdge)) + &
-                          scalar_weight2(k,9)  * scalar_new(iScalar,k,advCellsForEdge(9,iEdge)) + &
-                          scalar_weight2(k,10) * scalar_new(iScalar,k,advCellsForEdge(10,iEdge))
+                          adv_coefs(1,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(1,iEdge)  * scalar_new(iScalar,k,advCellsForEdge(1,iEdge)) + &
+                          adv_coefs(2,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(2,iEdge)  * scalar_new(iScalar,k,advCellsForEdge(2,iEdge)) + &
+                          adv_coefs(3,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(3,iEdge)  * scalar_new(iScalar,k,advCellsForEdge(3,iEdge)) + &
+                          adv_coefs(4,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(4,iEdge)  * scalar_new(iScalar,k,advCellsForEdge(4,iEdge)) + &
+                          adv_coefs(5,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(5,iEdge)  * scalar_new(iScalar,k,advCellsForEdge(5,iEdge)) + &
+                          adv_coefs(6,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(6,iEdge)  * scalar_new(iScalar,k,advCellsForEdge(6,iEdge)) + &
+                          adv_coefs(7,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(7,iEdge)  * scalar_new(iScalar,k,advCellsForEdge(7,iEdge)) + &
+                          adv_coefs(8,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(8,iEdge)  * scalar_new(iScalar,k,advCellsForEdge(8,iEdge)) + &
+                          adv_coefs(9,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(9,iEdge)  * scalar_new(iScalar,k,advCellsForEdge(9,iEdge)) + &
+                          adv_coefs(10,iEdge) + sign(1.0_RKIND,uhAvg(k,iEdge))*adv_coefs_3rd(10,iEdge) * scalar_new(iScalar,k,advCellsForEdge(10,iEdge))
                   end do
                end do
 

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -4756,7 +4756,7 @@ module atm_time_integration
       end if
       weight_time_old = 1. - weight_time_new
 
-
+      call mpas_timer_start('atm_advance_scalars_4760')
       !$acc parallel async
       !$acc loop gang worker private(scalar_weight2, ica)
       do iEdge=edgeStart,edgeEnd
@@ -4842,7 +4842,7 @@ module atm_time_integration
           end if ! end of regional MPAS test
       end do
       !$acc end parallel
-
+      call mpas_timer_stop('atm_advance_scalars_4760')
 !$OMP BARRIER
 
       !


### PR DESCRIPTION
This PR introduces optimizations for the OpenACC port of atm_advance_scalars_work:4760.

The table below lists the timings for a real, global 30km experiment on A100 GPU with nvhpc, and Derecho CPUs with several compiler suites.

Version | GPU kernel time (ms) | CPU timer - nvhpc | CPU timer - gnu |   | CPU timer - intel25
-- | -- | -- | -- | -- | --
base | 22.569 | 0.02903 | 0.03156 |   | 0.03324
1 In case default, swap the seq and vector collapse(2) loops and fuse horiz_flux_arr | 18 | 0.02908 | 0.03318 |   | 0.03389
2 Remove ica loop, directly subst advCellsForEdge | 16.832 | 0.03088 | 0.03248 |   | 0.03351
3 case 10, remove separate scalar_weight2 loop and inline it in next loop | 12.023 | 0.03459 | 0.03204 |   | 0.0324
4 local_sign | 13.83 | 0.03459 | 0.032 |   | 0.03239


The performance increase from base version to Opt 4 in the CPU case with intel25 is 2.27% per invocation of this loop. With GNU, the increase is 13.88%. Note that these numbers are a little different from the table above. 

For nvhpc gpu runs, -gpu=math_uniform is introduced as a build flag to ensure optimizations are bit-identical, and the we report the numbers using NV_ACC_TIME=1. The GPU runs are on 1 Derecho GPU node, using 1 A100 via 1 MPI task.

The numbers reported for the CPU runs with gnu and intel compilers use the newly-added timers local to this region, and are averaged across three runs. The CPU runs use a single derecho CPU node each, fully subscribed to 128 MPI tasks.


This work was completed in part at the NCAR/NLR/NOAA Open Hackathon, part of the Open Hackathons program. The authors would like to acknowledge OpenACC-Standard.org for their support.