### PR TITLE
Work around nvfortran issue with continuation lines in PACKAGE_LOGIC_PRINT macro

### DIFF
--- a/src/tools/registry/gen_inc.c
+++ b/src/tools/registry/gen_inc.c
@@ -2999,7 +2999,11 @@ void gen_pkg_debug_info(FILE *fd, regex_t *preg, ezxml_t registry,
 	regoff_t next = 0;
 
 	fortprintf(fd, "      PACKAGE_LOGIC_PRINT('')\n");
+#ifdef CPRPGI
+	fprintf(fd, "      PACKAGE_LOGIC_PRINT(\"  %s is active when (%s)\")\n", packagename, packagewhen);
+#else
 	fortprintf(fd, "      PACKAGE_LOGIC_PRINT(\"  %s is active when (%s)\")\n", packagename, packagewhen);
+#endif
 	fortprintf(fd, "      PACKAGE_LOGIC_PRINT('    namelist settings:')\n");
 	fortprintf(fd, "      PACKAGE_LOGIC_PRINT('    ------------------')\n");
 


### PR DESCRIPTION
This PR modifies the Registry code generation to work around an issue with continuation lines in instances of the `PACKAGE_LOGIC_PRINT` macro when building with the `nvfortran` compiler.

Registry-generated code in `setup_packages.inc` (generated by the `gen_pkg_debug_info` registry function in `gen_inc.c`) may contain continuation lines in the invocation of the `PACKAGE_LOGIC_PRINT` macro, and this can lead to compilation failures with the `nvfortran` compiler. To work around this issue, this PR avoids continuation lines with the `PACKAGE_LOGIC_PRINT` macro only when building with the `nvfortran` or `pgf90` compilers (or, more generally, when the `CPRPGI` macro is defined). This may result in source lines longer than 132 columns, but in practice, recent releases of the `nvfortran` compiler appear to have no problems with any of the source lines generated in the current version of MPAS.