### PR TITLE
Fix for GPU-enabled restart runs

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -594,7 +594,7 @@ module atm_time_integration
       MPAS_ACC_TIMER_START('first_compute_solve_diagnostics [ACC_data_xfer]')
 
       call mpas_pool_get_array(state, 'rho_zz', h, 1)
-      !$acc enter data create(h)
+      !$acc enter data copyin(h)
 
       call mpas_pool_get_array(state, 'u', u, 1)
       !$acc enter data copyin(u)


### PR DESCRIPTION
This PR corrects the OpenACC data movement for the field `rho_zz` in routine `mpas_atm_pre_compute_solve_diagnostics`. Previously, an OpenACC `create` statement was used for this field. This is still correct for the cold initialization case, but produces incorrect results in the case of a restarted run. This is now changed to a `copyin` statement.

If the following condition is met  `.not. config_do_restart .or. (config_do_restart .and. config_do_DAcycling)` then the call to `atm_init_coupled_diagnostics` in `atm_mpas_init_block` computes the first time level of `rho_zz`. Allowing us to use a create statement in `mpas_atm_pre_compute_solve_diagnostics`. However, in the case of a restart run with no DA cycling, the usage of the create statement is incorrect.

This issue was discovered as a result of restarted real simulations on GPUs crashing. The unphysical values from the dynamical core lead to a segmentation fault occuring in the SW radiation calls. Furthermore, the Jablonowski-Williamson baroclinic wave case also showed discrepancies between the cold initialization and the restarted test case. Both of these issues have been addressed by this PR. 