### PR TITLE
Optimize ACC port of atm_advance_scalars_mono_work:5481

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -5477,7 +5477,7 @@ module atm_time_integration
          !$acc end parallel
 
 !$OMP BARRIER
-
+         call mpas_timer_start('atm_advance_scalars_mono_work_5481')
          !$acc parallel
 
          !
@@ -5549,7 +5549,7 @@ module atm_time_integration
          end do
 
          !$acc end parallel
-
+         call mpas_timer_stop('atm_advance_scalars_mono_work_5481')
 !$OMP BARRIER
 
          !$acc parallel

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -5536,15 +5536,12 @@ module atm_time_integration
                flux_upwind_tmp(k,iEdge) = dvEdge(iEdge) * dt *   &
                       (max(0.0_RKIND,uhAvg(k,iEdge))*scalar_old(k,cell1) + min(0.0_RKIND,uhAvg(k,iEdge))*scalar_old(k,cell2))
                flux_tmp(k,iEdge) = dt * flux_arr(k,iEdge) - flux_upwind_tmp(k,iEdge)
-            end do
-
-            if( config_apply_lbcs .and. (bdyMaskEdge(iEdge) == nRelaxZone) .or. (bdyMaskEdge(iEdge) == nRelaxZone-1) ) then
-               !$acc loop vector
-               do k=1,nVertLevels
+            
+               if( config_apply_lbcs .and. (bdyMaskEdge(iEdge) == nRelaxZone) .or. (bdyMaskEdge(iEdge) == nRelaxZone-1) ) then
                   flux_tmp(k,iEdge) = 0.0_RKIND
                   flux_arr(k,iEdge) = flux_upwind_tmp(k,iEdge)
-               end do
-            end if
+               end if
+            end do
 
          end do
 

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -5519,11 +5519,11 @@ module atm_time_integration
             end do
 
          end do
-
+         !$acc end parallel
          !
          !  horizontal flux divergence for upwind update
          !
-
+         !$acc parallel
          !  upwind flux computation
          !$acc loop gang worker
          do iEdge=edgeStart,edgeEnd


### PR DESCRIPTION
This PR introduces optimizations for the OpenACC port of atm_advance_scalars_mono_work:5481. The table below lists the timings for a real, global 30km experiment on A100 GPU with the nvhpc.

For nvhpc gpu runs, -gpu=math_uniform is introduced as a build flag to ensure optimizations are bit-identical, and the we report the numbers using NV_ACC_TIME=1. The GPU runs are on 1 Derecho GPU node, using 1 A100 via 1 MPI task.

The numbers reported for the CPU runs with gnu and intel compilers use the newly-added timers local to this region, and are averaged across three runs. The CPU runs use a single derecho CPU node each, fully subscribed to 128 MPI tasks.

Version | GPU kernel time (ms) |   | CPU timer - gnu |   | CPU timer - intel25
-- | -- | -- | -- | -- | --
base | 6 |   | 0.00929 |   | 0.00833
1 - split into two parallel regions | 4.247 |   | 0.00929 |   | 0.00833
2 - move if clause to inside vector in 2nd parallel | 3.7 |   | 0.00937 |   | 0.00854

The slowdowns for the CPU runs, looking at the most immediate timer, with intel25 is 2.52% and 0.9% with gnu.

Looking at the parent timer, `atm_advance_scalars_mono`, the slowdown with intel25 is 0.4% and 0.1% with gnu. 

TODO: Add @Pranay-Reddy-Kommera as primary commit author

This work was completed in part at the NCAR/NLR/NOAA Open Hackathon, part of the Open Hackathons program. The authors would like to acknowledge OpenACC-Standard.org for their support.
