### PR TITLE
Use the file() CREATE_LINK command to create symlinks when running cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 ## MPAS-Model
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.14)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Functions/MPAS_Functions.cmake)
 get_mpas_version(MPAS_VERSION)

--- a/src/core_atmosphere/CMakeLists.txt
+++ b/src/core_atmosphere/CMakeLists.txt
@@ -388,8 +388,8 @@ set(PHYSICS_WRF_DATA_DIR ${mpas_data_SOURCE_DIR}/atmosphere/physics_wrf/files)
 file(GLOB PHYSICS_WRF_DATA RELATIVE ${PHYSICS_WRF_DATA_DIR} "${PHYSICS_WRF_DATA_DIR}/*")
 file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/${PROJECT_NAME}/core_atmosphere)
 foreach (data_file IN LISTS PHYSICS_WRF_DATA)
-    execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${PHYSICS_WRF_DATA_DIR}/${data_file}
-                    ${CMAKE_BINARY_DIR}/${PROJECT_NAME}/core_atmosphere/${data_file})
+    file(CREATE_LINK ${PHYSICS_WRF_DATA_DIR}/${data_file}
+         ${CMAKE_BINARY_DIR}/${PROJECT_NAME}/core_atmosphere/${data_file} SYMBOLIC)
 endforeach ()
 install(DIRECTORY ${PHYSICS_WRF_DATA_DIR}/ DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/core_atmosphere)
 


### PR DESCRIPTION
This PR replaces the cmake execute_process() command with the file() command to create symlinks.

Using execute_process to make symlinks is expensive; it spawns a new cmake process.
The file() command is more efficient; it makes the symlink in the currently executing cmake process.

This was tested by running cmake directly against a clone of the MPAS-Model repository, as well
as running cmake against a clone of the mpas-bundle repository (which include MPAS-Model).
