### PR TITLE
Fix qv index lookup for lbc_scalars

### DIFF
--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -5623,7 +5623,7 @@ call mpas_log_write('Done with soil consistency check')
       call mpas_pool_get_dimension(dims, 'nCellsSolve', nCellsSolve)
       nVertLevelsP1 = nVertLevels + 1
 
-      call mpas_pool_get_dimension(state, 'index_qv', index_qv)
+      call mpas_pool_get_dimension(lbc_state, 'index_lbc_qv', index_qv)
 
       etavs = (1.0_RKIND - 0.252_RKIND) * pii / 2.0_RKIND
       rcv = rgas / (cp - rgas)


### PR DESCRIPTION
This PR fixes the qv constituent index lookup in the `init_atm_case_lbc` subroutine. 

The `init_atm_case_lbc` subroutine retrieves the `lbc_scalars` array from the `lbc_state` pool, but obtains the `qv` constituent index from the `state` pool using `index_qv`. The `scalars` and `lbc_scalars` arrays are separate variable arrays, and their constituent indices are generated independently. Therefore, the `index_lbc_qv` should be retrieved from `lbc_state` and used when indexing `lbc_scalars`.

Since `index_qv` and `index_lbc_qv` are expected to always be the same (both equal to 1), this change would not affect the lateral boundary conditions generated for regional MPAS simulations. 
