### PR TITLE
Optimize ACC port of atm_advance_acoustic_step_work:3976

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -3972,7 +3972,7 @@ module atm_time_integration
       end if
 
 !$OMP BARRIER
-
+      call mpas_timer_start('atm_advance_acoustic_step_3976')
       !$acc parallel default(present)
       !$acc loop gang worker private(ts,rs)
       do iCell=cellSolveStart,cellSolveEnd  ! loop over all owned cells to solve
@@ -4104,7 +4104,7 @@ module atm_time_integration
 
       end do !  end of loop over cells
       !$acc end parallel
-
+      call mpas_timer_stop('atm_advance_acoustic_step_3976')
 
    end subroutine atm_advance_acoustic_step_work
 


### PR DESCRIPTION
This PR introduces optimizations for the OpenACC port of atm_advance_acoustic_step_work: 3976. The table below lists the timings for a real, global 30km experiment on A100 GPU with the nvhpc.

For nvhpc gpu runs, -gpu=math_uniform is introduced as a build flag to ensure optimizations are bit-identical, and the we report the numbers using NV_ACC_TIME=1. The GPU runs are on 1 Derecho GPU node, using 1 A100 via 1 MPI task.

The numbers reported for the CPU runs with gnu and intel compilers use the newly-added timers local to this region, and are averaged across three runs. The CPU runs use a single derecho CPU node each, fully subscribed to 128 MPI tasks.

Version | GPU kernel time (ms) |   | CPU timer - gnu |   | CPU timer - intel25
-- | -- | -- | -- | -- | --
base | 12.825 |   | 3.71329 |   | 3.41218
Opt 1 | 10.954 |   | 3.846676667 |   | 3.7927
Opt 1 + macros | 10.952 |   |   |   | 3.515413333
Opt 2 + macro | 9.354 |   | 3.80428 |   | 3.436093333
Opt 3 | 9.276 |   | 3.691653333 |   | 3.41279

TODO: Add @Pranay-Reddy-Kommera as primary commit author

This work was completed in part at the NCAR/NLR/NOAA Open Hackathon, part of the Open Hackathons program. The authors would like to acknowledge OpenACC-Standard.org for their support.