### PR TITLE
Fix for LES tke in real-data cases

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_dissipation_models.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_dissipation_models.F
@@ -407,8 +407,10 @@ contains
                ! eddy viscocities set here if we are running the 1.5 order prognostic tke scheme
                eddy_visc_h = c_k*l_horizontal*sqrt(scalars(index_tke,k,iCell))
                eddy_visc_h = min(eddy_visc_h,(0.01*config_len_disp**2) * invDt)
+               eddy_visc_h = max(0.01, eddy_visc_h)
                eddy_visc_v = c_k*l_vertical*sqrt(scalars(index_tke,k,iCell))
                eddy_visc_v = min(eddy_visc_v,(0.01*delta_z**2) * invDt)
+               eddy_visc_v = max(0.01, eddy_visc_v)
 
                eddy_visc_horz(k,iCell) = eddy_visc_h
                eddy_visc_vert(k,iCell) = eddy_visc_v


### PR DESCRIPTION
For the prognostic tke option, initial tke was zero. This leads to no tke generation because source terms depend on non-zero tke through the K diffusion coefficients. The fix is to set a small minimum value (currently chosen as 0.01 m2/s) on the K coefficients. Two lines are added in the dissipation module.

