### PR TITLE
Rename internal ESMF time-manager library to libesmf_time in CMake builds

### DIFF
--- a/src/external/esmf_time_f90/CMakeLists.txt
+++ b/src/external/esmf_time_f90/CMakeLists.txt
@@ -22,6 +22,12 @@ add_library(esmf ${_esmf_time_src})
 mpas_fortran_target(esmf)
 add_library(${PROJECT_NAME}::external::esmf ALIAS esmf)
 
+# This library is MPAS's bundled ESMF time-manager stubs, not the full ESMF. Naming the
+# file libesmf lets the loader substitute a real ESMF found via LD_LIBRARY_PATH,
+# breaking every MPAS executable. Changing the output name results in the library
+# being installed as libesmf_time.{so,a} and resolves the name conflict.
+set_target_properties(esmf PROPERTIES OUTPUT_NAME esmf_time)
+
 target_compile_definitions(esmf PRIVATE HIDE_MPI=1)
 
 target_include_directories(esmf PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)


### PR DESCRIPTION
MPAS ships its own small ESMF time manager under src/external/esmf_time_f90. It isn't [ESMF](https://earthsystemmodeling.org/), it's a handful of stub routines that provide the clock and calendar interface MPAS needs. Until now it was built into a file called libesmf.so (or libesmf.a), which is exactly the name the real Earth System Modeling Framework uses.

This isn't a problem unless MPAS-model is built in an environment with the full ESMF library and other components dependent on it. When that happens there are two different files named libesmf.so causing conflicts either in MPAS or elsewhere. Usuaally get a bunch of lines like this

```
symbol lookup error: libmpas_framework.so: undefined symbol: esmf_stubs_mp_esmf_initialize_
```

This PR gives the MPAS-model library a unique name; `esmf_time` to prevent the conflict.

  - The build target is still named esmf, so everything that refers to it by that name inside mpas keeps working when referencing `MPAS::external::esmf`.
  - Nothing in MPAS or mpas-jedi refers to the library by its file name, so there's nothing else to update.

Once this is accepted into develop I'll make a cherry pick for the 8.4.2 hotfix branch so it can get added to the 8.4.2 release.

Fixes: https://github.com/JCSDA-internal/mpas-jedi/issues/919