### PR TITLE
Optimize ACC port of atm_advance_scalars_mono_work:5555

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -5584,10 +5584,8 @@ module atm_time_integration
          ! added benefit that it should address ifort single prec overflow issue
          if (local_advance_density) then
             !$acc parallel
-            !$acc loop gang worker
+            !$acc loop gang worker vector collapse(2)
             do iCell=cellSolveStart,cellSolveEnd
-
-               !$acc loop vector
                do k = 1, nVertLevels
                   scale_factor = (s_max(k,iCell)*rho_zz_int(k,iCell) - scalar_new(k,iCell)) / &
                        (scale_arr(k,SCALE_IN,iCell)  + eps)
@@ -5601,10 +5599,8 @@ module atm_time_integration
             !$acc end parallel
          else
             !$acc parallel
-            !$acc loop gang worker
+            !$acc loop gang worker vector collapse(2)
             do iCell=cellSolveStart,cellSolveEnd
-
-               !$acc loop vector
                do k = 1, nVertLevels
                   scale_factor = (s_max(k,iCell)*rho_zz_new(k,iCell) - scalar_new(k,iCell)) / &
                        (scale_arr(k,SCALE_IN,iCell)  + eps)

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -5165,6 +5165,7 @@ module atm_time_integration
       real (kind=RKIND), dimension(nVertLevels) :: flux_upwind_arr
       real (kind=RKIND) :: flux3, flux4, flux_upwind
       real (kind=RKIND) :: q_im2, q_im1, q_i, q_ip1, ua, coef3
+      real (kind=RKIND) :: iac, eoc_s, f_t
 #ifdef DEBUG_TRANSPORT
       real (kind=RKIND) :: scmin,scmax
 #endif
@@ -5556,19 +5557,18 @@ module atm_time_integration
 
          !$acc loop gang worker
          do iCell=cellSolveStart,cellSolveEnd
+            iac = invAreaCell(iCell)
+            !$acc loop vector
+            do k=1, nVertLevels
+               !$acc loop seq
+               do i=1,nEdgesOnCell(iCell)
+                  iEdge = edgesOnCell(i,iCell)
+                  eoc_s = edgesOnCell_sign(i,iCell)
+                  f_t = flux_tmp(k,iEdge)
 
-            !$acc loop seq
-            do i=1,nEdgesOnCell(iCell)
-               iEdge = edgesOnCell(i,iCell)
-
-               !$acc loop vector
-               do k=1, nVertLevels
-                  scalar_new(k,iCell) = scalar_new(k,iCell) - edgesOnCell_sign(i,iCell) * flux_upwind_tmp(k,iEdge) * invAreaCell(iCell)
- 
-                  scale_arr(k,SCALE_OUT,iCell) = scale_arr(k,SCALE_OUT,iCell) &
-                                                 - max(0.0_RKIND,edgesOnCell_sign(i,iCell)*flux_tmp(k,iEdge)) * invAreaCell(iCell)
-                  scale_arr(k,SCALE_IN, iCell) = scale_arr(k,SCALE_IN, iCell) &
-                                                 - min(0.0_RKIND,edgesOnCell_sign(i,iCell)*flux_tmp(k,iEdge)) * invAreaCell(iCell)
+                  scalar_new(k,iCell) = scalar_new(k,iCell) - eoc_s * flux_upwind_tmp(k,iEdge) * iac
+                  scale_arr(k,SCALE_OUT,iCell) = scale_arr(k,SCALE_OUT,iCell) - max(0.0_RKIND,eoc_s*f_t) * iac
+                  scale_arr(k,SCALE_IN, iCell) = scale_arr(k,SCALE_IN, iCell) - min(0.0_RKIND,eoc_s*f_t) * iac
                end do
 
             end do

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -5551,7 +5551,7 @@ module atm_time_integration
          !$acc end parallel
 
 !$OMP BARRIER
-
+         call mpas_timer_start('atm_advance_scalars_mono_work_5555')
          !$acc parallel
 
          !$acc loop gang worker
@@ -5615,7 +5615,7 @@ module atm_time_integration
          end if
 
          !$acc end parallel
-
+         call mpas_timer_stop('atm_advance_scalars_mono_work_5555')
          !
          !  communicate scale factors here.
          !  communicate only first halo row in these next two exchanges

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -5584,8 +5584,9 @@ module atm_time_integration
          ! added benefit that it should address ifort single prec overflow issue
          if (local_advance_density) then
             !$acc parallel
-            !$acc loop gang worker vector collapse(2)
+            !$acc loop gang worker
             do iCell=cellSolveStart,cellSolveEnd
+               !$acc loop vector
                do k = 1, nVertLevels
                   scale_factor = (s_max(k,iCell)*rho_zz_int(k,iCell) - scalar_new(k,iCell)) / &
                        (scale_arr(k,SCALE_IN,iCell)  + eps)
@@ -5599,8 +5600,9 @@ module atm_time_integration
             !$acc end parallel
          else
             !$acc parallel
-            !$acc loop gang worker vector collapse(2)
+            !$acc loop gang worker
             do iCell=cellSolveStart,cellSolveEnd
+               !$acc loop vector
                do k = 1, nVertLevels
                   scale_factor = (s_max(k,iCell)*rho_zz_new(k,iCell) - scalar_new(k,iCell)) / &
                        (scale_arr(k,SCALE_IN,iCell)  + eps)

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -5573,7 +5573,7 @@ module atm_time_integration
 
             end do
          end do
-
+         !$acc end parallel
 
          !
          !  next, the limiter
@@ -5583,6 +5583,7 @@ module atm_time_integration
          ! worked through algebra and found equivalent form
          ! added benefit that it should address ifort single prec overflow issue
          if (local_advance_density) then
+            !$acc parallel
             !$acc loop gang worker
             do iCell=cellSolveStart,cellSolveEnd
 
@@ -5597,7 +5598,9 @@ module atm_time_integration
                   scale_arr(k,SCALE_OUT,iCell) = min( 1.0_RKIND, max( 0.0_RKIND, scale_factor) )
                end do
             end do
+            !$acc end parallel
          else
+            !$acc parallel
             !$acc loop gang worker
             do iCell=cellSolveStart,cellSolveEnd
 
@@ -5612,10 +5615,12 @@ module atm_time_integration
                   scale_arr(k,SCALE_OUT,iCell) = min( 1.0_RKIND, max( 0.0_RKIND, scale_factor) )
                end do
             end do
+            !$acc end parallel
          end if
 
-         !$acc end parallel
+
          call mpas_timer_stop('atm_advance_scalars_mono_work_5555')
+
          !
          !  communicate scale factors here.
          !  communicate only first halo row in these next two exchanges


### PR DESCRIPTION
This PR introduces optimizations for the OpenACC port of atm_advance_scalars_mono_work:5555. The table below lists the timings for a real, global 30km experiment on A100 GPU with the nvhpc.

For nvhpc gpu runs, -gpu=math_uniform is introduced as a build flag to ensure optimizations are bit-identical, and the we report the numbers using NV_ACC_TIME=1. The GPU runs are on 1 Derecho GPU node, using 1 A100 via 1 MPI task.

The numbers reported for the CPU runs with gnu and intel compilers use the newly-added timers local to this region, and are averaged across three runs. The CPU runs use a single derecho CPU node each, fully subscribed to 128 MPI tasks.

Version | GPU kernel time (ms) |   | CPU timer - gnu |   | CPU timer - intel25
-- | -- | -- | -- | -- | --
base | 6.095 |   | 0.007606 |   | 0.00773
1 - Split up into parallel regions | 5.035 |   | - |   | -
2 - Use vector collapse(2) | 5.485 |   | - |   | -
3 - Swap loop vector and seq in first parallel region | 4.128 |   | 0.008813 |   | 0.008406
4 - Remove vector collapse(2) in 2nd & 3rd regions | 3.684 |   | - |   | -


The performance drop from base version to Opt 3 in the CPU case with GNU is 15.87% per invocation of this loop. But looking at the timings provided by `atm_advance_scalars_mono`, we actually see a 0.15% faster timing from base to Opt 3.

TODO: Add @Pranay-Reddy-Kommera as primary commit author

This work was completed in part at the NCAR/NLR/NOAA Open Hackathon, part of the Open Hackathons program. The authors would like to acknowledge OpenACC-Standard.org for their support.