### PR TITLE
Change default value of atmosphere core config_number_of_sub_steps from 2 to 4

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -101,10 +101,10 @@
                      description="Whether to super-cycle scalar transport"
                      possible_values="Logical values"/>
 
-                <nml_option name="config_number_of_sub_steps" type="integer" default_value="2"
+                <nml_option name="config_number_of_sub_steps" type="integer" default_value="4"
                      units="-"
                      description="Number of acoustic steps per full RK step"
-                     possible_values="Positive, even integer values, typically 2 or 6 depending on transport splitting"/>
+                     possible_values="Positive, even integer values, typically 2, 4, or 6 depending on transport splitting"/>
 
                 <nml_option name="config_dynamics_split_steps" type="integer" default_value="3"
                      units="-"


### PR DESCRIPTION
This PR changes the default value of the atmosphere core namelist option `config_number_of_sub_steps` from 2 to 4 in the `Registry.xml` file. This change addresses an issue in convection-permitting simulations where noise can sometimes appear in the jet streams using the previous default value (`config_number_of_sub_steps = 2`). The noise, when present, also produces unphysical features in horizontal kinetic energy spectra at high wavenumbers.

_Note: Increasing the number of sub-steps from 2 to 4 can be expected to increase the computational cost of the dynamics by ~10%, and the computational cost of a full-physics simulation by ~5%._