### PR TITLE
Correct order of lbc_ni and lbc_nr in the atmosphere core's Registry.xml file

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1988,13 +1988,13 @@
                              units="kg kg^{-1} s^{-1}"
                              description="Lateral boundary tendency of graupel mixing ratio"/>
 
-                        <var name="lbc_nr" name_in_code="nr" array_group="number" packages="mp_thompson_in;mp_thompson_aers_in"
-                             units="m^{-3} s^{-1}"
-                             description="Lateral boundary tendency of rain number concentration"/>
-
                         <var name="lbc_ni" name_in_code="ni" array_group="number" packages="bl_mynn_in;mp_thompson_in;mp_thompson_aers_in"
                              units="m^{-3} s^{-1}"
                              description="Lateral boundary tendency of ice number concentration"/>
+
+                        <var name="lbc_nr" name_in_code="nr" array_group="number" packages="mp_thompson_in;mp_thompson_aers_in"
+                             units="m^{-3} s^{-1}"
+                             description="Lateral boundary tendency of rain number concentration"/>
 
                         <var name="lbc_nc" name_in_code="nc" array_group="number" packages="mp_thompson_aers_in"
                              units="m^{-3} s^{-1}"


### PR DESCRIPTION
This PR swaps the order of `lbc_ni` and `lbc_nr` in the atmosphere core's `Registry.xml` file so that the LBC fields for the `ni` and `nr` scalars are defined in the same order as the tendencies (`tend_ni` and `tend_nr`) and state (`ni` and `nr`) for these scalars.

Note that unless LBCs are provided for `ni` and `nr`, the previously incorrect order of `lbc_ni` and `lbc_nr` would not affect results, as both fields would be filled with zero values.

Thanks to Trude Eidhammer (NSF NCAR / RAL; @trudeeidhammer) for identifying the issue addressed in this PR.